### PR TITLE
rm を TypeScript 実装へ移行する

### DIFF
--- a/features/circuit/auto_shrink.feature.md
+++ b/features/circuit/auto_shrink.feature.md
@@ -48,3 +48,19 @@ gate remove 後の auto-shrink シナリオもここで扱う。
     ]
   }
   ```
+
+## Scenario: 空の末尾 step は自動的に削除される
+
+- Given "qni add H --qubit 0 --step 0" を実行
+- And "qni add X --qubit 1 --step 1" を実行
+- When "qni rm --qubit 1 --step 1" を実行
+- Then "circuit.json" の内容:
+
+  ```json
+  {
+    "qubits": 1,
+    "cols": [
+      ["H"]
+    ]
+  }
+  ```

--- a/features/cli/rm/rm_command.feature.md
+++ b/features/cli/rm/rm_command.feature.md
@@ -156,6 +156,22 @@ qni-cli のユーザとして、試行錯誤しながら回路を編集するた
   circuit.json does not exist
   ```
 
+## Scenario: QNI_USE_RUBY=1 の qni rm は Ruby fallback で gate を削除する
+
+- Given 環境変数 "QNI_USE_RUBY" を "1" に設定する
+- And "qni add H --qubit 0 --step 0" を実行
+- When "qni rm --qubit 0 --step 0" を実行
+- Then "circuit.json" の内容:
+
+  ```json
+  {
+    "qubits": 1,
+    "cols": [
+      [1]
+    ]
+  }
+  ```
+
 ## Scenario: qni rm --help は rm コマンドの使い方を表示
 
 - When "qni rm --help" を実行

