### PR TITLE
YAS-213 TypeScript tooling と Ruby 委譲 dispatcher を追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .cache/
 .python-symbolic/
 node_modules/
+dist/
 __pycache__/
 .codex/
 excalidraw.log

--- a/features/cli/dispatcher/node_dispatcher.feature.md
+++ b/features/cli/dispatcher/node_dispatcher.feature.md
@@ -1,0 +1,27 @@
+# Feature: Node dispatcher
+
+Ruby から TypeScript へ段階移行するために
+qni CLI は Node dispatcher から既存 Ruby 実装へ委譲できる必要がある。
+
+## Scenario: Node dispatcher は Ruby 実装へ委譲したコマンドを成功させる
+
+- Given 空の 1 qubit 回路がある
+- When Node dispatcher で "qni view" を実行
+- Then コマンドは成功
+
+## Scenario: Node dispatcher は Ruby 実装の標準出力を返す
+
+- Given 空の 1 qubit 回路がある
+- When Node dispatcher で "qni view" を実行
+- Then 標準出力:
+
+  ```text
+  q0: ─
+  ```
+
+## Scenario: QNI_USE_RUBY override は Node dispatcher 経由でも成功する
+
+- Given 空の 1 qubit 回路がある
+- Given 環境変数 "QNI_USE_RUBY" を "1" に設定する
+- When Node dispatcher で "qni view" を実行
+- Then コマンドは成功

--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -8,6 +8,7 @@ const { Given, Then, When } = require('@cucumber/cucumber');
 
 const PROJECT_ROOT = path.resolve(__dirname, '../..');
 const QNI_BIN = path.join(PROJECT_ROOT, 'bin', 'qni');
