### PR TITLE
YAS-196 空の qni_bloch feature を削除する

### DIFF
--- a/features/qni_bloch.feature
+++ b/features/qni_bloch.feature
@@ -1,4 +1,0 @@
-Feature: qni bloch コマンド
-  qni-cli のユーザとして
-  1 qubit の状態を幾何学的に理解するために
-  qni bloch でブロッホ球の PNG や APNG や inline 表示を使いたい


### PR DESCRIPTION
## Summary

- YAS-196
- Removed the empty `features/qni_bloch.feature` root feature file.
- Confirmed the split bloch scenarios remain under `features/bloch/*.feature.md`.

## Validation

- [x] `test ! -e features/qni_bloch.feature`
- [x] one-Then check across `features/bloch/*.feature.md`
- [x] `BUNDLE_PATH=/tmp/qni-cli-yas-196-bundle npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress "features/bloch/*.feature.md"`
- [x] `BUNDLE_PATH=/tmp/qni-cli-yas-196-bundle bundle exec rake check`

## Notes

No PR template exists at `.github/pull_request_template.md` in this repository.
