### PR TITLE
YAS-172 Move add slot constraint scenario

### DIFF
--- a/features/add/add_slot_constraints.feature.md
+++ b/features/add/add_slot_constraints.feature.md
@@ -1,0 +1,14 @@
+# Feature: add コマンドのスロット制約
+
+qni-cli のユーザとして、既存のゲートを誤って上書きしないために、
+すでに埋まっているスロットへの add は失敗してほしい。
+
+## Scenario: 既存スロットへの qni add は失敗
+
+- Given "qni add H --qubit 0 --step 0" を実行
+- When "qni add H --qubit 0 --step 0" を実行
+- Then コマンドは失敗して標準エラー:
+
+  ```text
+  target slot is occupied: cols[0][0] = "H"
+  ```

--- a/features/qni_add.feature
+++ b/features/qni_add.feature
@@ -11,11 +11,6 @@ Feature: qni add コマンド
     When "qni add SWAP --qubit 0,1 --step 0" を実行
     Then コマンドは成功
 
-  Scenario: すでに H があるスロットへの qni add は失敗
-    Given "qni add H --qubit 0 --step 0" を実行
-    When "qni add H --qubit 0 --step 0" を実行
-    Then コマンドは失敗
-
   Scenario: 既存回路に新しい qubit を追加できる
     Given "qni add H --qubit 0 --step 0" を実行
     When "qni add H --qubit 1 --step 0" を実行


### PR DESCRIPTION
## Summary

- Add `features/add/add_slot_constraints.feature.md` for the occupied-slot `qni add` failure scenario.
- Remove the duplicate occupied-slot scenario from `features/qni_add.feature`.

## Validation

- `BUNDLE_PATH=/tmp/yas172-bundle ./node_modules/.bin/cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress features/add/add_slot_constraints.feature.md`
- `BUNDLE_PATH=/tmp/yas172-bundle bundle exec rake check`

Linear: YAS-172
