### PR TITLE
YAS-183 qni bloch help シナリオを移動

### DIFF
--- a/features/bloch/help.feature.md
+++ b/features/bloch/help.feature.md
@@ -1,0 +1,93 @@
+# Feature: qni bloch help
+
+qni-cli のユーザとして
+ブロッホ球出力の使い方を迷わず選べるように
+qni bloch の help で利用できる出力形式と option を確認したい。
+
+## Scenario: qni bloch --help は成功する
+
+- When "qni bloch --help" を実行
+- Then コマンドは成功
+
+## Scenario: qni bloch --help は bloch コマンドの使い方を表示
+
+- When "qni bloch --help" を実行
+- Then 標準出力:
+
+  ```text
+  Usage:
+    qni bloch --png --output bloch.png
+    qni bloch --png --trajectory --output bloch.png
+    qni bloch --apng --output bloch.png
+    qni bloch --inline
+    qni bloch --inline --animate
+
+  Overview:
+    Render the current 1-qubit state on the Bloch sphere.
+    --png writes a static Bloch sphere image.
+    --apng writes an animated Bloch sphere showing state evolution.
+    --inline draws the Bloch sphere directly in a Kitty-compatible terminal.
+    The first release supports only 1-qubit circuits with fully resolved numeric parameters.
+
+  Options:
+    --png           # write a Bloch sphere PNG
+    --apng          # write a Bloch sphere APNG
+    --inline        # render a Bloch sphere inline in a Kitty-compatible terminal
+    --animate       # animate inline Bloch output; valid only with --inline
+    --trajectory    # draw the sampled state-evolution trail on the Bloch sphere
+    --dark          # draw light content for dark backgrounds (default)
+    --light         # draw dark content for light backgrounds
+    [--output=PATH] # output file path; required for --png and --apng
+
+  Examples:
+    qni bloch --png --output bloch.png
+    qni bloch --png --trajectory --output bloch.png
+    qni bloch --apng --output bloch.png
+    qni bloch --png --light --output bloch.png
+    qni bloch --inline
+    qni bloch --inline --animate
+  ```
+
+## Scenario: qni bloch は成功する
+
+- When "qni bloch" を実行
+- Then コマンドは成功
+
+## Scenario: qni bloch は bare command help を表示
+
+- When "qni bloch" を実行
+- Then 標準出力:
+
+  ```text
+  Usage:
+    qni bloch --png --output bloch.png
+    qni bloch --png --trajectory --output bloch.png
+    qni bloch --apng --output bloch.png
+    qni bloch --inline
+    qni bloch --inline --animate
+
+  Overview:
+    Render the current 1-qubit state on the Bloch sphere.
+    --png writes a static Bloch sphere image.
+    --apng writes an animated Bloch sphere showing state evolution.
+    --inline draws the Bloch sphere directly in a Kitty-compatible terminal.
+    The first release supports only 1-qubit circuits with fully resolved numeric parameters.
+
+  Options:
+    --png           # write a Bloch sphere PNG
+    --apng          # write a Bloch sphere APNG
+    --inline        # render a Bloch sphere inline in a Kitty-compatible terminal
+    --animate       # animate inline Bloch output; valid only with --inline
+    --trajectory    # draw the sampled state-evolution trail on the Bloch sphere
+    --dark          # draw light content for dark backgrounds (default)
+    --light         # draw dark content for light backgrounds
+    [--output=PATH] # output file path; required for --png and --apng
+
+  Examples:
+    qni bloch --png --output bloch.png
+    qni bloch --png --trajectory --output bloch.png
+    qni bloch --apng --output bloch.png
+    qni bloch --png --light --output bloch.png
+    qni bloch --inline
+    qni bloch --inline --animate
+  ```

--- a/features/qni_cli.feature
+++ b/features/qni_cli.feature
@@ -107,44 +107,6 @@ Feature: qni CLI
       qni state set "alpha|0> + beta|1>"
       """
 
-  Scenario: qni bloch --help は bloch コマンドの使い方を表示
-    When "qni bloch --help" を実行
-    Then コマンドは成功
-    And 標準出力:
-      """
-      Usage:
-        qni bloch --png --output bloch.png
-        qni bloch --png --trajectory --output bloch.png
-        qni bloch --apng --output bloch.png
-        qni bloch --inline
-        qni bloch --inline --animate
-
-      Overview:
-        Render the current 1-qubit state on the Bloch sphere.
-        --png writes a static Bloch sphere image.
-        --apng writes an animated Bloch sphere showing state evolution.
-        --inline draws the Bloch sphere directly in a Kitty-compatible terminal.
-        The first release supports only 1-qubit circuits with fully resolved numeric parameters.
-
-      Options:
-        --png           # write a Bloch sphere PNG
-        --apng          # write a Bloch sphere APNG
-        --inline        # render a Bloch sphere inline in a Kitty-compatible terminal
-        --animate       # animate inline Bloch output; valid only with --inline
-        --trajectory    # draw the sampled state-evolution trail on the Bloch sphere
-        --dark          # draw light content for dark backgrounds (default)
-        --light         # draw dark content for light backgrounds
-        [--output=PATH] # output file path; required for --png and --apng
-
-      Examples:
-        qni bloch --png --output bloch.png
-        qni bloch --png --trajectory --output bloch.png
-        qni bloch --apng --output bloch.png
-        qni bloch --png --light --output bloch.png
-        qni bloch --inline
-        qni bloch --inline --animate
-      """
-
   Scenario: qni help は使えない
     When "qni help add" を実行
     Then コマンドは失敗


### PR DESCRIPTION
## Summary
- Add `features/bloch/help.feature.md` for `qni bloch --help` and bare `qni bloch` help behavior.
- Remove the old bloch help scenario from `features/qni_cli.feature`.
- Exact-match the full bare `qni bloch` help output, matching `qni bloch --help`, with one validation-focused `Then` per scenario.

## Validation
- `BUNDLE_PATH=/tmp/qni-cli-bundle npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress features/bloch/help.feature.md`
- `BUNDLE_PATH=/tmp/qni-cli-bundle bundle exec rake check`

Linear: YAS-183
