### PR TITLE
qni variable を TypeScript 実装へ移行する

### DIFF
--- a/features/cli/variable/errors.feature.md
+++ b/features/cli/variable/errors.feature.md
@@ -19,3 +19,106 @@ qni variable のエラーを確認したい
   ```text
   circuit.json does not exist
   ```
+
+## Scenario: qni variable clear は余分な引数があると失敗する
+
+- Given 次の circuit.json がある:
+
+  ```json
+  {
+    "qubits": 1,
+    "cols": [
+      ["Ry(theta)"]
+    ],
+    "variables": {
+      "theta": "π/4"
+    }
+  }
+  ```
+
+- When "qni variable clear extra" を実行
+- Then コマンドは失敗
+
+## Scenario: qni variable clear は余分な引数があると circuit.json を変更しない
+
+- Given 次の circuit.json がある:
+
+  ```json
+  {
+    "qubits": 1,
+    "cols": [
+      ["Ry(theta)"]
+    ],
+    "variables": {
+      "theta": "π/4"
+    }
+  }
+  ```
+
+- When "qni variable clear extra" を実行
+- Then "circuit.json" の JSON 内容:
+
+  ```json
+  {
+    "qubits": 1,
+    "cols": [
+      ["Ry(theta)"]
+    ],
+    "variables": {
+      "theta": "π/4"
+    }
+  }
+  ```
+
+## Scenario: qni variable set は cols が配列でない circuit.json では失敗する
+
+- Given 次の circuit.json がある:
+
+  ```json
+  {
+    "qubits": 1,
+    "cols": "bad"
+  }
+  ```
+
+- When "qni variable set theta π/4" を実行
+- Then コマンドは失敗
+
+## Scenario: qni variable set は cols が配列でない circuit.json のエラー内容を表示する
+
+- Given 次の circuit.json がある:
+
+  ```json
+  {
+    "qubits": 1,
+    "cols": "bad"
+  }
+  ```
+
+- When "qni variable set theta π/4" を実行
+- Then 標準エラー:
+
+  ```text
+  cols must be an array
+  ```
+
+## Scenario: qni variable set は cols が配列でない circuit.json を変更しない
+
+- Given 次の circuit.json がある:
+
+  ```json
+  {
+    "qubits": 1,
+    "cols": "bad"
+  }
+  ```
+
+- When "qni variable set theta π/4" を実行
+- Then "circuit.json" の JSON 内容:
+
+  ```json
+  {
+    "qubits": 1,
+    "cols": "bad"
+  }
+  ```