--- a/src/circuit_file.ts
+++ b/src/circuit_file.ts
@@ -2,9 +2,13 @@ import { readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 import { AngleExpression, AngleExpressionError, validAngleIdentifier } from './angle_expression';
-import { formatInitialState, zeroInitialStateText } from './initial_state';
+import { formatInitialState, initialStateQubitCount, zeroInitialStateText } from './initial_state';
 
 export class CircuitFileError extends Error {}
+
+const CONTROL_SYMBOL = '•';
+const EMPTY_SLOT = 1;
+const SWAP_SYMBOL = 'Swap';
 
 interface CircuitData {
   cols: unknown[][];
@@ -64,6 +68,23 @@ export class CircuitFile {
     }
 
     return String(col[qubit]);
+  }
+
+  removeGate(step: number, qubit: number): void {
+    const circuit = this.requiredCircuit();
+    const col = existingSlot(circuit, step, qubit);
+    const selectedSlot = col[qubit];
+
+    if (selectedSlot === EMPTY_SLOT) {
+      throw new CircuitFileError(`slot is empty: cols[${step}][${qubit}]`);
+    }
+
+    for (const removableQubit of removableQubits(col, selectedSlot, step, qubit)) {
+      col[removableQubit] = EMPTY_SLOT;
+    }
+
+    normalizeAfterRemoval(circuit);
+    this.write(circuit);
   }
 
   setVariable(name: string, value: unknown): boolean {
@@ -139,6 +160,136 @@ export class CircuitFile {
       rmSync(tempPath, { force: true });
     }
   }
+}
+
+function existingSlot(circuit: CircuitData, step: number, qubit: number): unknown[] {
+  const col = circuit.cols[step];
+
+  if (!col || qubit < 0 || qubit >= col.length) {
+    throw new CircuitFileError(`slot does not exist: cols[${step}][${qubit}]`);
+  }
+
+  return col;
+}
+
+function removableQubits(
+  col: unknown[],
+  selectedSlot: unknown,
+  step: number,
+  qubit: number
+): number[] {
+  if (selectedSlot === SWAP_SYMBOL) {
+    return swapQubits(col, step);
+  }
+
+  if (controlledSlot(col, selectedSlot, qubit)) {
+    return controlledQubits(col, step);
+  }
+
+  return [qubit];
+}
+
+function controlledSlot(col: unknown[], selectedSlot: unknown, qubit: number): boolean {
+  return col.includes(CONTROL_SYMBOL) && (selectedSlot === CONTROL_SYMBOL || targetQubits(col).includes(qubit));
+}
+
+function controlledQubits(col: unknown[], step: number): number[] {
+  const targets = targetQubits(col);
+
+  if (targets.length !== 1) {
+    throw new CircuitFileError(`unsupported controlled step: cols[${step}] = ${JSON.stringify(col)}`);
+  }
+
+  return [...slotIndices(col, CONTROL_SYMBOL), ...targets];
+}
+
+function targetQubits(col: unknown[]): number[] {
+  return col
+    .map((slot, index) => ({ index, slot }))
+    .filter(({ slot }) => slot !== EMPTY_SLOT && slot !== CONTROL_SYMBOL)
+    .map(({ index }) => index);
+}
+
+function swapQubits(col: unknown[], step: number): number[] {
+  const indices = slotIndices(col, SWAP_SYMBOL);
+
+  if (indices.length !== 2) {
+    throw new CircuitFileError(`unsupported swap step: cols[${step}] = ${JSON.stringify(col)}`);
+  }
+
+  return indices;
+}
+
+function slotIndices(col: unknown[], symbol: string): number[] {
+  return col
+    .map((slot, index) => ({ index, slot }))
+    .filter(({ slot }) => slot === symbol)
+    .map(({ index }) => index);
+}
+
+function normalizeAfterRemoval(circuit: CircuitData): void {
+  trimLeadingEmptySteps(circuit);
+  trimLeadingEmptyQubits(circuit);
+  trimTrailingEmptyQubits(circuit);
+}
+
+function trimLeadingEmptySteps(circuit: CircuitData): void {
+  while (circuit.cols.length > 1 && emptyCol(circuit.cols[0])) {
+    circuit.cols.shift();
+  }
+}
+
+function trimLeadingEmptyQubits(circuit: CircuitData): void {
+  const count = leadingEmptyQubitCount(circuit);
+
+  if (count > 0) {
+    circuit.cols.forEach((col) => col.splice(0, count));
+    circuit.qubits -= count;
+  }
+}
+
+function trimTrailingEmptyQubits(circuit: CircuitData): void {
+  const count = trailingEmptyQubitCount(circuit);
+
+  if (count > 0) {
+    circuit.cols.forEach((col) => col.splice(circuit.qubits - count, count));
+    circuit.qubits -= count;
+  }
+}
+
+function leadingEmptyQubitCount(circuit: CircuitData): number {
+  let count = 0;
+
+  while (count < removableQubitsLimit(circuit) && circuit.cols.every((col) => col[count] === EMPTY_SLOT)) {
+    count += 1;
+  }
+
+  return count;
+}
+
+function trailingEmptyQubitCount(circuit: CircuitData): number {
+  let count = 0;
+
+  while (
+    count < removableQubitsLimit(circuit) &&
+    circuit.cols.every((col) => col[circuit.qubits - count - 1] === EMPTY_SLOT)
+  ) {
+    count += 1;
+  }
+
+  return count;
+}
+
+function removableQubitsLimit(circuit: CircuitData): number {
+  return circuit.qubits - minimumQubits(circuit);
+}
+
+function minimumQubits(circuit: CircuitData): number {
+  return circuit.initial_state == null ? 1 : initialStateQubitCount(circuit.initial_state);
+}
+
+function emptyCol(col: unknown[] | undefined): boolean {
+  return Boolean(col?.every((slot) => slot === EMPTY_SLOT));
 }
 
 function validateInitialState(circuit: CircuitData): void {

--- a/src/circuit_file.ts
+++ b/src/circuit_file.ts
@@ -231,6 +231,7 @@ function normalizeAfterRemoval(circuit: CircuitData): void {
   trimLeadingEmptySteps(circuit);
   trimLeadingEmptyQubits(circuit);
   trimTrailingEmptyQubits(circuit);
+  trimTrailingEmptySteps(circuit);
 }
 
 function trimLeadingEmptySteps(circuit: CircuitData): void {
@@ -254,6 +255,12 @@ function trimTrailingEmptyQubits(circuit: CircuitData): void {
   if (count > 0) {
     circuit.cols.forEach((col) => col.splice(circuit.qubits - count, count));
     circuit.qubits -= count;
+  }
+}
+
+function trimTrailingEmptySteps(circuit: CircuitData): void {
+  while (circuit.cols.length > 1 && emptyCol(circuit.cols[circuit.cols.length - 1])) {
+    circuit.cols.pop();
   }
 }
 

--- a/src/commands/remove_command.ts
+++ b/src/commands/remove_command.ts
@@ -1,0 +1,83 @@
+import { CircuitFileError, currentCircuitFile } from '../circuit_file';
+import type { CommandHandlerContext } from '../dispatcher';
+
+const HELP_TEXT = `Usage:
+  qni rm --qubit=N --step=N
+
+Overview:
+  Remove the gate operation at one slot from ./circuit.json.
+  step and qubit are 0-based indices.
+  Controlled gates are removed as one operation from either control or target.
+  SWAP is removed as one operation from either Swap slot.
+
+Options:
+  --step=N   # 0-based step index
+  --qubit=N  # 0-based qubit index
+
+Examples:
+  qni rm --qubit 0 --step 0`;
+
+interface RemoveOptions {
+  readonly qubit: number;
+  readonly step: number;
+}
+
+export function runRemoveCommand(argv: string[], context: CommandHandlerContext): number {
+  try {
+    if (argv.length === 1 || argv[1] === '--help' || argv[1] === '-h') {
+      process.stdout.write(`${HELP_TEXT}\n`);
+      return 0;
+    }
+
+    const options = parseRemoveOptions(argv.slice(1));
+    currentCircuitFile(context.cwd).removeGate(options.step, options.qubit);
+    return 0;
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}
+
+function parseRemoveOptions(args: string[]): RemoveOptions {
+  const values = new Map<string, string>();
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    const match = /^--(?<name>qubit|step)(?:=(?<value>.*))?$/u.exec(arg);
+
+    if (!match?.groups) {
+      throw new CircuitFileError(`unknown option: ${arg}`);
+    }
+
+    const value = match.groups.value ?? args[index + 1];
+
+    if (match.groups.value === undefined) {
+      index += 1;
+    }
+
+    values.set(match.groups.name, value ?? '');
+  }
+
+  return {
+    qubit: requiredNonNegativeInteger(values.get('qubit'), 'qubit'),
+    step: requiredNonNegativeInteger(values.get('step'), 'step')
+  };
+}
+
+function requiredNonNegativeInteger(value: string | undefined, name: string): number {
+  if (!value) {
+    throw new CircuitFileError(`${name} is required`);
+  }
+
+  if (!/^[+-]?\d+$/u.test(value)) {
+    throw new CircuitFileError(`${name} must be an integer`);
+  }
+
+  const parsedValue = Number.parseInt(value, 10);
+
+  if (parsedValue < 0) {
+    throw new CircuitFileError(`${name} must be >= 0`);
+  }
+
+  return parsedValue;
+}

--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -3,6 +3,7 @@ import {
   runRubyFallbackSync
 } from './process/process_compatibility';
 import { runGateCommand } from './commands/gate_command';
+import { runRemoveCommand } from './commands/remove_command';
 import { runStateCommand } from './commands/state_command';
 import { runVariableCommand } from './commands/variable_command';
 
@@ -28,6 +29,7 @@ interface CommandRoute {
 
 const TYPESCRIPT_ROUTES = new Map<string, CommandHandler>([
   ['gate', runGateCommand],
+  ['rm', runRemoveCommand],
   ['state', runStateCommand],
   ['variable', runVariableCommand]
 ]);

--- a/src/initial_state.ts
+++ b/src/initial_state.ts
@@ -22,6 +22,13 @@ export function formatInitialState(value: unknown): string {
   return formatTerms(loadTerms(value));
 }
 
+export function initialStateQubitCount(value: unknown): number {
+  const terms = loadTerms(value);
+  const basis = terms[0]?.basis;
+
+  return basis ? qubitCount(basis) : 1;
+}
+
 function loadTerms(value: unknown): InitialStateTerm[] {
   if (!isRecord(value)) {
     throw new InitialStateError('initial state must be an object');

--- a/test/typescript/remove_command.test.ts
+++ b/test/typescript/remove_command.test.ts
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import { createDispatcher } from '../../src/dispatcher';
+
+interface CapturedRun {
+  readonly exitStatus: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}
+
+async function withTempDir<T>(callback: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'qni-cli-rm-'));
+
+  try {
+    return await callback(dir);
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+}
+
+function captureDispatcherRun(
+  cwd: string,
+  argv: string[],
+  env: NodeJS.ProcessEnv = { PATH: '' }
+): CapturedRun {
+  let stdout = '';
+  let stderr = '';
+  const originalStdoutWrite = process.stdout.write;
+  const originalStderrWrite = process.stderr.write;
+
+  process.stdout.write = ((chunk: string | Uint8Array, encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void), callback?: (error?: Error | null) => void): boolean => {
+    stdout += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk.toString();
+    if (typeof encodingOrCallback === 'function') {
+      encodingOrCallback();
+    }
+    if (callback) {
+      callback();
+    }
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = ((chunk: string | Uint8Array, encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void), callback?: BufferEncoding | ((error?: Error | null) => void)): boolean => {
+    stderr += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk.toString();
+    if (typeof encodingOrCallback === 'function') {
+      encodingOrCallback();
+    }
+    if (typeof callback === 'function') {
+      callback();
+    }
+    return true;
+  }) as typeof process.stderr.write;
+
+  try {
+    const dispatcher = createDispatcher({
+      cwd,
+      env,
+      projectRoot: process.cwd()
+    });
+
+    return {
+      exitStatus: dispatcher.run(argv),
+      stderr,
+      stdout
+    };
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+}
+
+async function writeCircuit(dir: string, circuit: unknown): Promise<string> {
+  const circuitPath = path.join(dir, 'circuit.json');
+  await writeFile(circuitPath, `${JSON.stringify(circuit, null, 2)}\n`);
+
+  return circuitPath;
+}
+
+async function readCircuit(circuitPath: string): Promise<unknown> {
+  return JSON.parse(await readFile(circuitPath, 'utf8'));
+}
+
+describe('rm command TypeScript route', () => {
+  it('removes a single-qubit gate without invoking Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      const circuitPath = await writeCircuit(dir, {
+        qubits: 1,
+        cols: [['H']]
+      });
+
+      const result = captureDispatcherRun(dir, ['rm', '--qubit', '0', '--step', '0']);
+
+      assert.equal(result.exitStatus, 0);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, '');
+      assert.deepEqual(await readCircuit(circuitPath), {
+        qubits: 1,
+        cols: [[1]]
+      });
+    });
+  });
+
+  it('removes a controlled operation when the target is selected', async () => {
+    await withTempDir(async (dir) => {
+      const circuitPath = await writeCircuit(dir, {
+        qubits: 2,
+        cols: [['•', 'X']]
+      });
+
+      const result = captureDispatcherRun(dir, ['rm', '--qubit', '1', '--step', '0']);
+
+      assert.equal(result.exitStatus, 0);
+      assert.deepEqual(await readCircuit(circuitPath), {
+        qubits: 1,
+        cols: [[1]]
+      });
+    });
+  });
+
+  it('removes a SWAP operation when one Swap slot is selected', async () => {
+    await withTempDir(async (dir) => {
+      const circuitPath = await writeCircuit(dir, {
+        qubits: 2,
+        cols: [['Swap', 'Swap']]
+      });
+
+      const result = captureDispatcherRun(dir, ['rm', '--qubit', '0', '--step', '0']);
+
+      assert.equal(result.exitStatus, 0);
+      assert.deepEqual(await readCircuit(circuitPath), {
+        qubits: 1,
+        cols: [[1]]
+      });
+    });
+  });
+
+  it('reports empty slots without mutating circuit.json', async () => {
+    await withTempDir(async (dir) => {
+      const originalCircuit = {
+        qubits: 2,
+        cols: [['H', 1]]
+      };
+      const circuitPath = await writeCircuit(dir, originalCircuit);
+
+      const result = captureDispatcherRun(dir, ['rm', '--qubit', '1', '--step', '0']);
+
+      assert.equal(result.exitStatus, 1);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, 'slot is empty: cols[0][1]\n');
+      assert.deepEqual(await readCircuit(circuitPath), originalCircuit);
+    });
+  });
+
+  it('honors QNI_USE_RUBY for rm', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, ['rm', '--qubit', '0', '--step', '0'], {
+        PATH: '',
+        QNI_USE_RUBY: '1'
+      });
+
+      assert.equal(result.exitStatus, 127);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, 'spawnSync bundle ENOENT\n');
+    });
+  });
+});

