### PR TITLE
YAS-191 qni bloch PNG feature を分離

### DIFF
--- a/features/bloch/png.feature.md
+++ b/features/bloch/png.feature.md
@@ -1,0 +1,41 @@
+# Feature: qni bloch PNG
+
+qni-cli のユーザとして
+1 qubit の状態を画像として確認するために
+qni bloch --png でブロッホ球 PNG を書き出したい。
+
+## Scenario: qni bloch --png は成功する
+
+- Given "qni add H --qubit 0 --step 0" を実行
+- When "qni bloch --png --output bloch.png" を実行
+- Then コマンドは成功
+
+## Scenario: qni bloch --png は PNG ファイルを書き出す
+
+- Given "qni add H --qubit 0 --step 0" を実行
+- When "qni bloch --png --output bloch.png" を実行
+- Then "bloch.png" は PNG 画像である
+
+## Scenario: qni bloch --png は透過 PNG ファイルを書き出す
+
+- Given "qni add H --qubit 0 --step 0" を実行
+- When "qni bloch --png --output bloch.png" を実行
+- Then "bloch.png" は透過 PNG 画像である
+
+## Scenario: qni bloch --png は 512x512 の PNG ファイルを書き出す
+
+- Given "qni add H --qubit 0 --step 0" を実行
+- When "qni bloch --png --output bloch.png" を実行
+- Then "bloch.png" の画像サイズは 512x512 である
+
+## Scenario: qni bloch --png --light は成功する
+
+- Given "qni add H --qubit 0 --step 0" を実行
+- When "qni bloch --png --light --output bloch-light.png" を実行
+- Then コマンドは成功
+
+## Scenario: qni bloch --png --light は PNG ファイルを書き出す
+
+- Given "qni add H --qubit 0 --step 0" を実行
+- When "qni bloch --png --light --output bloch-light.png" を実行
+- Then "bloch-light.png" は PNG 画像である

--- a/features/qni_bloch.feature
+++ b/features/qni_bloch.feature
@@ -3,20 +3,6 @@ Feature: qni bloch コマンド
   1 qubit の状態を幾何学的に理解するために
   qni bloch でブロッホ球の PNG や APNG や inline 表示を使いたい
 
-  Scenario: qni bloch --png は 1 qubit 回路のブロッホ球 PNG を書き出す
-    Given "qni add H --qubit 0 --step 0" を実行
-    When "qni bloch --png --output bloch.png" を実行
-    Then コマンドは成功
-    And "bloch.png" は PNG 画像である
-    And "bloch.png" は透過 PNG 画像である
-    And "bloch.png" の画像サイズは 512x512 である
-
-  Scenario: qni bloch --png --light は light theme のブロッホ球 PNG を書き出す
-    Given "qni add H --qubit 0 --step 0" を実行
-    When "qni bloch --png --light --output bloch-light.png" を実行
-    Then コマンドは成功
-    And "bloch-light.png" は PNG 画像である
-
   Scenario: qni bloch は z 軸ラベルと |0> ラベルを重ならない位置に配置する
     Given "qni add H --qubit 0 --step 0" を実行
     When "qni bloch --png --light --output bloch-layout.png" を実行


### PR DESCRIPTION
## Summary
- YAS-191
- features/bloch/png.feature.md を追加し、qni bloch PNG 出力仕様を検証目的ごとに分割
- features/qni_bloch.feature から移動対象の PNG / light PNG シナリオを削除

## Validation
- npx cucumber-js --config cucumber-js.mjs --require features/support/**/*.js --require features/step_definitions/**/*.js --format progress features/bloch/png.feature.md
- bundle exec cucumber features/qni_bloch.feature
- env MPLCONFIGDIR=/tmp/qni-cli-matplotlib bundle exec rake check