### PR TITLE
YAS-201 superposition feature の one-Then 違反を解消する

### DIFF
--- a/features/katas/superposition/all_bell_states.feature
+++ b/features/katas/superposition/all_bell_states.feature
@@ -16,7 +16,7 @@ Feature: Quantum Katas Superposition Task 1.7 AllBellStates
   そのあと 2 個目の qubit に Z と X を組み合わせて
   4 つの Bell 状態を切り替えられることを確かめる。
 
-  Scenario: index = 0 のとき |Φ+> を作る
+  Scenario: index = 0 のとき計算基底で |Φ+> を作る
     Given 初期状態ベクトルは:
       """
       |00>
@@ -33,12 +33,26 @@ Feature: Quantum Katas Superposition Task 1.7 AllBellStates
       """
       sqrt(2)/2|00> + sqrt(2)/2|11>
       """
-    And Bell 基底での状態ベクトルは:
+
+  Scenario: index = 0 のとき Bell 基底で |Φ+> を作る
+    Given 初期状態ベクトルは:
+      """
+      |00>
+      """
+    When 次の回路を適用:
+      """
+          ┌───┐
+      q0: ┤ H ├──■──
+          └───┘┌─┴─┐
+      q1: ─────┤ X ├
+               └───┘
+      """
+    Then Bell 基底での状態ベクトルは:
       """
       |Φ+>
       """
 
-  Scenario: index = 1 のとき |Φ-> を作る
+  Scenario: index = 1 のとき計算基底で |Φ-> を作る
     Given 初期状態ベクトルは:
       """
       |00>
@@ -55,12 +69,26 @@ Feature: Quantum Katas Superposition Task 1.7 AllBellStates
       """
       sqrt(2)/2|00> - sqrt(2)/2|11>
       """
-    And Bell 基底での状態ベクトルは:
+
+  Scenario: index = 1 のとき Bell 基底で |Φ-> を作る
+    Given 初期状態ベクトルは:
+      """
+      |00>
+      """
+    When 次の回路を適用:
+      """
+          ┌───┐
+      q0: ┤ H ├──■───────
+          └───┘┌─┴─┐┌───┐
+      q1: ─────┤ X ├┤ Z ├
+               └───┘└───┘
+      """
+    Then Bell 基底での状態ベクトルは:
       """
       |Φ->
       """
 
-  Scenario: index = 2 のとき |Ψ+> を作る
+  Scenario: index = 2 のとき計算基底で |Ψ+> を作る
     Given 初期状態ベクトルは:
       """
       |00>
@@ -77,12 +105,26 @@ Feature: Quantum Katas Superposition Task 1.7 AllBellStates
       """
       sqrt(2)/2|01> + sqrt(2)/2|10>
       """
-    And Bell 基底での状態ベクトルは:
+
+  Scenario: index = 2 のとき Bell 基底で |Ψ+> を作る
+    Given 初期状態ベクトルは:
+      """
+      |00>
+      """
+    When 次の回路を適用:
+      """
+          ┌───┐
+      q0: ┤ H ├──■───────
+          └───┘┌─┴─┐┌───┐
+      q1: ─────┤ X ├┤ X ├
+               └───┘└───┘
+      """
+    Then Bell 基底での状態ベクトルは:
       """
       |Ψ+>
       """
 
-  Scenario: index = 3 のとき |Ψ-> を作る
+  Scenario: index = 3 のとき計算基底で |Ψ-> を作る
     Given 初期状態ベクトルは:
       """
       |00>
@@ -99,7 +141,21 @@ Feature: Quantum Katas Superposition Task 1.7 AllBellStates
       """
       sqrt(2)/2|01> - sqrt(2)/2|10>
       """
-    And Bell 基底での状態ベクトルは:
+
+  Scenario: index = 3 のとき Bell 基底で |Ψ-> を作る
+    Given 初期状態ベクトルは:
+      """
+      |00>
+      """
+    When 次の回路を適用:
+      """
+          ┌───┐
+      q0: ┤ H ├──■────────────
+          └───┘┌─┴─┐┌───┐┌───┐
+      q1: ─────┤ X ├┤ Z ├┤ X ├
+               └───┘└───┘└───┘
+      """
+    Then Bell 基底での状態ベクトルは:
       """
       |Ψ->
       """

--- a/features/katas/superposition/bell_state.feature
+++ b/features/katas/superposition/bell_state.feature
@@ -11,7 +11,7 @@ Feature: Quantum Katas Superposition Task 1.6 BellState
   その値を CNOT で 2 個目の qubit にコピーすると、
   2 qubit がもつれた Bell 状態になることを確かめる。
 
-  Scenario: H のあとに CNOT を適用すると |00> は Bell 状態 |Φ+> になる
+  Scenario: H のあとに CNOT を適用すると |00> は計算基底の Bell 重ね合わせになる
     Given 初期状態ベクトルは:
       """
       |00>
@@ -28,7 +28,21 @@ Feature: Quantum Katas Superposition Task 1.6 BellState
       """
       sqrt(2)/2|00> + sqrt(2)/2|11>
       """
-    And Bell 基底での状態ベクトルは:
+
+  Scenario: H のあとに CNOT を適用すると |00> は Bell 基底の |Φ+> になる
+    Given 初期状態ベクトルは:
+      """
+      |00>
+      """
+    When 次の回路を適用:
+      """
+          ┌───┐
+      q0: ┤ H ├──■──
+          └───┘┌─┴─┐
+      q1: ─────┤ X ├
+               └───┘
+      """
+    Then Bell 基底での状態ベクトルは:
       """
       |Φ+>
       """

--- a/features/katas/superposition/ghz_state.feature
+++ b/features/katas/superposition/ghz_state.feature
@@ -11,7 +11,7 @@ Feature: Quantum Katas Superposition Task 1.8 GHZ_State
   その値を残りの qubit に順に CNOT で伝えると、
   GHZ 状態が作れることを小さい N から確かめる。
 
-  Scenario: N = 1 のとき GHZ 状態は |+> になる
+  Scenario: N = 1 のとき GHZ 状態は計算基底の重ね合わせになる
     Given 初期状態ベクトルは:
       """
       |0>
