### PR TITLE
TypeScript process compatibility helper を整備する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /tmp/
 .tmp/
+dist/
 .bundle/
 .worktrees/
 .cache/

--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,11 @@ task :cucumber do
   sh 'npm run cucumber'
 end
 
+desc 'Run TypeScript tests'
+task :typescript do
+  sh 'npm run test:ts'
+end
+
 desc 'Run Minitest tests'
 Rake::TestTask.new(:test) do |task|
   task.libs << 'test'
@@ -38,6 +43,6 @@ Reek::Rake::Task.new(:reek) do |task|
 end
 
 desc 'Run all checks'
-task check: %i[rubocop flog flay reek cucumber test]
+task check: %i[rubocop flog flay reek typescript cucumber test]
 
 task default: :check

--- a/features/ci/github_actions.feature.md
+++ b/features/ci/github_actions.feature.md
@@ -14,7 +14,7 @@ GitHub Actions と共通の rake 入口を整えたい
 
 ## Scenario: rake check は cucumber-js task を含む
 
-- Then リポジトリファイル "Rakefile" は "task check: %i[rubocop flog flay reek cucumber" を含む
+- Then リポジトリファイル "Rakefile" は "task check: %i[rubocop flog flay reek typescript cucumber" を含む
 
 ## Scenario: rake check は test task を含む
 

--- a/features/cli/typescript_process_compatibility.feature.md
+++ b/features/cli/typescript_process_compatibility.feature.md
@@ -1,0 +1,17 @@
+# Feature: TypeScript process compatibility helper
+
+qni-cli のメンテナとして
+TypeScript dispatcher から Ruby fallback を安全に呼び出せるようにするために
+process compatibility helper の契約を明確にしたい
+
+## Scenario: helper module が存在する
+
+- Then リポジトリファイル "src/process/process_compatibility.ts" は存在する
+
+## Scenario: TypeScript test script が定義されている
+
+- Then リポジトリファイル "package.json" は "\"test:ts\"" を含む
+
+## Scenario: full check は TypeScript tests を実行する
+
+- Then リポジトリファイル "Rakefile" は "npm run test:ts" を含む

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,9 @@
     "": {
       "name": "qni-cli",
       "devDependencies": {
-        "@cucumber/cucumber": "^12.2.0"
+        "@cucumber/cucumber": "^12.2.0",
+        "@types/node": "^25.6.0",
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -281,6 +283,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -1294,6 +1306,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicorn-magic": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,13 @@
   "private": true,
   "type": "commonjs",
   "scripts": {
-    "cucumber": "cucumber-js --config cucumber-js.mjs --require \"features/support/**/*.js\" --require \"features/step_definitions/**/*.js\" --format progress \"features/**/*.feature.md\""
+    "build:ts": "tsc -p tsconfig.json",
+    "cucumber": "cucumber-js --config cucumber-js.mjs --require \"features/support/**/*.js\" --require \"features/step_definitions/**/*.js\" --format progress \"features/**/*.feature.md\"",
+    "test:ts": "tsc -p tsconfig.test.json && node --test \"tmp/typescript-tests/test/typescript/**/*.test.js\""
   },
   "devDependencies": {
-    "@cucumber/cucumber": "^12.2.0"
+    "@cucumber/cucumber": "^12.2.0",
+    "@types/node": "^25.6.0",
+    "typescript": "^6.0.3"
   }
 }

--- a/src/process/process_compatibility.ts
+++ b/src/process/process_compatibility.ts
@@ -1,0 +1,125 @@
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import type { Writable } from 'node:stream';
+
+export interface SubprocessInvocation {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly cwd: string;
+  readonly env?: NodeJS.ProcessEnv;
+}
+
+export interface ResolvedSubprocessInvocation extends SubprocessInvocation {
+  readonly env: NodeJS.ProcessEnv;
+}
+
+export interface RunSubprocessOptions extends SubprocessInvocation {
+  readonly stdout?: Writable;
+  readonly stderr?: Writable;
+}
+
+export interface SubprocessResult {
+  readonly exitStatus: number | null;
+  readonly signal: NodeJS.Signals | null;
+}
+
+export interface RubyFallbackOptions {
+  readonly argv: readonly string[];
+  readonly cwd: string;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly projectRoot: string;
+}
+
+export interface RunRubyFallbackOptions extends RubyFallbackOptions {
+  readonly stdout?: Writable;
+  readonly stderr?: Writable;
+}
+
+export interface CommandImplementationOptions {
+  readonly argv: readonly string[];
+  readonly env: NodeJS.ProcessEnv;
+  readonly migratedCommands: ReadonlySet<string>;
+}
+
+export type CommandImplementation =
+  | {
+      readonly kind: 'ruby';
+      readonly reason: 'forced-by-env';
+    }
+  | {
+      readonly command: string;
+      readonly kind: 'ruby';
+      readonly reason: 'unmigrated-command';
+    }
+  | {
+      readonly command: string;
+      readonly kind: 'typescript';
+    };
+
+function mergedEnv(env: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    ...env
+  };
+}
+
+export function commandLineArgs(processArgv: readonly string[] = process.argv): string[] {
+  return processArgv.slice(2);
+}
+
+export function rubyFallbackForced(env: NodeJS.ProcessEnv): boolean {
+  return env.QNI_USE_RUBY === '1';
+}
+
+export function chooseCommandImplementation(
+  options: CommandImplementationOptions
+): CommandImplementation {
+  if (rubyFallbackForced(options.env)) {
+    return { kind: 'ruby', reason: 'forced-by-env' };
+  }
+
+  const command = options.argv[0] ?? '';
+
+  if (options.migratedCommands.has(command)) {
+    return { command, kind: 'typescript' };
+  }
+
+  return { command, kind: 'ruby', reason: 'unmigrated-command' };
+}
+
+export function createRubyFallbackInvocation(options: RubyFallbackOptions): ResolvedSubprocessInvocation {
+  return {
+    args: ['exec', path.join(options.projectRoot, 'bin', 'qni'), ...options.argv],
+    command: 'bundle',
+    cwd: options.cwd,
+    env: {
+      ...mergedEnv(options.env),
+      BUNDLE_GEMFILE: path.join(options.projectRoot, 'Gemfile')
+    }
+  };
+}
+
+export function runSubprocess(options: RunSubprocessOptions): Promise<SubprocessResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(options.command, [...options.args], {
+      cwd: options.cwd,
+      env: mergedEnv(options.env),
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+
+    child.stdout.pipe(options.stdout ?? process.stdout, { end: false });
+    child.stderr.pipe(options.stderr ?? process.stderr, { end: false });
+    child.once('error', reject);
+    child.once('close', (exitStatus, signal) => {
+      resolve({ exitStatus, signal });
+    });
+  });
+}
+
+export function runRubyFallback(options: RunRubyFallbackOptions): Promise<SubprocessResult> {
+  return runSubprocess({
+    ...createRubyFallbackInvocation(options),
+    stderr: options.stderr,
+    stdout: options.stdout
+  });
+}

