### PR TITLE
YAS-184 qni expect の help シナリオを移動

### DIFF
--- a/features/expect/help.feature.md
+++ b/features/expect/help.feature.md
@@ -1,0 +1,58 @@
+# Feature: expect コマンドのヘルプ表示
+
+qni-cli のユーザとして、Pauli string の期待値計算方法を確認するために、
+`qni expect` の使い方をヘルプで見たい。
+
+## Scenario: qni expect は成功する
+
+- When "qni expect" を実行
+- Then コマンドは成功
+
+## Scenario: qni expect は expect コマンドの使い方を表示
+
+- When "qni expect" を実行
+- Then 標準出力:
+
+  ```text
+  Usage:
+    qni expect PAULI_STRING [PAULI_STRING...]
+
+  Overview:
+    Calculate expectation values from ./circuit.json.
+    qni simulates the whole circuit and evaluates each Pauli string on the resulting state.
+    Each PAULI_STRING must use only I, X, Y, and Z.
+    The length of each PAULI_STRING must match the circuit qubit count.
+    Output is one line per observable in the form PAULI_STRING=value.
+
+  Examples:
+    qni expect Z
+    qni expect ZZ XX
+    qni expect ZZI IZZ XXX
+  ```
+
+## Scenario: qni expect --help は成功する
+
+- When "qni expect --help" を実行
+- Then コマンドは成功
+
+## Scenario: qni expect --help は expect コマンドの使い方を表示
+
+- When "qni expect --help" を実行
+- Then 標準出力:
+
+  ```text
+  Usage:
+    qni expect PAULI_STRING [PAULI_STRING...]
+
+  Overview:
+    Calculate expectation values from ./circuit.json.
+    qni simulates the whole circuit and evaluates each Pauli string on the resulting state.
+    Each PAULI_STRING must use only I, X, Y, and Z.
+    The length of each PAULI_STRING must match the circuit qubit count.
+    Output is one line per observable in the form PAULI_STRING=value.
+
+  Examples:
+    qni expect Z
+    qni expect ZZ XX
+    qni expect ZZI IZZ XXX
+  ```

--- a/features/qni_cli.feature
+++ b/features/qni_cli.feature
@@ -112,48 +112,6 @@ Feature: qni CLI
       qubit must be an integer
       """
 
-  Scenario: qni expect は expect コマンドの使い方を表示
-    When "qni expect" を実行
-    Then コマンドは成功
-    And 標準出力:
-      """
-      Usage:
-        qni expect PAULI_STRING [PAULI_STRING...]
-
-      Overview:
-        Calculate expectation values from ./circuit.json.
-        qni simulates the whole circuit and evaluates each Pauli string on the resulting state.
-        Each PAULI_STRING must use only I, X, Y, and Z.
-        The length of each PAULI_STRING must match the circuit qubit count.
-        Output is one line per observable in the form PAULI_STRING=value.
-
-      Examples:
-        qni expect Z
-        qni expect ZZ XX
-        qni expect ZZI IZZ XXX
-      """
-
-  Scenario: qni expect --help は expect コマンドの使い方を表示
-    When "qni expect --help" を実行
-    Then コマンドは成功
-    And 標準出力:
-      """
-      Usage:
-        qni expect PAULI_STRING [PAULI_STRING...]
-
-      Overview:
-        Calculate expectation values from ./circuit.json.
-        qni simulates the whole circuit and evaluates each Pauli string on the resulting state.
-        Each PAULI_STRING must use only I, X, Y, and Z.
-        The length of each PAULI_STRING must match the circuit qubit count.
-        Output is one line per observable in the form PAULI_STRING=value.
-
-      Examples:
-        qni expect Z
-        qni expect ZZ XX
-        qni expect ZZI IZZ XXX
-      """
-
   Scenario: qni clear --help は clear コマンドの使い方を表示
     When "qni clear --help" を実行
     Then コマンドは成功


### PR DESCRIPTION
## Summary
- YAS-184
- Move qni expect / qni expect --help help scenarios into features/expect/help.feature.md.
- Remove the duplicated expect help scenarios from features/qni_cli.feature.
- Keep success and stdout checks split across separate scenarios.

## Validation
- BUNDLE_PATH=vendor/bundle bundle exec rake check