+const NODE_QNI_BIN = path.join(PROJECT_ROOT, 'dist', 'bin', 'qni.js');
 const PYTHON_SYMBOLIC = path.join(PROJECT_ROOT, '.python-symbolic', 'bin', 'python');
 const MPLCONFIGDIR = process.env.MPLCONFIGDIR || path.join(os.tmpdir(), 'qni-cli-matplotlib');
 const ONE_QUBIT_INITIAL_STATE_COLS = new Map([
@@ -101,6 +102,36 @@ function runQniCommand(scenarioDir, command, extraEnv = {}) {
 
   return new Promise((resolve, reject) => {
     const child = spawn('bundle', ['exec', QNI_BIN, ...argv.slice(1)], {
+      cwd: scenarioDir,
+      env: bundlerEnv(extraEnv)
+    });
+
+    const stdout = [];
+    const stderr = [];
+
+    child.stdout.on('data', (chunk) => stdout.push(chunk));
+    child.stderr.on('data', (chunk) => stderr.push(chunk));
+    child.on('error', reject);
+    child.on('close', (code, signal) => {
+      resolve({
+        code,
+        signal,
+        stdout: Buffer.concat(stdout).toString('utf8'),
+        stderr: Buffer.concat(stderr).toString('utf8')
+      });
+    });
+  });
+}
+
+function runNodeDispatcherCommand(scenarioDir, command, extraEnv = {}) {
+  const argv = splitCommand(command);
+
+  if (argv[0] !== 'qni') {
+    throw new Error(`command must start with qni: ${command}`);
+  }
+
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [NODE_QNI_BIN, ...argv.slice(1)], {
       cwd: scenarioDir,
       env: bundlerEnv(extraEnv)
     });
@@ -693,6 +724,10 @@ Given('空の 3 qubit 回路がある', function () {
 
 When('{string} を実行', async function (command) {
   this.lastCommand = await runQniCommand(this.scenarioDir, command, this.commandEnv);
+});
+
+When('Node dispatcher で {string} を実行', async function (command) {
+  this.lastCommand = await runNodeDispatcherCommand(this.scenarioDir, command, this.commandEnv);
 });
 
 Given('次の circuit.json がある:', function (docString) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,13 @@
   "packages": {
     "": {
       "name": "qni-cli",
+      "bin": {
+        "qni": "dist/bin/qni.js"
+      },
       "devDependencies": {
-        "@cucumber/cucumber": "^12.2.0"
+        "@cucumber/cucumber": "^12.2.0",
+        "@types/node": "^25.6.0",
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -281,6 +286,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -1294,6 +1309,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicorn-magic": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,16 @@
   "name": "qni-cli",
   "private": true,
   "type": "commonjs",
+  "bin": {
+    "qni": "./dist/bin/qni.js"
+  },
   "scripts": {
-    "cucumber": "cucumber-js --config cucumber-js.mjs --require \"features/support/**/*.js\" --require \"features/step_definitions/**/*.js\" --format progress \"features/**/*.feature.md\""
+    "build": "tsc",
+    "cucumber": "npm run build && cucumber-js --config cucumber-js.mjs --require \"features/support/**/*.js\" --require \"features/step_definitions/**/*.js\" --format progress \"features/**/*.feature.md\""
   },
   "devDependencies": {
-    "@cucumber/cucumber": "^12.2.0"
+    "@cucumber/cucumber": "^12.2.0",
+    "@types/node": "^25.6.0",
+    "typescript": "^6.0.3"
   }
 }

--- a/src/bin/qni.ts
+++ b/src/bin/qni.ts
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+import path = require('node:path');
+
+import { createDispatcher } from '../dispatcher';
+
+const projectRoot = path.resolve(__dirname, '../..');
+const dispatcher = createDispatcher({
+  env: process.env,
+  projectRoot
+});
+
+process.exit(dispatcher.run(process.argv.slice(2)));

--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -1,0 +1,69 @@
+import { delegateToRuby } from './ruby_delegate';
+
+export type CommandHandler = (argv: string[]) => number;
+export type RouteTarget = 'ruby' | 'typescript';
+
+export interface DispatcherOptions {
+  env: NodeJS.ProcessEnv;
+  projectRoot: string;
+}
+
+interface CommandRoute {
+  handler?: CommandHandler;
+  target: RouteTarget;
+}
+
+const TYPESCRIPT_ROUTES = new Map<string, CommandHandler>();
+
+export function createDispatcher(options: DispatcherOptions): Dispatcher {
+  return new Dispatcher(options);
+}
+
+export class Dispatcher {
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly projectRoot: string;
+
+  constructor(options: DispatcherOptions) {
+    this.env = options.env;
+    this.projectRoot = options.projectRoot;
+  }
+
+  run(argv: string[]): number {
+    const route = this.routeFor(argv);
+
+    if (route.target === 'typescript' && route.handler) {
+      return route.handler(argv);
+    }
+
+    return delegateToRuby({
+      argv,
+      env: this.env,
+      projectRoot: this.projectRoot
+    });
+  }
+
+  private routeFor(argv: string[]): CommandRoute {
+    if (this.useRubyOverride()) {
+      return { target: 'ruby' };
+    }
+
+    const handler = TYPESCRIPT_ROUTES.get(commandName(argv));
+
+    if (handler) {
+      return {
+        handler,
+        target: 'typescript'
+      };
+    }
+
+    return { target: 'ruby' };
+  }
+
+  private useRubyOverride(): boolean {
+    return this.env.QNI_USE_RUBY === '1';
+  }
+}
+
+function commandName(argv: string[]): string {
+  return argv[0] ?? '';
+}

--- a/src/ruby_delegate.ts
+++ b/src/ruby_delegate.ts
@@ -1,0 +1,38 @@
+import { spawnSync } from 'node:child_process';
+import path = require('node:path');
+
+export interface RubyDelegateOptions {
+  argv: string[];
+  env: NodeJS.ProcessEnv;
+  projectRoot: string;
+}
+
+export function delegateToRuby(options: RubyDelegateOptions): number {
+  const result = spawnSync('bundle', ['exec', rubyEntrypoint(options.projectRoot), ...options.argv], {
+    cwd: process.cwd(),
+    env: rubyEnv(options),
+    stdio: 'inherit'
+  });
+
+  if (result.error) {
+    console.error(result.error.message);
+    return 127;
+  }
+
+  if (result.signal) {
+    return 1;
+  }
+
+  return result.status ?? 1;
+}
+
+function rubyEntrypoint(projectRoot: string): string {
+  return path.join(projectRoot, 'bin', 'qni');
+}
+
+function rubyEnv(options: RubyDelegateOptions): NodeJS.ProcessEnv {
+  return {
+    ...options.env,
+    BUNDLE_GEMFILE: path.join(options.projectRoot, 'Gemfile')
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "noEmitOnError": true,
+    "types": [
+      "node"
+    ],
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## 概要

- YAS-213
- TypeScript source tree、`tsconfig.json`、`npm run build` を追加しました。
- Node executable entrypoint と dispatcher を追加し、現時点では全 command を Ruby 実装へ委譲します。
- 将来の per-command TypeScript routing 用に dispatcher の route map を用意しました。
- `QNI_USE_RUBY=1` override と Ruby fallback を維持し、既存 `bin/qni` の default behavior は変更していません。

## 検証

- `npm run build`
- `npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress features/cli/dispatcher/node_dispatcher.feature.md`
- `node dist/bin/qni.js view`
- `QNI_USE_RUBY=1 node dist/bin/qni.js view`
- `bundle exec rake check`
