### PR TITLE
YAS-212 qni-cli workspace の未追跡ファイルノイズを減らす

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,19 @@ jobs:
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
+
+      - name: Cache Ruby dependencies
+        uses: actions/cache@v4
         with:
-          bundler-cache: true
+          path: .bundle/vendor
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
+      - name: Install Ruby dependencies
+        run: |
+          bundle config set path .bundle/vendor
+          bundle install
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,8 @@ jobs:
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
-
-      - name: Install Ruby dependencies
-        run: |
-          bundle config set path .bundle/vendor
-          bundle install
+        with:
+          bundler-cache: true
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,11 @@ jobs:
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
+
+      - name: Install Ruby dependencies
+        run: |
+          bundle config set path .bundle/vendor
+          bundle install
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 .python-symbolic/
 node_modules/
 __pycache__/
+.codex/
+excalidraw.log

--- a/features/ci/github_actions.feature.md
+++ b/features/ci/github_actions.feature.md
@@ -56,14 +56,6 @@ GitHub Actions と共通の rake 入口を整えたい
 
 - Then リポジトリファイル ".github/workflows/ci.yml" は "npm ci" を含む
 
-## Scenario: GitHub Actions workflow は Bundler path を workspace-local にする
-
-- Then リポジトリファイル ".github/workflows/ci.yml" は "bundle config set path .bundle/vendor" を含む
-
-## Scenario: GitHub Actions workflow は Ruby dependencies を入れる
-
-- Then リポジトリファイル ".github/workflows/ci.yml" は "bundle install" を含む
-
 ## Scenario: GitHub Actions workflow は symbolic Python を設定する
 
 - Then リポジトリファイル ".github/workflows/ci.yml" は "scripts/setup_symbolic_python.sh" を含む

--- a/features/ci/github_actions.feature.md
+++ b/features/ci/github_actions.feature.md
@@ -56,6 +56,18 @@ GitHub Actions と共通の rake 入口を整えたい
 
 - Then リポジトリファイル ".github/workflows/ci.yml" は "npm ci" を含む
 
+## Scenario: GitHub Actions workflow は Bundler path を workspace-local にする
+
+- Then リポジトリファイル ".github/workflows/ci.yml" は "bundle config set path .bundle/vendor" を含む
+
+## Scenario: GitHub Actions workflow は Ruby dependencies を入れる
+
+- Then リポジトリファイル ".github/workflows/ci.yml" は "bundle install" を含む
+
+## Scenario: GitHub Actions workflow は Ruby dependencies を cache する
+
+- Then リポジトリファイル ".github/workflows/ci.yml" は "actions/cache@v4" を含む
+
 ## Scenario: GitHub Actions workflow は symbolic Python を設定する
 
 - Then リポジトリファイル ".github/workflows/ci.yml" は "scripts/setup_symbolic_python.sh" を含む

--- a/features/ci/github_actions.feature.md
+++ b/features/ci/github_actions.feature.md
@@ -56,6 +56,14 @@ GitHub Actions と共通の rake 入口を整えたい
 
 - Then リポジトリファイル ".github/workflows/ci.yml" は "npm ci" を含む
 
+## Scenario: GitHub Actions workflow は Bundler path を workspace-local にする
+
+- Then リポジトリファイル ".github/workflows/ci.yml" は "bundle config set path .bundle/vendor" を含む
+
+## Scenario: GitHub Actions workflow は Ruby dependencies を入れる
+
+- Then リポジトリファイル ".github/workflows/ci.yml" は "bundle install" を含む
+
 ## Scenario: GitHub Actions workflow は symbolic Python を設定する
 
 - Then リポジトリファイル ".github/workflows/ci.yml" は "scripts/setup_symbolic_python.sh" を含む

--- a/features/repository/workspace_noise.feature.md
+++ b/features/repository/workspace_noise.feature.md
@@ -1,0 +1,12 @@
+# Feature: Workspace noise
+
+qni-cli の Symphony workspace 利用者として
+作業に関係ない生成ファイルで git status が埋まらないようにしたい
+
+## Scenario: `.codex/` は ignore される
+
+- Then リポジトリファイル ".gitignore" は ".codex/" を含む
+
+## Scenario: `excalidraw.log` は ignore される
+
+- Then リポジトリファイル ".gitignore" は "excalidraw.log" を含む


### PR DESCRIPTION
## 概要

- YAS-212: Symphony issue workspace にコピーされる `.codex/` と、既存 workspace に残り得る `excalidraw.log` を `.gitignore` に追加しました。
- repo 内に専用の Symphony workflow ファイルはないため、repo-owned workflow surface の `.github/workflows/ci.yml` で Ruby dependencies の install を明示化しました。
- `bundle install` の前に `bundle config set path .bundle/vendor` を実行し、workspace-local な gem path を使うようにしました。
- `bundler-cache` の代わりに `actions/cache@v4` で `.bundle/vendor` を cache します。
- 変更内容を `features/repository/workspace_noise.feature.md` と `features/ci/github_actions.feature.md` に追加しました。

## 検証

- `npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress features/ci/github_actions.feature.md features/repository/workspace_noise.feature.md`
- `git check-ignore -v .codex/ excalidraw.log`
- `ruby -rpsych -e 'Psych.load_file(ARGV.fetch(0)); puts "ok"' .github/workflows/ci.yml`
- `git diff --check`
- `bundle exec rake check`