--- a/test/typescript/remove_command.test.ts
+++ b/test/typescript/remove_command.test.ts
@@ -137,6 +137,26 @@ describe('rm command TypeScript route', () => {
     });
   });
 
+  it('trims empty trailing steps after removal', async () => {
+    await withTempDir(async (dir) => {
+      const circuitPath = await writeCircuit(dir, {
+        qubits: 2,
+        cols: [
+          ['H', 1],
+          [1, 'X']
+        ]
+      });
+
+      const result = captureDispatcherRun(dir, ['rm', '--qubit', '1', '--step', '1']);
+
+      assert.equal(result.exitStatus, 0);
+      assert.deepEqual(await readCircuit(circuitPath), {
+        qubits: 1,
+        cols: [['H']]
+      });
+    });
+  });
+
   it('reports empty slots without mutating circuit.json', async () => {
     await withTempDir(async (dir) => {
       const originalCircuit = {


### PR DESCRIPTION
## 概要

- `qni rm` を TypeScript dispatcher route に追加しました。
- 単一 gate、controlled gate、SWAP の operation removal と、削除後の layout normalization を TypeScript 側に実装しました。
- `QNI_USE_RUBY=1` の Ruby fallback は維持し、rm feature と TypeScript unit test で確認しました。

## Linear

- YAS-219: https://linear.app/yasuhito/issue/YAS-219/rm-を-typescript-に移行する

## 検証

- `npm run test:ts`
- `npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress features/cli/rm/*.feature.md`
- `QNI_USE_RUBY=1 npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress features/cli/rm/*.feature.md`
- Ruby route と TypeScript route の `circuit.json` を single / controlled / SWAP removal で比較
- `bundle exec rake check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * `qni rm` コマンドを追加しました。指定したステップと量子ビットのゲートを削除できるようになりました。
  * 削除後、回路ファイルは自動的に最適化されます。
  * Ruby フォールバック環境（`QNI_USE_RUBY=1`）に対応しています。

* **テスト**
  * 新しいコマンドの動作検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->