@@ -26,12 +26,24 @@ Feature: Quantum Katas Superposition Task 1.8 GHZ_State
       """
       sqrt(2)/2|0> + sqrt(2)/2|1>
       """
-    And |+>, |-> 基底での状態ベクトルは:
+
+  Scenario: N = 1 のとき GHZ 状態は |+> 基底状態になる
+    Given 初期状態ベクトルは:
+      """
+      |0>
+      """
+    When 次の回路を適用:
+      """
+          ┌───┐
+      q0: ┤ H ├
+          └───┘
+      """
+    Then |+>, |-> 基底での状態ベクトルは:
       """
       |+>
       """
 
-  Scenario: N = 2 のとき GHZ 状態は Bell state |Φ+> になる
+  Scenario: N = 2 のとき GHZ 状態は計算基底の Bell 重ね合わせになる
     Given 初期状態ベクトルは:
       """
       |00>
@@ -48,7 +60,21 @@ Feature: Quantum Katas Superposition Task 1.8 GHZ_State
       """
       sqrt(2)/2|00> + sqrt(2)/2|11>
       """
-    And Bell 基底での状態ベクトルは:
+
+  Scenario: N = 2 のとき GHZ 状態は Bell 基底の |Φ+> になる
+    Given 初期状態ベクトルは:
+      """
+      |00>
+      """
+    When 次の回路を適用:
+      """
+          ┌───┐
+      q0: ┤ H ├──■──
+          └───┘┌─┴─┐
+      q1: ─────┤ X ├
+               └───┘
+      """
+    Then Bell 基底での状態ベクトルは:
       """
       |Φ+>
       """

--- a/features/katas/superposition/minus_state.feature
+++ b/features/katas/superposition/minus_state.feature
@@ -10,7 +10,7 @@ Feature: Quantum Katas Superposition Task 1.2 MinusState
   この task では、X ゲートで |1⟩ を作ってから
   Hadamard ゲート H をかけることで |-⟩ が得られることを確かめる。
 
-  Scenario: X のあとに H を適用すると |0> は |-> に変わる
+  Scenario: X のあとに H を適用すると |0> は計算基底で負の重ね合わせになる
     Given 初期状態ベクトルは:
       """
       |0>
@@ -25,7 +25,19 @@ Feature: Quantum Katas Superposition Task 1.2 MinusState
       """
       sqrt(2)/2|0> - sqrt(2)/2|1>
       """
-    And |+>, |-> 基底での状態ベクトルは:
+
+  Scenario: X のあとに H を適用すると |0> は |-> 基底状態に変わる
+    Given 初期状態ベクトルは:
+      """
+      |0>
+      """
+    When 次の回路を適用:
+      """
+          ┌───┐┌───┐
+      q0: ┤ X ├┤ H ├
+          └───┘└───┘
+      """
+    Then |+>, |-> 基底での状態ベクトルは:
       """
       |->
       """

--- a/features/katas/superposition/plus_state.feature
+++ b/features/katas/superposition/plus_state.feature
@@ -10,7 +10,7 @@ Feature: Quantum Katas Superposition Task 1.1 PlusState
   この task では、Hadamard ゲート H が
   計算基底の |0⟩ を x 基底の |+⟩ に変えることを確かめる。
 
-  Scenario: H ゲートは |0> を |+> に変える
+  Scenario: H ゲートは |0> を計算基底の重ね合わせに変える
     Given 初期状態ベクトルは:
       """
       |0>
@@ -25,7 +25,19 @@ Feature: Quantum Katas Superposition Task 1.1 PlusState
       """
       sqrt(2)/2|0> + sqrt(2)/2|1>
       """
-    And |+>, |-> 基底での状態ベクトルは:
+
+  Scenario: H ゲートは |0> を |+> 基底状態に変える
+    Given 初期状態ベクトルは:
+      """
+      |0>
+      """
+    When 次の回路を適用:
+      """
+          ┌───┐
+      q0: ┤ H ├
+          └───┘
+      """
+    Then |+>, |-> 基底での状態ベクトルは:
       """
       |+>
       """


### PR DESCRIPTION
## Summary
- root 直下の Ruby feature が既に削除済みであることを確認
- `features/katas/superposition/*.feature` の複数検証シナリオを分割
- `features/**/*.feature.md` と `features/**/*.feature` の実行対象を確認

## Validation
- `ruby` one-Then validation script
- `BUNDLE_PATH=/tmp/qni-cli-yas-201-bundle bundle exec cucumber features/katas/superposition/plus_state.feature features/katas/superposition/minus_state.feature features/katas/superposition/bell_state.feature features/katas/superposition/ghz_state.feature features/katas/superposition/all_bell_states.feature`
- `BUNDLE_PATH=/tmp/qni-cli-yas-201-bundle bundle exec rake check`

Linear: YAS-201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 変更内容

* **テスト**
  * テストシナリオを再構成しました。複数の基底における状態検証を独立したテストケースに分割し、各検証項目をより詳細かつ明確に整理することで、テスト構造の可読性と保守性が向上しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->