### PR TITLE
test(clear): move clear help feature

### DIFF
--- a/features/clear/help.feature.md
+++ b/features/clear/help.feature.md
@@ -1,0 +1,28 @@
+# Feature: qni clear help
+
+qni-cli のユーザとして
+clear コマンドの使い方を知るために
+qni clear の help を見たい
+
+## Scenario: qni clear --help は成功する
+
+- When "qni clear --help" を実行
+- Then コマンドは成功
+
+## Scenario: qni clear --help は clear コマンドの使い方を表示
+
+- When "qni clear --help" を実行
+- Then 標準出力:
+
+  ```text
+  Usage:
+    qni clear
+
+  Overview:
+    Delete ./circuit.json.
+    If ./circuit.json does not exist, qni clear still succeeds.
+    Standard output is empty on success.
+
+  Examples:
+    qni clear
+  ```

--- a/features/qni_cli.feature
+++ b/features/qni_cli.feature
@@ -30,23 +30,6 @@ Feature: qni CLI
       qubit must be an integer
       """
 
-  Scenario: qni clear --help は clear コマンドの使い方を表示
-    When "qni clear --help" を実行
-    Then コマンドは成功
-    And 標準出力:
-      """
-      Usage:
-        qni clear
-
-      Overview:
-        Delete ./circuit.json.
-        If ./circuit.json does not exist, qni clear still succeeds.
-        Standard output is empty on success.
-
-      Examples:
-        qni clear
-      """
-
   Scenario: qni variable は variable コマンドの使い方を表示
     When "qni variable" を実行
     Then コマンドは成功


### PR DESCRIPTION
## Summary
- Move the `qni clear --help` scenarios into `features/clear/help.feature.md`.
- Split success and stdout assertions into separate Markdown scenarios to preserve the one-Then rule.
- Remove the duplicate clear help scenario from `features/qni_cli.feature`.

## Validation
- `BUNDLE_PATH=/tmp/qni-cli-bundle bundle exec rake check`

Linear: YAS-185
