### PR TITLE
YAS-187 qni variable help scenarios を移動

### DIFF
--- a/features/qni_cli.feature
+++ b/features/qni_cli.feature
@@ -47,58 +47,6 @@ Feature: qni CLI
         qni clear
       """
 
-  Scenario: qni variable は variable コマンドの使い方を表示
-    When "qni variable" を実行
-    Then コマンドは成功
-    And 標準出力:
-      """
-      Usage:
-        qni variable set NAME ANGLE
-        qni variable list
-        qni variable unset NAME
-        qni variable clear
-
-      Overview:
-        Manage symbolic angle variables in ./circuit.json.
-        NAME must be an ASCII identifier such as theta.
-        ANGLE must be concrete, such as π/4, pi/3, or 0.5.
-        qni variable set requires ./circuit.json to already exist.
-        qni add Ry --angle theta --qubit 0 --step 0 stores Ry(theta).
-        qni run and qni expect resolve symbolic angles through these variables.
-
-      Examples:
-        qni variable set theta π/4
-        qni variable list
-        qni variable unset theta
-        qni variable clear
-      """
-
-  Scenario: qni variable --help は variable コマンドの使い方を表示
-    When "qni variable --help" を実行
-    Then コマンドは成功
-    And 標準出力:
-      """
-      Usage:
-        qni variable set NAME ANGLE
-        qni variable list
-        qni variable unset NAME
-        qni variable clear
-
-      Overview:
-        Manage symbolic angle variables in ./circuit.json.
-        NAME must be an ASCII identifier such as theta.
-        ANGLE must be concrete, such as π/4, pi/3, or 0.5.
-        qni variable set requires ./circuit.json to already exist.
-        qni add Ry --angle theta --qubit 0 --step 0 stores Ry(theta).
-        qni run and qni expect resolve symbolic angles through these variables.
-
-      Examples:
-        qni variable set theta π/4
-        qni variable list
-        qni variable unset theta
-        qni variable clear
-      """
-
   Scenario: qni help は使えない
     When "qni help add" を実行
     Then コマンドは失敗

--- a/features/variable/help.feature.md
+++ b/features/variable/help.feature.md
@@ -1,0 +1,69 @@
+# Feature: qni variable help
+
+qni-cli のユーザとして
+symbolic angle variable の管理方法を知るために
+qni variable の help を見たい
+
+## Scenario: qni variable は成功する
+
+- When "qni variable" を実行
+- Then コマンドは成功
+
+## Scenario: qni variable は variable コマンドの使い方を表示
+
+- When "qni variable" を実行
+- Then 標準出力:
+
+  ```text
+  Usage:
+    qni variable set NAME ANGLE
+    qni variable list
+    qni variable unset NAME
+    qni variable clear
+
+  Overview:
+    Manage symbolic angle variables in ./circuit.json.
+    NAME must be an ASCII identifier such as theta.
+    ANGLE must be concrete, such as π/4, pi/3, or 0.5.
+    qni variable set requires ./circuit.json to already exist.
+    qni add Ry --angle theta --qubit 0 --step 0 stores Ry(theta).
+    qni run and qni expect resolve symbolic angles through these variables.
+
+  Examples:
+    qni variable set theta π/4
+    qni variable list
+    qni variable unset theta
+    qni variable clear
+  ```
+
+## Scenario: qni variable --help は成功する
+
+- When "qni variable --help" を実行
+- Then コマンドは成功
+
+## Scenario: qni variable --help は variable コマンドの使い方を表示
+
+- When "qni variable --help" を実行
+- Then 標準出力:
+
+  ```text
+  Usage:
+    qni variable set NAME ANGLE
+    qni variable list
+    qni variable unset NAME
+    qni variable clear
+
+  Overview:
+    Manage symbolic angle variables in ./circuit.json.
+    NAME must be an ASCII identifier such as theta.
+    ANGLE must be concrete, such as π/4, pi/3, or 0.5.
+    qni variable set requires ./circuit.json to already exist.
+    qni add Ry --angle theta --qubit 0 --step 0 stores Ry(theta).
+    qni run and qni expect resolve symbolic angles through these variables.
+
+  Examples:
+    qni variable set theta π/4
+    qni variable list
+    qni variable unset theta
+    qni variable clear
+  ```


### PR DESCRIPTION
## Summary

- Move `qni variable` and `qni variable --help` help scenarios into `features/variable/help.feature.md`.
- Remove the duplicated variable help scenarios from `features/qni_cli.feature`.
- Split success and stdout assertions so each moved scenario has one `Then`.

## Validation

- `PATH=/home/yasuhito/.local/share/mise/installs/ruby/4.0.2/bin:$PATH BUNDLE_PATH=/tmp/qni-cli-yas-187-bundle mise exec ruby@4.0.2 -- bundle exec rake check`

Linear: YAS-187
