### PR TITLE
YAS-192 qni bloch trajectory シナリオを分離する

### DIFF
--- a/features/bloch/trajectory.feature.md
+++ b/features/bloch/trajectory.feature.md
@@ -1,0 +1,30 @@
+# Feature: qni bloch trajectory PNG
+
+qni-cli のユーザとして
+1 qubit の状態変化を静止画でも確認できるように
+qni bloch --png --trajectory でブロッホ球 PNG に軌跡を描きたい。
+
+## Scenario: qni bloch --png --trajectory は X ゲートのブロッホ球 PNG で成功する
+
+- Given "qni add X --qubit 0 --step 0" を実行
+- When "qni bloch --png --trajectory --light --output bloch-trajectory.png" を実行
+- Then コマンドは成功
+
+## Scenario: qni bloch --png --trajectory は X ゲートのブロッホ球 PNG を書き出す
+
+- Given "qni add X --qubit 0 --step 0" を実行
+- When "qni bloch --png --trajectory --light --output bloch-trajectory.png" を実行
+- Then "bloch-trajectory.png" は PNG 画像である
+
+## Scenario: qni bloch --png --trajectory は X ゲートのブロッホ球 PNG に軌跡色を描く
+
+- Given "qni add X --qubit 0 --step 0" を実行
+- When "qni bloch --png --trajectory --light --output bloch-trajectory.png" を実行
+- Then "bloch-trajectory.png" は色 "#0f766e" のピクセルを含む
+
+## Scenario: qni bloch --png --trajectory は X ゲートの通常 PNG とは異なるファイルを書き出す
+
+- Given "qni add X --qubit 0 --step 0" を実行
+- When "qni bloch --png --light --output bloch.png" を実行
+- When "qni bloch --png --trajectory --light --output bloch-trajectory.png" を実行
+- Then "bloch.png" と "bloch-trajectory.png" は異なるファイル内容である

--- a/features/qni_bloch.feature
+++ b/features/qni_bloch.feature
@@ -19,16 +19,6 @@ Feature: qni bloch コマンド
     And ブロッホ球のラベル "|+i>" の表示は y 軸の先端より上にある
     And ブロッホ球のラベル "y" と "|+i>" の表示領域は重ならない
 
-  Scenario: qni bloch --png --trajectory は X ゲートのブロッホ球 PNG に軌跡を描く
-    Given "qni add X --qubit 0 --step 0" を実行
-    When "qni bloch --png --output bloch.png" を実行
-    Then コマンドは成功
-    When "qni bloch --png --trajectory --light --output bloch-trajectory.png" を実行
-    Then コマンドは成功
-    And "bloch-trajectory.png" は PNG 画像である
-    And "bloch-trajectory.png" は色 "#0f766e" のピクセルを含む
-    And "bloch.png" と "bloch-trajectory.png" は異なるファイル内容である
-
   Scenario: qni bloch --inline は 1 qubit 回路のブロッホ球を Kitty graphics protocol で表示する
     Given "qni add H --qubit 0 --step 0" を実行
     And 環境変数 "QNI_TEST_FORCE_INLINE" を "1" に設定する

--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -264,6 +264,26 @@ print(json.dumps({
   return pythonJson(script, [actualPath]);
 }
 
+function imageIncludesColor(actualPath, hexColor) {
+  const color = hexColor.replace(/^#/, '');
+  const script = `
+from PIL import Image
+import json
+import sys
+
+image = Image.open(sys.argv[1]).convert("RGBA")
+pixels = image.load()
+width, height = image.size
+target = tuple(int(sys.argv[2][index:index + 2], 16) for index in (0, 2, 4))
+print(json.dumps(any(
+    pixels[x, y][:3] == target and pixels[x, y][3] > 0
+    for y in range(height)
+    for x in range(width)
+)))
+`;
+  return pythonJson(script, [actualPath, color]);
+}
+
 function circleNotationPhaseMetrics(real, imag) {
   const script = `
 import importlib.util
@@ -564,6 +584,16 @@ Then('{string} の画像サイズは {int}x{int} である', function (filePath,
   const metadata = pngMetadata(actualPath);
 
   assert.deepEqual([metadata.width, metadata.height], [width, height]);
+});
+
+Then('{string} は色 {string} のピクセルを含む', function (filePath, hexColor) {
+  const actualPath = path.join(this.scenarioDir, filePath);
+
+  assert.ok(fs.existsSync(actualPath), `expected file to exist: ${filePath}`);
+  assert.ok(
+    imageIncludesColor(actualPath, hexColor),
+    `expected image to include color ${hexColor}: ${filePath}`
+  );
 });
 
 Then('{string} と {string} は異なるファイル内容である', function (lhsPath, rhsPath) {


### PR DESCRIPTION
## Summary

- Move the `qni bloch --png --trajectory` trajectory scenario from `features/qni_bloch.feature` into `features/bloch/trajectory.feature.md`.
- Split trajectory coverage into focused one-Then Cucumber scenarios for success, PNG output, trajectory color pixels, and difference from a normal PNG.
- Add a cucumber-js step that checks whether a generated image contains an exact RGB color pixel.

## Linear

YAS-192

## Validation

- `BUNDLE_PATH=/tmp/qni-cli-bundle npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress features/bloch/trajectory.feature.md`
- `BUNDLE_PATH=/tmp/qni-cli-bundle bundle exec rake check`