--- a/test/typescript/process_compatibility.test.ts
+++ b/test/typescript/process_compatibility.test.ts
@@ -1,0 +1,193 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { Writable } from 'node:stream';
+import { describe, it } from 'node:test';
+
+import {
+  chooseCommandImplementation,
+  commandLineArgs,
+  createRubyFallbackInvocation,
+  runRubyFallback,
+  runSubprocess
+} from '../../src/process/process_compatibility';
+
+class StringSink extends Writable {
+  readonly chunks: Buffer[] = [];
+
+  _write(
+    chunk: Buffer | string,
+    encoding: BufferEncoding,
+    callback: (error?: Error | null) => void
+  ): void {
+    this.chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding));
+    callback();
+  }
+
+  text(): string {
+    return Buffer.concat(this.chunks).toString('utf8');
+  }
+}
+
+async function withTempDir<T>(callback: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'qni-cli-ts-'));
+
+  try {
+    return await callback(dir);
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+}
+
+describe('runSubprocess', () => {
+  it('forwards stdout, stderr, and exit status', async () => {
+    const stdout = new StringSink();
+    const stderr = new StringSink();
+    const result = await runSubprocess({
+      args: [
+        '-e',
+        "process.stdout.write('stdout from child\\n'); process.stderr.write('stderr from child\\n'); process.exit(7);"
+      ],
+      command: process.execPath,
+      cwd: process.cwd(),
+      stderr,
+      stdout
+    });
+
+    assert.equal(result.exitStatus, 7);
+    assert.equal(result.signal, null);
+    assert.equal(stdout.text(), 'stdout from child\n');
+    assert.equal(stderr.text(), 'stderr from child\n');
+  });
+
+  it('passes cwd, argv, and env to the child process', async () => {
+    await withTempDir(async (dir) => {
+      const probePath = path.join(dir, 'probe.js');
+      await writeFile(
+        probePath,
+        [
+          'const payload = {',
+          '  cwd: process.cwd(),',
+          '  argv: process.argv.slice(2),',
+          '  env: process.env.QNI_COMPAT_TEST',
+          '};',
+          'process.stdout.write(JSON.stringify(payload));'
+        ].join('\n')
+      );
+
+      const stdout = new StringSink();
+      const result = await runSubprocess({
+        args: [probePath, 'alpha', 'beta'],
+        command: process.execPath,
+        cwd: dir,
+        env: { QNI_COMPAT_TEST: 'present' },
+        stdout
+      });
+
+      assert.equal(result.exitStatus, 0);
+      assert.deepEqual(JSON.parse(stdout.text()), {
+        argv: ['alpha', 'beta'],
+        cwd: dir,
+        env: 'present'
+      });
+    });
+  });
+});
+
+describe('Ruby fallback process compatibility', () => {
+  it('builds a Ruby fallback invocation that preserves cwd, argv, and env', () => {
+    const invocation = createRubyFallbackInvocation({
+      argv: ['run', '--symbolic'],
+      cwd: '/tmp/qni-work',
+      env: { PATH: '/usr/bin', QNI_USE_RUBY: '1' },
+      projectRoot: '/repo/qni-cli'
+    });
+
+    assert.equal(invocation.command, 'bundle');
+    assert.deepEqual(invocation.args, ['exec', '/repo/qni-cli/bin/qni', 'run', '--symbolic']);
+    assert.equal(invocation.cwd, '/tmp/qni-work');
+    assert.equal(invocation.env.BUNDLE_GEMFILE, '/repo/qni-cli/Gemfile');
+    assert.equal(invocation.env.PATH, '/usr/bin');
+    assert.equal(invocation.env.QNI_USE_RUBY, '1');
+  });
+
+  it('forwards Ruby fallback stdout', async () => {
+    await withTempDir(async (dir) => {
+      const stdout = new StringSink();
+      const stderr = new StringSink();
+      const result = await runRubyFallback({
+        argv: ['clear', '--help'],
+        cwd: dir,
+        projectRoot: process.cwd(),
+        stderr,
+        stdout
+      });
+
+      assert.equal(result.exitStatus, 0);
+      assert.match(stdout.text(), /^Usage:\n  qni clear\n/u);
+      assert.equal(stderr.text(), '');
+    });
+  });
+
+  it('forwards Ruby fallback stderr and exit status', async () => {
+    await withTempDir(async (dir) => {
+      const stdout = new StringSink();
+      const stderr = new StringSink();
+      const result = await runRubyFallback({
+        argv: ['__missing_command__'],
+        cwd: dir,
+        projectRoot: process.cwd(),
+        stderr,
+        stdout
+      });
+
+      assert.equal(result.exitStatus, 1);
+      assert.equal(stdout.text(), '');
+      assert.equal(stderr.text(), 'Could not find command "__missing_command__".\n');
+    });
+  });
+});
+
+describe('dispatcher-facing helpers', () => {
+  it('forces the Ruby implementation when QNI_USE_RUBY is 1', () => {
+    assert.deepEqual(
+      chooseCommandImplementation({
+        argv: ['clear'],
+        env: { QNI_USE_RUBY: '1' },
+        migratedCommands: new Set(['clear'])
+      }),
+      { kind: 'ruby', reason: 'forced-by-env' }
+    );
+  });
+
+  it('chooses Ruby fallback for commands that are not migrated', () => {
+    assert.deepEqual(
+      chooseCommandImplementation({
+        argv: ['bloch'],
+        env: {},
+        migratedCommands: new Set(['clear'])
+      }),
+      { command: 'bloch', kind: 'ruby', reason: 'unmigrated-command' }
+    );
+  });
+
+  it('chooses TypeScript for migrated commands when Ruby is not forced', () => {
+    assert.deepEqual(
+      chooseCommandImplementation({
+        argv: ['clear'],
+        env: {},
+        migratedCommands: new Set(['clear'])
+      }),
+      { command: 'clear', kind: 'typescript' }
+    );
+  });
+
+  it('normalizes direct node and npm bin argv shapes', () => {
+    assert.deepEqual(commandLineArgs(['/usr/bin/node', '/repo/dist/cli.js', 'add', 'H']), [
+      'add',
+      'H'
+    ]);
+    assert.deepEqual(commandLineArgs(['/usr/bin/node', '/usr/local/bin/qni', 'run']), ['run']);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "noImplicitReturns": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "target": "ES2022",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "outDir": "tmp/typescript-tests",
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "test/typescript/**/*.test.ts"]
+}


### PR DESCRIPTION
## 概要

YAS-214 の対応として、TypeScript dispatcher から利用できる process compatibility helper を追加しました。

- `src/process/process_compatibility.ts` に subprocess forwarding / Ruby fallback invocation / routing decision / argv normalization を追加
- Ruby fallback の stdout、stderr、exit status、cwd、argv、env、`QNI_USE_RUBY=1` を TypeScript tests で検証
- TypeScript build/test harness を追加し、`bundle exec rake check` に `npm run test:ts` を組み込み
- feature-first ルールに合わせて helper 契約の feature を追加し、CI feature の `rake check` 期待値も更新

## 検証

- `npm run test:ts`
- `npm run build:ts`
- `npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress features/cli/typescript_process_compatibility.feature.md`
- `npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress features/ci/github_actions.feature.md`
- `git diff --check`
- `bundle exec rake check`

## 備考

ローカル sandbox が `.git/index.lock` / `.git` object 書き込みを read-only として拒否したため、検証済みの staged diff から `gh api` で remote branch commit を作成しました。remote commit は `82bee5857ae5bdd1c2a79d7e164a8a3428414484` です。
