### PR TITLE
test(add): cover empty stdout for Markdown gate features

### DIFF
--- a/features/add/add_h_gate.feature.md
+++ b/features/add/add_h_gate.feature.md
@@ -8,6 +8,11 @@ qni-cli のユーザとして、コマンドラインから量子回路を組み
 - When "qni add H --qubit 0 --step 0" を実行
 - Then コマンドは成功
 
+## Scenario: H ゲート追加コマンドの標準出力は空
+
+- When "qni add H --qubit 0 --step 0" を実行
+- Then 標準出力は空
+
 ## Scenario: H ゲートを指定位置から取得
 
 - Given "qni add H --qubit 0 --step 0" を実行

--- a/features/add/add_phase_gate.feature.md
+++ b/features/add/add_phase_gate.feature.md
@@ -8,6 +8,11 @@ qni-cli のユーザとして、コマンドラインから量子回路を組み
 - When "qni add P --angle π/3 --qubit 0 --step 0" を実行
 - Then コマンドは成功
 
+## Scenario: Phase ゲート追加コマンドの標準出力は空
+
+- When "qni add P --angle π/3 --qubit 0 --step 0" を実行
+- Then 標準出力は空
+
 ## Scenario: Phase ゲートを指定位置から取得
 
 - Given "qni add P --angle π/3 --qubit 0 --step 0" を実行

--- a/features/add/add_rx_gate.feature.md
+++ b/features/add/add_rx_gate.feature.md
@@ -8,6 +8,11 @@ qni-cli のユーザとして、コマンドラインから量子回路を組み
 - When "qni add Rx --angle π/2 --qubit 0 --step 0" を実行
 - Then コマンドは成功
 
+## Scenario: Rx ゲート追加コマンドの標準出力は空
+
+- When "qni add Rx --angle π/2 --qubit 0 --step 0" を実行
+- Then 標準出力は空
+
 ## Scenario: Rx ゲートを指定位置から取得
 
 - Given "qni add Rx --angle π/2 --qubit 0 --step 0" を実行

--- a/features/add/add_ry_gate.feature.md
+++ b/features/add/add_ry_gate.feature.md
@@ -8,6 +8,11 @@ qni-cli のユーザとして、コマンドラインから量子回路を組み
 - When "qni add Ry --angle π/2 --qubit 0 --step 0" を実行
 - Then コマンドは成功
 
+## Scenario: Ry ゲート追加コマンドの標準出力は空
+
+- When "qni add Ry --angle π/2 --qubit 0 --step 0" を実行
+- Then 標準出力は空
+
 ## Scenario: Ry ゲートを指定位置から取得
 
 - Given "qni add Ry --angle π/2 --qubit 0 --step 0" を実行

--- a/features/add/add_rz_gate.feature.md
+++ b/features/add/add_rz_gate.feature.md
@@ -8,6 +8,11 @@ qni-cli のユーザとして、コマンドラインから量子回路を組み
 - When "qni add Rz --angle π/2 --qubit 0 --step 0" を実行
 - Then コマンドは成功
 
+## Scenario: Rz ゲート追加コマンドの標準出力は空
+
+- When "qni add Rz --angle π/2 --qubit 0 --step 0" を実行
+- Then 標準出力は空
+
 ## Scenario: Rz ゲートを指定位置から取得
 
 - Given "qni add Rz --angle π/2 --qubit 0 --step 0" を実行

--- a/features/add/add_s_dagger_gate.feature.md
+++ b/features/add/add_s_dagger_gate.feature.md
@@ -8,6 +8,11 @@ qni-cli のユーザとして、コマンドラインから量子回路を組み
 - When "qni add S† --qubit 0 --step 0" を実行
 - Then コマンドは成功
 
+## Scenario: S† ゲート追加コマンドの標準出力は空
+
+- When "qni add S† --qubit 0 --step 0" を実行
+- Then 標準出力は空
+
 ## Scenario: S† ゲートを指定位置から取得
 
 - Given "qni add S† --qubit 0 --step 0" を実行

--- a/features/add/add_s_gate.feature.md
+++ b/features/add/add_s_gate.feature.md
@@ -8,6 +8,11 @@ qni-cli のユーザとして、コマンドラインから量子回路を組み
 - When "qni add S --qubit 0 --step 0" を実行
 - Then コマンドは成功
 
+## Scenario: S ゲート追加コマンドの標準出力は空
+
+- When "qni add S --qubit 0 --step 0" を実行
+- Then 標準出力は空
+
 ## Scenario: S ゲートを指定位置から取得
 
 - Given "qni add S --qubit 0 --step 0" を実行

--- a/features/add/add_sqrt_x_gate.feature.md
+++ b/features/add/add_sqrt_x_gate.feature.md
@@ -8,6 +8,11 @@ qni-cli のユーザとして、コマンドラインから量子回路を組み
 - When "qni add √X --qubit 0 --step 0" を実行
 - Then コマンドは成功
 
