### PR TITLE
state show と state clear を TypeScript に移行する

### DIFF
--- a/features/cli/state/clear.feature.md
+++ b/features/cli/state/clear.feature.md
@@ -26,3 +26,21 @@ qni state clear を使いたい
     ]
   }
   ```
+
+## Scenario: QNI_USE_RUBY=1 の qni state clear は initial_state を circuit.json から削除する
+
+- Given 環境変数 "QNI_USE_RUBY" を "1" に設定する
+- Given "qni state set \"alpha|0> + beta|1>\"" を実行
+- When "qni state clear" を実行
+- Then "circuit.json" の内容:
+
+  ```text
+  {
+    "qubits": 1,
+    "cols": [
+      [
+        1
+      ]
+    ]
+  }
+  ```

--- a/features/cli/state/show.feature.md
+++ b/features/cli/state/show.feature.md
@@ -19,3 +19,14 @@ qni state show を使いたい
   ```text
   alpha|0> + beta|1>
   ```
+
+## Scenario: QNI_USE_RUBY=1 の qni state show は現在の初期状態を表示する
+
+- Given 環境変数 "QNI_USE_RUBY" を "1" に設定する
+- Given "qni state set \"alpha|0> + beta|1>\"" を実行
+- When "qni state show" を実行
+- Then 標準出力:
+
+  ```text
+  alpha|0> + beta|1>
+  ```

--- a/src/circuit_file.ts
+++ b/src/circuit_file.ts
@@ -2,6 +2,7 @@ import { readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 import { AngleExpression, AngleExpressionError, validAngleIdentifier } from './angle_expression';
+import { formatInitialState, zeroInitialStateText } from './initial_state';
 
 export class CircuitFileError extends Error {}
 
@@ -29,6 +30,29 @@ export class CircuitFile {
     }
 
     return false;
+  }
+
+  clearInitialState(): boolean {
+    const circuit = this.existingCircuit();
+
+    if (circuit) {
+      validateInitialState(circuit);
+      delete circuit.initial_state;
+      this.write(circuit);
+      return true;
+    }
+
+    return false;
+  }
+
+  initialStateText(): string {
+    const circuit = this.existingCircuit();
+
+    if (!circuit || circuit.initial_state == null) {
+      return zeroInitialStateText();
+    }
+
+    return formatInitialState(circuit.initial_state);
   }
 
   setVariable(name: string, value: unknown): boolean {
@@ -103,6 +127,12 @@ export class CircuitFile {
     } finally {
       rmSync(tempPath, { force: true });
     }
+  }
+}
+
+function validateInitialState(circuit: CircuitData): void {
+  if (circuit.initial_state != null) {
+    formatInitialState(circuit.initial_state);
   }
 }
 

--- a/src/commands/state_command.ts
+++ b/src/commands/state_command.ts
@@ -1,0 +1,85 @@
+import { CircuitFileError, currentCircuitFile } from '../circuit_file';
+import type { CommandHandlerContext } from '../dispatcher';
+import { runRubyFallbackSync } from '../process/process_compatibility';
+
+const HELP_TEXT = `Usage:
+  qni state set "alpha|0> + beta|1>"
+  qni state show
+  qni state clear
+
+Overview:
+  Manage the initial state vector in ./circuit.json.
+  The first release supports 1-qubit ket sums such as alpha|0> + beta|1>.
+  Coefficients can be numeric literals or ASCII identifiers such as alpha.
+  qni state clear removes the explicit initial state and falls back to |0>.
+
+Examples:
+  qni state set "alpha|0> + beta|1>"
+  qni state show
+  qni state clear`;
+
+type StateSubcommand = 'clear' | 'set' | 'show';
+type TypeScriptStateSubcommand = Exclude<StateSubcommand, 'set'>;
+
+const TYPESCRIPT_SUBCOMMANDS = new Set<TypeScriptStateSubcommand>(['clear', 'show']);
+
+export function runStateCommand(argv: string[], context: CommandHandlerContext): number {
+  const subcommand = argv[1];
+
+  if (!subcommand || subcommand === '--help' || subcommand === '-h') {
+    process.stdout.write(`${HELP_TEXT}\n`);
+    return 0;
+  }
+
+  if (subcommand === 'set') {
+    return runRubyFallbackSync({
+      argv,
+      cwd: context.cwd,
+      env: context.env,
+      projectRoot: context.projectRoot
+    }).exitStatus ?? 1;
+  }
+
+  try {
+    if (!isTypeScriptStateSubcommand(subcommand)) {
+      throw new CircuitFileError(`unsupported state subcommand: ${subcommand}`);
+    }
+
+    const output = executeSubcommand(subcommand, argv.slice(2), context);
+
+    if (output.length > 0) {
+      process.stdout.write(`${output}\n`);
+    }
+
+    return 0;
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}
+
+function executeSubcommand(
+  subcommand: TypeScriptStateSubcommand,
+  args: string[],
+  context: CommandHandlerContext
+): string {
+  requireArgumentCount(args, 0);
+  const circuitFile = currentCircuitFile(context.cwd);
+
+  switch (subcommand) {
+    case 'clear':
+      return circuitFile.clearInitialState() ? '0' : '';
+    case 'show':
+      return circuitFile.initialStateText();
+  }
+}
+
+function isTypeScriptStateSubcommand(value: string): value is TypeScriptStateSubcommand {
+  return TYPESCRIPT_SUBCOMMANDS.has(value as TypeScriptStateSubcommand);
+}
+
+function requireArgumentCount(args: string[], expected: number): void {
+  if (args.length !== expected) {
+    throw new CircuitFileError('wrong number of arguments');
+  }
+}

--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -2,6 +2,7 @@ import {
   chooseCommandImplementation,
   runRubyFallbackSync
 } from './process/process_compatibility';
+import { runStateCommand } from './commands/state_command';
 import { runVariableCommand } from './commands/variable_command';
 
 export interface CommandHandlerContext {
@@ -24,7 +25,10 @@ interface CommandRoute {
   target: RouteTarget;
 }
 
-const TYPESCRIPT_ROUTES = new Map<string, CommandHandler>([['variable', runVariableCommand]]);
+const TYPESCRIPT_ROUTES = new Map<string, CommandHandler>([
+  ['state', runStateCommand],
+  ['variable', runVariableCommand]
+]);
 
 export function createDispatcher(options: DispatcherOptions): Dispatcher {
   return new Dispatcher(options);

--- a/src/initial_state.ts
+++ b/src/initial_state.ts
@@ -1,0 +1,164 @@
+export class InitialStateError extends Error {}
+
+const FORMAT = 'ket_sum_v1';
+const SQRT_HALF_TEXT = Math.sqrt(0.5).toString();
+const COMPUTATIONAL_BASIS_PATTERN = /^[01]+$/u;
+const IDENTIFIER_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/u;
+const SIGNED_IDENTIFIER_PATTERN = /^[+-][a-zA-Z_][a-zA-Z0-9_]*$/u;
+const NUMERIC_PATTERN = /^[+-]?\d+(?:\.\d+)?$/u;
+const IMAGINARY_NUMERIC_PATTERN = /^[+-]?\d+(?:\.\d+)?i$/u;
+const BELL_BASES = new Set(['Φ+', 'Φ-', 'Ψ+', 'Ψ-']);
+
+interface InitialStateTerm {
+  readonly basis: string;
+  readonly coefficient: string;
+}
+
+export function zeroInitialStateText(): string {
+  return '1|0>';
+}
+
+export function formatInitialState(value: unknown): string {
+  return formatTerms(loadTerms(value));
+}
+
+function loadTerms(value: unknown): InitialStateTerm[] {
+  if (!isRecord(value)) {
+    throw new InitialStateError('initial state must be an object');
+  }
+
+  if (value.format !== FORMAT) {
+    throw new InitialStateError(`unsupported initial state format: ${String(value.format)}`);
+  }
+
+  if (!Array.isArray(value.terms) || value.terms.length === 0) {
+    throw new InitialStateError('initial state must have at least one term');
+  }
+
+  return normalizedTerms(value.terms.map(loadTerm));
+}
+
+function loadTerm(value: unknown): InitialStateTerm {
+  if (!isRecord(value)) {
+    throw new InitialStateError('initial state term must be an object');
+  }
+
+  return {
+    basis: validatedBasis(value.basis),
+    coefficient: validatedCoefficient(value.coefficient)
+  };
+}
+
+function normalizedTerms(terms: InitialStateTerm[]): InitialStateTerm[] {
+  validateUniqueBasis(terms);
+  validateBasisDimensions(terms);
+
+  return [...terms].sort((left, right) => compareText(left.basis, right.basis));
+}
+
+function validateUniqueBasis(terms: InitialStateTerm[]): void {
+  const seen = new Set<string>();
+
+  for (const term of terms) {
+    if (seen.has(term.basis)) {
+      throw new InitialStateError(`duplicate basis state: ${term.basis}`);
+    }
+
+    seen.add(term.basis);
+  }
+}
+
+function validateBasisDimensions(terms: InitialStateTerm[]): void {
+  const dimensions = new Set(terms.map((term) => qubitCount(term.basis)));
+
+  if (dimensions.size > 1) {
+    throw new InitialStateError('mixed basis dimensions are not supported');
+  }
+}
+
+function validatedBasis(value: unknown): string {
+  const basis = String(value);
+
+  if (qubitCount(basis) > 0) {
+    return basis;
+  }
+
+  throw new InitialStateError(`unsupported basis state: ${basis}`);
+}
+
+function qubitCount(basis: string): number {
+  if (COMPUTATIONAL_BASIS_PATTERN.test(basis)) {
+    return basis.length;
+  }
+
+  return BELL_BASES.has(basis) ? 2 : 0;
+}
+
+function validatedCoefficient(value: unknown): string {
+  const coefficient = String(value).trim();
+
+  if (supportedCoefficient(coefficient)) {
+    return coefficient;
+  }
+
+  throw new InitialStateError(`invalid initial state coefficient: ${coefficient}`);
+}
+
+function supportedCoefficient(coefficient: string): boolean {
+  return [
+    IDENTIFIER_PATTERN,
+    SIGNED_IDENTIFIER_PATTERN,
+    NUMERIC_PATTERN,
+    IMAGINARY_NUMERIC_PATTERN
+  ].some((pattern) => pattern.test(coefficient));
+}
+
+function formatTerms(terms: InitialStateTerm[]): string {
+  return oneQubitSpecialLabel(terms) ?? bellBasisLabel(terms) ?? ketSum(terms);
+}
+
+function oneQubitSpecialLabel(terms: InitialStateTerm[]): string | undefined {
+  if (terms.length !== 2 || terms[0]?.basis !== '0' || terms[1]?.basis !== '1') {
+    return undefined;
+  }
+
+  const coefficients = terms.map((term) => term.coefficient).join(',');
+  const labels = new Map<string, string>([
+    [`${SQRT_HALF_TEXT},${SQRT_HALF_TEXT}`, '|+>'],
+    [`${SQRT_HALF_TEXT},-${SQRT_HALF_TEXT}`, '|->'],
+    [`${SQRT_HALF_TEXT},${SQRT_HALF_TEXT}i`, '|+i>'],
+    [`${SQRT_HALF_TEXT},-${SQRT_HALF_TEXT}i`, '|-i>']
+  ]);
+
+  return labels.get(coefficients);
+}
+
+function bellBasisLabel(terms: InitialStateTerm[]): string | undefined {
+  const term = terms[0];
+
+  if (terms.length === 1 && term?.coefficient === '1' && BELL_BASES.has(term.basis)) {
+    return `|${term.basis}>`;
+  }
+
+  return undefined;
+}
+
+function ketSum(terms: InitialStateTerm[]): string {
+  return terms.map((term) => `${term.coefficient}|${term.basis}>`).join(' + ').replaceAll('+ -', '- ');
+}
+
+function compareText(left: string, right: string): number {
+  if (left < right) {
+    return -1;
+  }
+
+  if (left > right) {
+    return 1;
+  }
+
+  return 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/test/typescript/state_command.test.ts
+++ b/test/typescript/state_command.test.ts
@@ -1,0 +1,164 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import { createDispatcher } from '../../src/dispatcher';
+
+interface CapturedRun {
+  readonly exitStatus: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}
+
+async function withTempDir<T>(callback: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'qni-cli-state-'));
+
+  try {
+    return await callback(dir);
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+}
+
+function captureDispatcherRun(
+  cwd: string,
+  argv: string[],
+  env: NodeJS.ProcessEnv = { PATH: '' }
+): CapturedRun {
+  let stdout = '';
+  let stderr = '';
+  const originalStdoutWrite = process.stdout.write;
+  const originalStderrWrite = process.stderr.write;
+
+  process.stdout.write = ((chunk: string | Uint8Array, encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void), callback?: (error?: Error | null) => void): boolean => {
+    stdout += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk.toString();
+    if (typeof encodingOrCallback === 'function') {
+      encodingOrCallback();
+    }
+    if (callback) {
+      callback();
+    }
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = ((chunk: string | Uint8Array, encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void), callback?: (error?: Error | null) => void): boolean => {
+    stderr += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk.toString();
+    if (typeof encodingOrCallback === 'function') {
+      encodingOrCallback();
+    }
+    if (callback) {
+      callback();
+    }
+    return true;
+  }) as typeof process.stderr.write;
+
+  try {
+    const dispatcher = createDispatcher({
+      cwd,
+      env,
+      projectRoot: process.cwd()
+    });
+
+    return {
+      exitStatus: dispatcher.run(argv),
+      stderr,
+      stdout
+    };
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+}
+
+describe('state command TypeScript route', () => {
+  it('shows a stored initial state without invoking Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      await writeFile(
+        path.join(dir, 'circuit.json'),
+        `${JSON.stringify(
+          {
+            qubits: 1,
+            cols: [[1]],
+            initial_state: {
+              format: 'ket_sum_v1',
+              terms: [
+                { basis: '0', coefficient: 'alpha' },
+                { basis: '1', coefficient: 'beta' }
+              ]
+            }
+          },
+          null,
+          2
+        )}\n`
+      );
+
+      const result = captureDispatcherRun(dir, ['state', 'show']);
+
+      assert.equal(result.exitStatus, 0);
+      assert.equal(result.stdout, 'alpha|0> + beta|1>\n');
+      assert.equal(result.stderr, '');
+    });
+  });
+
+  it('clears only the stored initial state without invoking Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      const circuitPath = path.join(dir, 'circuit.json');
+      await writeFile(
+        circuitPath,
+        `${JSON.stringify(
+          {
+            qubits: 1,
+            cols: [['Ry(theta)']],
+            initial_state: {
+              format: 'ket_sum_v1',
+              terms: [
+                { basis: '0', coefficient: 'alpha' },
+                { basis: '1', coefficient: 'beta' }
+              ]
+            },
+            variables: {
+              theta: 'π/4'
+            }
+          },
+          null,
+          2
+        )}\n`
+      );
+
+      const result = captureDispatcherRun(dir, ['state', 'clear']);
+
+      assert.equal(result.exitStatus, 0);
+      assert.equal(result.stdout, '0\n');
+      assert.equal(result.stderr, '');
+      assert.deepEqual(JSON.parse(await readFile(circuitPath, 'utf8')), {
+        qubits: 1,
+        cols: [['Ry(theta)']],
+        variables: {
+          theta: 'π/4'
+        }
+      });
+    });
+  });
+
+  it('keeps state set on the Ruby fallback route', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, ['state', 'set', '1|0>']);
+
+      assert.equal(result.exitStatus, 127);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, 'spawnSync bundle ENOENT\n');
+    });
+  });
+
+  it('honors QNI_USE_RUBY for migrated state subcommands', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, ['state', 'show'], { PATH: '', QNI_USE_RUBY: '1' });
+
+      assert.equal(result.exitStatus, 127);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, 'spawnSync bundle ENOENT\n');
+    });
+  });
+});


### PR DESCRIPTION
## 概要

- `qni state show` と `qni state clear` を TypeScript route に移行しました。
- `ket_sum_v1` の最小 formatter/loader を TypeScript 側に追加しました。
- `qni state set` と `QNI_USE_RUBY=1` は Ruby fallback のまま維持しました。

## Linear

- YAS-217

## 検証

- `npm run test:ts`
- `npm run build && npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress features/cli/state/show.feature.md features/cli/state/clear.feature.md`
- Ruby oracle comparison: `show_default`, `show_stored`, `clear_stored`, `show_bad_format`
- `bundle exec rake check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 量子回路の初期状態を管理する新しい `qni state` コマンドを追加しました。`qni state show` で現在の初期状態を表示、`qni state clear` で初期状態を削除、`qni state set` で初期状態を設定できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->