### PR TITLE
YAS-190 qni bloch APNG シナリオを Markdown feature へ移動

### DIFF
--- a/features/bloch/apng.feature.md
+++ b/features/bloch/apng.feature.md
@@ -1,0 +1,44 @@
+# Feature: qni bloch APNG
+
+qni-cli のユーザとして
+1 qubit の状態変化をアニメーションで確認できるように
+qni bloch --apng でブロッホ球 APNG を書き出したい。
+
+## Scenario: qni bloch --apng は回転ゲートを含む 1 qubit 回路で成功する
+
+- Given "qni add Ry --angle π/2 --qubit 0 --step 0" を実行
+- When "qni bloch --apng --output bloch.png" を実行
+- Then コマンドは成功
+
+## Scenario: qni bloch --apng は回転ゲートを含む 1 qubit 回路の APNG を書き出す
+
+- Given "qni add Ry --angle π/2 --qubit 0 --step 0" を実行
+- When "qni bloch --apng --output bloch.png" を実行
+- Then "bloch.png" は APNG 画像である
+
+## Scenario: qni bloch --apng は回転ゲートを含む 1 qubit 回路を複数フレームで書き出す
+
+- Given "qni add Ry --angle π/2 --qubit 0 --step 0" を実行
+- When "qni bloch --apng --output bloch.png" を実行
+- Then "bloch.png" は 2 フレーム以上の APNG 画像である
+
+## Scenario: qni bloch --apng は S ゲートの位相回転で成功する
+
+- Given "qni state set \"|+>\"" を実行
+- Given "qni add S --qubit 0 --step 0" を実行
+- When "qni bloch --apng --output bloch-s.png" を実行
+- Then コマンドは成功
+
+## Scenario: qni bloch --apng は S ゲートの位相回転を APNG で書き出す
+
+- Given "qni state set \"|+>\"" を実行
+- Given "qni add S --qubit 0 --step 0" を実行
+- When "qni bloch --apng --output bloch-s.png" を実行
+- Then "bloch-s.png" は APNG 画像である
+
+## Scenario: qni bloch --apng は S ゲートの位相回転も段階的にアニメーションする
+
+- Given "qni state set \"|+>\"" を実行
+- Given "qni add S --qubit 0 --step 0" を実行
+- When "qni bloch --apng --output bloch-s.png" を実行
+- Then "bloch-s.png" は 3 フレーム以上の APNG 画像である

--- a/features/qni_bloch.feature
+++ b/features/qni_bloch.feature
@@ -11,21 +11,6 @@ Feature: qni bloch コマンド
     And "bloch.png" は透過 PNG 画像である
     And "bloch.png" の画像サイズは 512x512 である
 
-  Scenario: qni bloch --apng は回転ゲートを含む 1 qubit 回路のブロッホ球 APNG を書き出す
-    Given "qni add Ry --angle π/2 --qubit 0 --step 0" を実行
-    When "qni bloch --apng --output bloch.png" を実行
-    Then コマンドは成功
-    And "bloch.png" は APNG 画像である
-    And "bloch.png" は 2 フレーム以上の APNG 画像である
-
-  Scenario: qni bloch --apng は S ゲートの位相回転も段階的にアニメーションする
-    Given "qni state set \"|+>\"" を実行
-    And "qni add S --qubit 0 --step 0" を実行
-    When "qni bloch --apng --output bloch-s.png" を実行
-    Then コマンドは成功
-    And "bloch-s.png" は APNG 画像である
-    And "bloch-s.png" は 3 フレーム以上の APNG 画像である
-
   Scenario: qni bloch --png --light は light theme のブロッホ球 PNG を書き出す
     Given "qni add H --qubit 0 --step 0" を実行
     When "qni bloch --png --light --output bloch-light.png" を実行

--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -199,6 +199,48 @@ function assertPngSignature(actualPath, filePath) {
   assert.deepEqual(signature, pngSignature, `expected file to be a PNG image: ${filePath}`);
 }
 
+function pngChunks(actualPath, filePath) {
+  const png = fs.readFileSync(actualPath);
+  assertPngSignature(actualPath, filePath);
+
+  const chunks = [];
+  let offset = 8;
+
+  while (offset + 8 <= png.length) {
+    const length = png.readUInt32BE(offset);
+    const type = png.toString('ascii', offset + 4, offset + 8);
+    const dataStart = offset + 8;
+    const dataEnd = dataStart + length;
+
+    assert.ok(
+      dataEnd + 4 <= png.length,
+      `expected complete PNG chunk ${type} in: ${filePath}`
+    );
+
+    chunks.push({ type, dataStart, length });
+    offset = dataEnd + 4;
+
+    if (type === 'IEND') {
+      break;
+    }
+  }
+
+  return { png, chunks };
+}
+
+function apngMetadata(actualPath, filePath) {
+  const { png, chunks } = pngChunks(actualPath, filePath);
+  const animationControl = chunks.find((chunk) => chunk.type === 'acTL');
+  const frameChunks = chunks.filter((chunk) => chunk.type === 'fcTL');
+
+  return {
+    animated: animationControl !== undefined,
+    frameCount: animationControl
+      ? png.readUInt32BE(animationControl.dataStart)
+      : frameChunks.length
+  };
+}
+
 function pngMetadata(actualPath) {
   const script = `
 from PIL import Image
@@ -454,6 +496,23 @@ Then('{string} は PNG 画像である', function (filePath) {
 
   assert.ok(fs.existsSync(actualPath), `expected file to exist: ${filePath}`);
   assertPngSignature(actualPath, filePath);
+});
+
+Then('{string} は APNG 画像である', function (filePath) {
+  const actualPath = path.join(this.scenarioDir, filePath);
+
+  assert.ok(fs.existsSync(actualPath), `expected file to exist: ${filePath}`);
+  assert.equal(apngMetadata(actualPath, filePath).animated, true);
+});
+
+Then('{string} は {int} フレーム以上の APNG 画像である', function (filePath, minimumFrames) {
+  const actualPath = path.join(this.scenarioDir, filePath);
+
+  assert.ok(fs.existsSync(actualPath), `expected file to exist: ${filePath}`);
+  assert.ok(
+    apngMetadata(actualPath, filePath).frameCount >= minimumFrames,
+    `expected APNG frame count to be at least ${minimumFrames}: ${filePath}`
+  );
 });
 
 Then('{string} は透過 PNG 画像である', function (filePath) {


### PR DESCRIPTION
## Summary
- Move qni bloch APNG output scenarios from `features/qni_bloch.feature` to `features/bloch/apng.feature.md`.
- Split success, APNG image, and frame-count checks into separate one-Then scenarios.
- Add cucumber-js APNG image and frame-count steps for Markdown features.

## Validation
- `npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress features/bloch/apng.feature.md`
- `bundle exec rake check`

Linear: YAS-190