+## Scenario: √X ゲート追加コマンドの標準出力は空
+
+- When "qni add √X --qubit 0 --step 0" を実行
+- Then 標準出力は空
+
 ## Scenario: √X ゲートを指定位置から取得
 
 - Given "qni add √X --qubit 0 --step 0" を実行

--- a/features/add/add_swap_gate.feature.md
+++ b/features/add/add_swap_gate.feature.md
@@ -8,6 +8,11 @@ qni add SWAP を実行したい。
 - When "qni add SWAP --qubit 0,1 --step 0" を実行
 - Then コマンドは成功
 
+## Scenario: qni add SWAP の標準出力は空
+
+- When "qni add SWAP --qubit 0,1 --step 0" を実行
+- Then 標準出力は空
+
 ## Scenario: qni add SWAP は指定位置から Swap を取得
 
 - Given "qni add SWAP --qubit 0,1 --step 0" を実行

--- a/features/add/add_t_dagger_gate.feature.md
+++ b/features/add/add_t_dagger_gate.feature.md
@@ -8,6 +8,11 @@ qni-cli のユーザとして、コマンドラインから量子回路を組み
 - When "qni add T† --qubit 0 --step 0" を実行
 - Then コマンドは成功
 
+## Scenario: T† ゲート追加コマンドの標準出力は空
+
+- When "qni add T† --qubit 0 --step 0" を実行
+- Then 標準出力は空
+
 ## Scenario: T† ゲートを指定位置から取得
 
 - Given "qni add T† --qubit 0 --step 0" を実行

--- a/features/add/add_t_gate.feature.md
+++ b/features/add/add_t_gate.feature.md
@@ -8,6 +8,11 @@ qni-cli のユーザとして、コマンドラインから量子回路を組み
 - When "qni add T --qubit 0 --step 0" を実行
 - Then コマンドは成功
 
+## Scenario: T ゲート追加コマンドの標準出力は空
+
+- When "qni add T --qubit 0 --step 0" を実行
+- Then 標準出力は空
+
 ## Scenario: T ゲートを指定位置から取得
 
 - Given "qni add T --qubit 0 --step 0" を実行

--- a/features/add/add_x_gate.feature.md
+++ b/features/add/add_x_gate.feature.md
@@ -8,6 +8,11 @@ qni-cli のユーザとして、コマンドラインから量子回路を組み
 - When "qni add X --qubit 0 --step 0" を実行
 - Then コマンドは成功
 
+## Scenario: X ゲート追加コマンドの標準出力は空
+
+- When "qni add X --qubit 0 --step 0" を実行
+- Then 標準出力は空
+
 ## Scenario: X ゲートを指定位置から取得
 
 - Given "qni add X --qubit 0 --step 0" を実行

--- a/features/add/add_y_gate.feature.md
+++ b/features/add/add_y_gate.feature.md
@@ -8,6 +8,11 @@ qni-cli のユーザとして、コマンドラインから量子回路を組み
 - When "qni add Y --qubit 0 --step 0" を実行
 - Then コマンドは成功
 
+## Scenario: Y ゲート追加コマンドの標準出力は空
+
+- When "qni add Y --qubit 0 --step 0" を実行
+- Then 標準出力は空
+
 ## Scenario: Y ゲートを指定位置から取得
 
 - Given "qni add Y --qubit 0 --step 0" を実行

--- a/features/add/add_z_gate.feature.md
+++ b/features/add/add_z_gate.feature.md
@@ -8,6 +8,11 @@ qni-cli のユーザとして、コマンドラインから量子回路を組み
 - When "qni add Z --qubit 0 --step 0" を実行
 - Then コマンドは成功
 
+## Scenario: Z ゲート追加コマンドの標準出力は空
+
+- When "qni add Z --qubit 0 --step 0" を実行
+- Then 標準出力は空
+
 ## Scenario: Z ゲートを指定位置から取得
 
 - Given "qni add Z --qubit 0 --step 0" を実行

--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -140,6 +140,10 @@ Then('コマンドは成功', function () {
   assert.equal(this.lastCommand.code, 0, commandFailureMessage(this.lastCommand));
 });
 
+Then('標準出力は空', function () {
+  assert.equal(this.lastCommand.stdout, '');
+});
+
 Then('{string} の内容:', function (filePath, docString) {
   assert.equal(this.lastCommand.code, 0, commandFailureMessage(this.lastCommand));
 


### PR DESCRIPTION
## Summary

- Add an empty stdout scenario to each add gate Markdown feature.
- Add the cucumber-js `標準出力は空` step used by the new Markdown scenarios.
- Keep `features/qni_add.feature` representative stdout coverage in place as command-level coverage.

## Validation

- `BUNDLE_PATH=/tmp/qni-cli-bundle BUNDLE_APP_CONFIG=/tmp/qni-cli-bundle-config npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress features/add/*.feature.md`
- `BUNDLE_PATH=/tmp/qni-cli-bundle BUNDLE_APP_CONFIG=/tmp/qni-cli-bundle-config bundle exec rake check`

Linear: YAS-169
