### PR TITLE
YAS-186 qni state help シナリオを移動

### DIFF
--- a/features/qni_cli.feature
+++ b/features/qni_cli.feature
@@ -99,14 +99,6 @@ Feature: qni CLI
         qni variable clear
       """
 
-  Scenario: qni state --help は state コマンドの使い方を表示
-    When "qni state --help" を実行
-    Then コマンドは成功
-    And 標準出力に次を含む:
-      """
-      qni state set "alpha|0> + beta|1>"
-      """
-
   Scenario: qni help は使えない
     When "qni help add" を実行
     Then コマンドは失敗

--- a/features/state/help.feature.md
+++ b/features/state/help.feature.md
@@ -1,0 +1,61 @@
+# Feature: qni state help
+
+qni-cli のユーザとして
+初期状態ベクトルの管理方法を知るために
+qni state の help を見たい
+
+## Scenario: qni state は成功する
+
+- When "qni state" を実行
+- Then コマンドは成功
+
+## Scenario: qni state は state コマンドの使い方を表示
+
+- When "qni state" を実行
+- Then 標準出力:
+
+  ```text
+  Usage:
+    qni state set "alpha|0> + beta|1>"
+    qni state show
+    qni state clear
+
+  Overview:
+    Manage the initial state vector in ./circuit.json.
+    The first release supports 1-qubit ket sums such as alpha|0> + beta|1>.
+    Coefficients can be numeric literals or ASCII identifiers such as alpha.
+    qni state clear removes the explicit initial state and falls back to |0>.
+
+  Examples:
+    qni state set "alpha|0> + beta|1>"
+    qni state show
+    qni state clear
+  ```
+
+## Scenario: qni state --help は成功する
+
+- When "qni state --help" を実行
+- Then コマンドは成功
+
+## Scenario: qni state --help は state コマンドの使い方を表示
+
+- When "qni state --help" を実行
+- Then 標準出力:
+
+  ```text
+  Usage:
+    qni state set "alpha|0> + beta|1>"
+    qni state show
+    qni state clear
+
+  Overview:
+    Manage the initial state vector in ./circuit.json.
+    The first release supports 1-qubit ket sums such as alpha|0> + beta|1>.
+    Coefficients can be numeric literals or ASCII identifiers such as alpha.
+    qni state clear removes the explicit initial state and falls back to |0>.
+
+  Examples:
+    qni state set "alpha|0> + beta|1>"
+    qni state show
+    qni state clear
+  ```


### PR DESCRIPTION
## Summary

- YAS-186
- Move qni state help scenarios into `features/state/help.feature.md`.
- Cover both `qni state` and `qni state --help` with separate success and exact stdout scenarios.
- Remove the duplicated state help scenario from `features/qni_cli.feature`.

## Validation

- `npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress features/state/help.feature.md`
- `bundle exec rake check`