--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -94,36 +94,14 @@ function bundlerEnv(extraEnv = {}) {
 }
 
 function runQniCommand(scenarioDir, command, extraEnv = {}) {
-  const argv = splitCommand(command);
-
-  if (argv[0] !== 'qni') {
-    throw new Error(`command must start with qni: ${command}`);
-  }
-
-  return new Promise((resolve, reject) => {
-    const child = spawn('node', [NODE_QNI_BIN, ...argv.slice(1)], {
-      cwd: scenarioDir,
-      env: bundlerEnv(extraEnv)
-    });
-
-    const stdout = [];
-    const stderr = [];
-
-    child.stdout.on('data', (chunk) => stdout.push(chunk));
-    child.stderr.on('data', (chunk) => stderr.push(chunk));
-    child.on('error', reject);
-    child.on('close', (code, signal) => {
-      resolve({
-        code,
-        signal,
-        stdout: Buffer.concat(stdout).toString('utf8'),
-        stderr: Buffer.concat(stderr).toString('utf8')
-      });
-    });
-  });
+  return runNodeQniCommand(scenarioDir, command, extraEnv);
 }
 
 function runNodeDispatcherCommand(scenarioDir, command, extraEnv = {}) {
+  return runNodeQniCommand(scenarioDir, command, extraEnv);
+}
+
+function runNodeQniCommand(scenarioDir, command, extraEnv = {}) {
   const argv = splitCommand(command);
 
   if (argv[0] !== 'qni') {

--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -101,7 +101,7 @@ function runQniCommand(scenarioDir, command, extraEnv = {}) {
   }
 
   return new Promise((resolve, reject) => {
-    const child = spawn('bundle', ['exec', QNI_BIN, ...argv.slice(1)], {
+    const child = spawn('node', [NODE_QNI_BIN, ...argv.slice(1)], {
       cwd: scenarioDir,
       env: bundlerEnv(extraEnv)
     });

--- a/src/angle_expression.ts
+++ b/src/angle_expression.ts
@@ -1,0 +1,132 @@
+export class AngleExpressionError extends Error {}
+
+const IDENTIFIER_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/u;
+const NUMERIC_PATTERN = /^[+-]?\d+(?:\.\d+)?$/u;
+const MULTIPLIED_PATTERN = /^(?<coefficient>[+-]?\d+(?:\.\d+)?)\*(?<term>.+)$/u;
+const PI_PATTERN =
+  /^(?<sign>[+-]?)(?:(?<coefficient>\d+(?:\.\d+)?)(?:\*)?)?(?:π|pi)(?:(?:\/|_)(?<denominator>\d+(?:\.\d+)?))?$/u;
+const SIGNED_IDENTIFIER_PATTERN = /^(?<sign>[+-])(?<identifier>[a-zA-Z_][a-zA-Z0-9_]*)$/u;
+
+export function validAngleIdentifier(value: string): boolean {
+  return IDENTIFIER_PATTERN.test(value);
+}
+
+interface AngleTerm {
+  readonly concrete: boolean;
+  readonly text: string;
+}
+
+export class AngleExpression {
+  private readonly rawValue: unknown;
+
+  constructor(rawValue: unknown) {
+    this.rawValue = rawValue;
+  }
+
+  concrete(): boolean {
+    return this.parse().concrete;
+  }
+
+  toString(): string {
+    return this.parse().text;
+  }
+
+  private normalized(): string {
+    const value = String(this.rawValue)
+      .replaceAll(' ', '')
+      .replaceAll('θ', 'theta')
+      .replace(/(?<=\d)theta/gu, '*theta');
+
+    if (value.length === 0) {
+      throw new AngleExpressionError('angle is required');
+    }
+
+    return value;
+  }
+
+  parse(): AngleTerm {
+    const value = this.normalized();
+    const term = parseAngleTerm(value);
+
+    if (!term) {
+      throw new AngleExpressionError(`invalid angle: ${value}`);
+    }
+
+    return term;
+  }
+}
+
+function parseAngleTerm(value: string): AngleTerm | undefined {
+  return (
+    parseNumericLiteral(value) ??
+    parseSignedIdentifier(value) ??
+    parseVariableReference(value) ??
+    parsePiTerm(value) ??
+    parseProduct(value)
+  );
+}
+
+function parseNumericLiteral(value: string): AngleTerm | undefined {
+  if (!NUMERIC_PATTERN.test(value)) {
+    return undefined;
+  }
+
+  return { concrete: true, text: value };
+}
+
+function parseSignedIdentifier(value: string): AngleTerm | undefined {
+  const match = SIGNED_IDENTIFIER_PATTERN.exec(value);
+
+  if (!match?.groups) {
+    return undefined;
+  }
+
+  const identifier = match.groups.identifier ?? '';
+  return {
+    concrete: false,
+    text: match.groups.sign === '-' ? `-${identifier}` : identifier
+  };
+}
+
+function parseVariableReference(value: string): AngleTerm | undefined {
+  if (!IDENTIFIER_PATTERN.test(value)) {
+    return undefined;
+  }
+
+  return { concrete: false, text: value };
+}
+
+function parsePiTerm(value: string): AngleTerm | undefined {
+  const match = PI_PATTERN.exec(value);
+
+  if (!match?.groups) {
+    return undefined;
+  }
+
+  const sign = match.groups.sign === '-' ? '-' : '';
+  const coefficient = match.groups.coefficient ?? '1';
+  const coefficientPrefix = coefficient === '1' ? '' : coefficient;
+  const denominator = match.groups.denominator ?? '1';
+  const denominatorSuffix = denominator === '1' ? '' : `/${denominator}`;
+
+  return {
+    concrete: true,
+    text: `${sign}${coefficientPrefix}π${denominatorSuffix}`
+  };
+}
+
+function parseProduct(value: string): AngleTerm | undefined {
+  const match = MULTIPLIED_PATTERN.exec(value);
+
+  if (!match?.groups) {
+    return undefined;
+  }
+
+  const coefficient = match.groups.coefficient ?? '';
+  const inner = new AngleExpression(match.groups.term).parse();
+
+  return {
+    concrete: inner.concrete,
+    text: `${coefficient}*${inner.text}`
+  };
+}

--- a/src/circuit_file.ts
+++ b/src/circuit_file.ts
@@ -142,7 +142,7 @@ function serializedCircuit(circuit: CircuitData): Record<string, unknown> {
     cols: circuit.cols
   };
 
-  if (circuit.initial_state) {
+  if (circuit.initial_state != null) {
     result.initial_state = circuit.initial_state;
   }
 

--- a/src/circuit_file.ts
+++ b/src/circuit_file.ts
@@ -6,9 +6,9 @@ import { AngleExpression, AngleExpressionError, validAngleIdentifier } from './a
 export class CircuitFileError extends Error {}
 
 interface CircuitData {
-  cols: unknown;
+  cols: unknown[][];
   initial_state?: unknown;
-  qubits: unknown;
+  qubits: number;
   variables?: Record<string, string>;
 }
 
@@ -115,12 +115,34 @@ function normalizeCircuit(value: unknown): CircuitData {
     throw new CircuitFileError('circuit must be an object');
   }
 
+  const qubits = normalizeQubits(value.qubits);
+
   return {
-    cols: value.cols,
+    cols: normalizeCols(value.cols, qubits),
     initial_state: value.initial_state,
-    qubits: value.qubits,
+    qubits,
     variables: normalizeVariables(value.variables ?? {})
   };
+}
+
+function normalizeQubits(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
+    throw new CircuitFileError('qubits must be a positive integer');
+  }
+
+  return value;
+}
+
+function normalizeCols(value: unknown, qubits: number): unknown[][] {
+  if (!Array.isArray(value)) {
+    throw new CircuitFileError('cols must be an array');
+  }
+
+  if (!value.every((col) => Array.isArray(col) && col.length === qubits)) {
+    throw new CircuitFileError('each column in cols must have exactly qubits entries');
+  }
+
+  return value.map((col) => [...col]);
 }
 
 function normalizeVariables(value: unknown): Record<string, string> {

--- a/src/circuit_file.ts
+++ b/src/circuit_file.ts
@@ -1,0 +1,198 @@
+import { readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { AngleExpression, AngleExpressionError, validAngleIdentifier } from './angle_expression';
+
+export class CircuitFileError extends Error {}
+
+interface CircuitData {
+  cols: unknown;
+  initial_state?: unknown;
+  qubits: unknown;
+  variables?: Record<string, string>;
+}
+
+export class CircuitFile {
+  private readonly filePath: string;
+
+  constructor(filePath: string) {
+    this.filePath = filePath;
+  }
+
+  clearVariables(): boolean {
+    const circuit = this.existingCircuit();
+
+    if (circuit) {
+      circuit.variables = {};
+      this.write(circuit);
+      return true;
+    }
+
+    return false;
+  }
+
+  setVariable(name: string, value: unknown): boolean {
+    const circuit = this.requiredCircuit();
+    const variables = circuit.variables ?? {};
+    circuit.variables = {
+      ...variables,
+      [validateVariableName(name)]: canonicalVariableValue(value)
+    };
+    this.write(circuit);
+    return true;
+  }
+
+  unsetVariable(name: string): boolean {
+    const circuit = this.existingCircuit();
+
+    if (circuit) {
+      const variables = circuit.variables ?? {};
+      delete variables[validateVariableName(name)];
+      circuit.variables = variables;
+      this.write(circuit);
+      return true;
+    }
+
+    return false;
+  }
+
+  variables(): Record<string, string> {
+    return this.existingCircuit()?.variables ?? {};
+  }
+
+  private existingCircuit(): CircuitData | undefined {
+    try {
+      return this.loadExistingCircuit();
+    } catch (error) {
+      throw domainError(error);
+    }
+  }
+
+  private requiredCircuit(): CircuitData {
+    const circuit = this.existingCircuit();
+
+    if (!circuit) {
+      throw new CircuitFileError('circuit.json does not exist');
+    }
+
+    return circuit;
+  }
+
+  private loadExistingCircuit(): CircuitData | undefined {
+    let raw: string;
+
+    try {
+      raw = readFileSync(this.filePath, 'utf8');
+    } catch (error) {
+      if (isNodeError(error) && error.code === 'ENOENT') {
+        return undefined;
+      }
+
+      throw error;
+    }
+
+    return normalizeCircuit(JSON.parse(raw));
+  }
+
+  private write(circuit: CircuitData): void {
+    const tempPath = `${this.filePath}.tmp`;
+
+    try {
+      writeFileSync(tempPath, `${JSON.stringify(serializedCircuit(circuit), null, 2)}\n`);
+      renameSync(tempPath, this.filePath);
+    } finally {
+      rmSync(tempPath, { force: true });
+    }
+  }
+}
+
+export function currentCircuitFile(cwd: string): CircuitFile {
+  return new CircuitFile(path.resolve(cwd, 'circuit.json'));
+}
+
+function normalizeCircuit(value: unknown): CircuitData {
+  if (!isRecord(value)) {
+    throw new CircuitFileError('circuit must be an object');
+  }
+
+  return {
+    cols: value.cols,
+    initial_state: value.initial_state,
+    qubits: value.qubits,
+    variables: normalizeVariables(value.variables ?? {})
+  };
+}
+
+function normalizeVariables(value: unknown): Record<string, string> {
+  if (!isRecord(value)) {
+    throw new CircuitFileError('variables must be an object');
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([name, variableValue]) => [
+      validateVariableName(name),
+      canonicalVariableValue(variableValue)
+    ])
+  );
+}
+
+function serializedCircuit(circuit: CircuitData): Record<string, unknown> {
+  const result: Record<string, unknown> = {
+    qubits: circuit.qubits,
+    cols: circuit.cols
+  };
+
+  if (circuit.initial_state) {
+    result.initial_state = circuit.initial_state;
+  }
+
+  if (circuit.variables && Object.keys(circuit.variables).length > 0) {
+    result.variables = circuit.variables;
+  }
+
+  return result;
+}
+
+function validateVariableName(name: string): string {
+  if (name.length === 0) {
+    throw new CircuitFileError('variable name is required');
+  }
+
+  if (!validAngleIdentifier(name)) {
+    throw new CircuitFileError(`invalid variable name: ${name}`);
+  }
+
+  return name;
+}
+
+function canonicalVariableValue(value: unknown): string {
+  try {
+    const angle = new AngleExpression(value);
+
+    if (!angle.concrete()) {
+      throw new CircuitFileError(`variable value must be concrete: ${value}`);
+    }
+
+    return angle.toString();
+  } catch (error) {
+    if (error instanceof AngleExpressionError) {
+      throw new CircuitFileError(error.message);
+    }
+
+    throw error;
+  }
+}
+
+function domainError(error: unknown): CircuitFileError {
+  return error instanceof CircuitFileError
+    ? error
+    : new CircuitFileError(error instanceof Error ? error.message : String(error));
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/commands/variable_command.ts
+++ b/src/commands/variable_command.ts
@@ -1,0 +1,104 @@
+import { CircuitFileError, currentCircuitFile } from '../circuit_file';
+import type { CommandHandlerContext } from '../dispatcher';
+
+const HELP_TEXT = `Usage:
+  qni variable set NAME ANGLE
+  qni variable list
+  qni variable unset NAME
+  qni variable clear
+
+Overview:
+  Manage symbolic angle variables in ./circuit.json.
+  NAME must be an ASCII identifier such as theta.
+  ANGLE must be concrete, such as π/4, pi/3, or 0.5.
+  qni variable set requires ./circuit.json to already exist.
+  qni add Ry --angle theta --qubit 0 --step 0 stores Ry(theta).
+  qni run and qni expect resolve symbolic angles through these variables.
+
+Examples:
+  qni variable set theta π/4
+  qni variable list
+  qni variable unset theta
+  qni variable clear`;
+
+type VariableSubcommand = 'clear' | 'list' | 'set' | 'unset';
+
+const SUBCOMMANDS = new Set<VariableSubcommand>(['clear', 'list', 'set', 'unset']);
+
+export function runVariableCommand(argv: string[], context: CommandHandlerContext): number {
+  try {
+    const subcommand = argv[1];
+
+    if (!subcommand || subcommand === '--help' || subcommand === '-h') {
+      process.stdout.write(`${HELP_TEXT}\n`);
+      return 0;
+    }
+
+    if (!isVariableSubcommand(subcommand)) {
+      throw new CircuitFileError(`unsupported variable subcommand: ${subcommand}`);
+    }
+
+    const output = executeSubcommand(subcommand, argv.slice(2), context);
+
+    if (output.length > 0) {
+      process.stdout.write(`${output}\n`);
+    }
+
+    return 0;
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}
+
+function executeSubcommand(
+  subcommand: VariableSubcommand,
+  args: string[],
+  context: CommandHandlerContext
+): string {
+  const circuitFile = currentCircuitFile(context.cwd);
+
+  switch (subcommand) {
+    case 'clear':
+      return circuitFile.clearVariables() ? '0' : '';
+    case 'list':
+      return Object.entries(circuitFile.variables())
+        .sort(([leftName], [rightName]) => compareVariableNames(leftName, rightName))
+        .map(([name, value]) => `${name}=${value}`)
+        .join('\n');
+    case 'set':
+      circuitFile.setVariable(
+        requiredArgument(args[0], 'wrong number of arguments'),
+        requiredArgument(args[1], 'wrong number of arguments')
+      );
+      return '0';
+    case 'unset':
+      return circuitFile.unsetVariable(requiredArgument(args[0], 'wrong number of arguments'))
+        ? '0'
+        : '';
+  }
+}
+
+function compareVariableNames(leftName: string, rightName: string): number {
+  if (leftName < rightName) {
+    return -1;
+  }
+
+  if (leftName > rightName) {
+    return 1;
+  }
+
+  return 0;
+}
+
+function isVariableSubcommand(value: string): value is VariableSubcommand {
+  return SUBCOMMANDS.has(value as VariableSubcommand);
+}
+
+function requiredArgument(value: string | undefined, message: string): string {
+  if (value === undefined) {
+    throw new CircuitFileError(message);
+  }
+
+  return value;
+}

--- a/src/commands/variable_command.ts
+++ b/src/commands/variable_command.ts
@@ -60,19 +60,23 @@ function executeSubcommand(
 
   switch (subcommand) {
     case 'clear':
+      requireArgumentCount(args, 0);
       return circuitFile.clearVariables() ? '0' : '';
     case 'list':
+      requireArgumentCount(args, 0);
       return Object.entries(circuitFile.variables())
         .sort(([leftName], [rightName]) => compareVariableNames(leftName, rightName))
         .map(([name, value]) => `${name}=${value}`)
         .join('\n');
     case 'set':
+      requireArgumentCount(args, 2);
       circuitFile.setVariable(
         requiredArgument(args[0], 'wrong number of arguments'),
         requiredArgument(args[1], 'wrong number of arguments')
       );
       return '0';
     case 'unset':
+      requireArgumentCount(args, 1);
       return circuitFile.unsetVariable(requiredArgument(args[0], 'wrong number of arguments'))
         ? '0'
         : '';
@@ -101,4 +105,10 @@ function requiredArgument(value: string | undefined, message: string): string {
   }
 
   return value;
+}
+
+function requireArgumentCount(args: string[], expected: number): void {
+  if (args.length !== expected) {
+    throw new CircuitFileError('wrong number of arguments');
+  }
 }

--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -2,8 +2,15 @@ import {
   chooseCommandImplementation,
   runRubyFallbackSync
 } from './process/process_compatibility';
+import { runVariableCommand } from './commands/variable_command';
 
-export type CommandHandler = (argv: string[]) => number;
+export interface CommandHandlerContext {
+  readonly cwd: string;
+  readonly env: NodeJS.ProcessEnv;
+  readonly projectRoot: string;
+}
+
+export type CommandHandler = (argv: string[], context: CommandHandlerContext) => number;
 export type RouteTarget = 'ruby' | 'typescript';
 
 export interface DispatcherOptions {
@@ -17,7 +24,7 @@ interface CommandRoute {
   target: RouteTarget;
 }
 
-const TYPESCRIPT_ROUTES = new Map<string, CommandHandler>();
+const TYPESCRIPT_ROUTES = new Map<string, CommandHandler>([['variable', runVariableCommand]]);
 
 export function createDispatcher(options: DispatcherOptions): Dispatcher {
   return new Dispatcher(options);
@@ -38,7 +45,11 @@ export class Dispatcher {
     const route = this.routeFor(argv);
 
     if (route.target === 'typescript' && route.handler) {
-      return route.handler(argv);
+      return route.handler(argv, {
+        cwd: this.cwd,
+        env: this.env,
+        projectRoot: this.projectRoot
+      });
     }
 
     const result = runRubyFallbackSync({

--- a/test/typescript/variable_command.test.ts
+++ b/test/typescript/variable_command.test.ts
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import { createDispatcher } from '../../src/dispatcher';
+
+interface CapturedRun {
+  readonly exitStatus: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}
+
+async function withTempDir<T>(callback: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'qni-cli-variable-'));
+
+  try {
+    return await callback(dir);
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+}
+
+function captureDispatcherRun(cwd: string, argv: string[]): CapturedRun {
+  let stdout = '';
+  let stderr = '';
+  const originalStdoutWrite = process.stdout.write;
+  const originalStderrWrite = process.stderr.write;
+
+  process.stdout.write = ((chunk: string | Uint8Array, encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void), callback?: (error?: Error | null) => void): boolean => {
+    stdout += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk.toString();
+    if (typeof encodingOrCallback === 'function') {
+      encodingOrCallback();
+    }
+    if (callback) {
+      callback();
+    }
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = ((chunk: string | Uint8Array, encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void), callback?: (error?: Error | null) => void): boolean => {
+    stderr += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk.toString();
+    if (typeof encodingOrCallback === 'function') {
+      encodingOrCallback();
+    }
+    if (callback) {
+      callback();
+    }
+    return true;
+  }) as typeof process.stderr.write;
+
+  try {
+    const dispatcher = createDispatcher({
+      cwd,
+      env: { PATH: '' },
+      projectRoot: process.cwd()
+    });
+
+    return {
+      exitStatus: dispatcher.run(argv),
+      stderr,
+      stdout
+    };
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+}
+
+describe('variable command TypeScript route', () => {
+  it('lists variables without invoking Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      await writeFile(
+        path.join(dir, 'circuit.json'),
+        [
+          '{',
+          '  "qubits": 1,',
+          '  "cols": [',
+          '    ["Ry(theta)"]',
+          '  ],',
+          '  "variables": {',
+          '    "theta": "π/4"',
+          '  }',
+          '}',
+          ''
+        ].join('\n')
+      );
+
+      const result = captureDispatcherRun(dir, ['variable', 'list']);
+
+      assert.equal(result.exitStatus, 0);
+      assert.equal(result.stdout, 'theta=π/4\n');
+      assert.equal(result.stderr, '');
+    });
+  });
+
+  it('sets variables in circuit.json without invoking Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      await writeFile(
+        path.join(dir, 'circuit.json'),
+        [
+          '{',
+          '  "qubits": 1,',
+          '  "cols": [',
+          '    ["Ry(theta)"]',
+          '  ]',
+          '}',
+          ''
+        ].join('\n')
+      );
+
+      const result = captureDispatcherRun(dir, ['variable', 'set', 'theta', 'π/4']);
+
+      assert.equal(result.exitStatus, 0);
+      assert.equal(result.stdout, '0\n');
+      assert.equal(result.stderr, '');
+      assert.deepEqual(JSON.parse(await readFile(path.join(dir, 'circuit.json'), 'utf8')), {
+        qubits: 1,
+        cols: [['Ry(theta)']],
+        variables: {
+          theta: 'π/4'
+        }
+      });
+    });
+  });
+});

--- a/test/typescript/variable_command.test.ts
+++ b/test/typescript/variable_command.test.ts
@@ -124,4 +124,50 @@ describe('variable command TypeScript route', () => {
       });
     });
   });
+
+  it('rejects extra arguments before mutating circuit.json', async () => {
+    await withTempDir(async (dir) => {
+      const circuitPath = path.join(dir, 'circuit.json');
+      const originalCircuit = {
+        qubits: 1,
+        cols: [['Ry(theta)']],
+        variables: {
+          theta: 'π/4'
+        }
+      };
+      await writeFile(circuitPath, `${JSON.stringify(originalCircuit, null, 2)}\n`);
+
+      for (const argv of [
+        ['variable', 'clear', 'extra'],
+        ['variable', 'list', 'extra'],
+        ['variable', 'set', 'theta', 'π/4', 'extra'],
+        ['variable', 'unset', 'theta', 'extra']
+      ]) {
+        const result = captureDispatcherRun(dir, argv);
+
+        assert.equal(result.exitStatus, 1, argv.join(' '));
+        assert.equal(result.stdout, '');
+        assert.equal(result.stderr, 'wrong number of arguments\n');
+        assert.deepEqual(JSON.parse(await readFile(circuitPath, 'utf8')), originalCircuit);
+      }
+    });
+  });
+
+  it('rejects malformed cols before mutating circuit.json', async () => {
+    await withTempDir(async (dir) => {
+      const circuitPath = path.join(dir, 'circuit.json');
+      const originalCircuit = {
+        qubits: 1,
+        cols: 'bad'
+      };
+      await writeFile(circuitPath, `${JSON.stringify(originalCircuit)}\n`);
+
+      const result = captureDispatcherRun(dir, ['variable', 'set', 'theta', 'π/4']);
+
+      assert.equal(result.exitStatus, 1);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, 'cols must be an array\n');
+      assert.deepEqual(JSON.parse(await readFile(circuitPath, 'utf8')), originalCircuit);
+    });
+  });
 });


### PR DESCRIPTION
## 概要

- `qni variable set/list/unset/clear` を TypeScript dispatcher の route に接続しました。
- TypeScript 側に angle expression 正規化と `circuit.json` の variables 読み書きを追加しました。
- 既存 `features/cli/variable/*.feature.md` を Node dispatcher 経由で実行し、TypeScript path の compatibility gate にしました。
- PR review を受けて、余分な引数では実行前に失敗し、malformed `cols` の `circuit.json` を書き換えない regression を追加しました。
- `QNI_USE_RUBY=1` では引き続き Ruby fallback に戻ります。

## Linear

- YAS-216

## 検証

- `npm run test:ts`
- `npm run build && npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress "features/cli/variable/**/*.feature.md"`
- Ruby oracle comparison:
  - 既存代表 case: `set_success`, `list_success`, `unset_success`, `clear_success`, `set_missing_circuit`
  - 追加 review case: malformed `cols` は status / stdout / stderr / `circuit.json` が一致
  - 追加 review case: extra args は Ruby 側が uncaught `ArgumentError` stack trace を stderr に出すため stderr は異なるが、status / stdout / `circuit.json` 非変更は一致
- `bundle exec rake check`
