### PR TITLE
固定 gate の add を TypeScript に移行する

### DIFF
--- a/features/cli/add/add_h_gate.feature.md
+++ b/features/cli/add/add_h_gate.feature.md
@@ -48,3 +48,18 @@ qni-cli のユーザとして、コマンドラインから量子回路を組み
     ]
   }
   ```
+
+## Scenario: QNI_USE_RUBY=1 の H ゲート追加は Ruby fallback で circuit.json を作成
+
+- Given 環境変数 "QNI_USE_RUBY" を "1" に設定する
+- When "qni add H --qubit 0 --step 0" を実行
+- Then "circuit.json" の内容:
+
+  ```json
+  {
+    "qubits": 1,
+    "cols": [
+      ["H"]
+    ]
+  }
+  ```

--- a/features/cli/add/add_h_gate.feature.md
+++ b/features/cli/add/add_h_gate.feature.md
@@ -49,6 +49,12 @@ qni-cli のユーザとして、コマンドラインから量子回路を組み
   }
   ```
 
+## Scenario: QNI_USE_RUBY=1 の H ゲート追加コマンドは成功
+
+- Given 環境変数 "QNI_USE_RUBY" を "1" に設定する
+- When "qni add H --qubit 0 --step 0" を実行
+- Then コマンドは成功
+
 ## Scenario: QNI_USE_RUBY=1 の H ゲート追加は Ruby fallback で circuit.json を作成
 
 - Given 環境変数 "QNI_USE_RUBY" を "1" に設定する

--- a/src/circuit_file.ts
+++ b/src/circuit_file.ts
@@ -49,6 +49,18 @@ export class CircuitFile {
     return false;
   }
 
+  addGate(gate: string, step: number, qubit: number): void {
+    const circuit = this.existingCircuit() ?? emptyCircuit(step, qubit);
+
+    expandQubitsTo(circuit, qubit);
+    expandStepsTo(circuit, step);
+    ensureAddSlotAvailable(circuit, step, qubit);
+
+    circuit.cols[step][qubit] = gate;
+    normalizeAfterAdd(circuit);
+    this.write(circuit);
+  }
+
   initialStateText(): string {
     const circuit = this.existingCircuit();
 
@@ -162,6 +174,43 @@ export class CircuitFile {
   }
 }
 
+function emptyCircuit(step: number, qubit: number): CircuitData {
+  const qubits = qubit + 1;
+
+  return {
+    cols: Array.from({ length: step + 1 }, () => Array.from({ length: qubits }, () => EMPTY_SLOT)),
+    qubits
+  };
+}
+
+function expandQubitsTo(circuit: CircuitData, qubit: number): void {
+  if (qubit < circuit.qubits) {
+    return;
+  }
+
+  const count = qubit - circuit.qubits + 1;
+
+  for (const col of circuit.cols) {
+    col.push(...Array.from({ length: count }, () => EMPTY_SLOT));
+  }
+
+  circuit.qubits += count;
+}
+
+function expandStepsTo(circuit: CircuitData, step: number): void {
+  while (circuit.cols.length <= step) {
+    circuit.cols.push(Array.from({ length: circuit.qubits }, () => EMPTY_SLOT));
+  }
+}
+
+function ensureAddSlotAvailable(circuit: CircuitData, step: number, qubit: number): void {
+  const slot = circuit.cols[step]?.[qubit];
+
+  if (slot !== EMPTY_SLOT) {
+    throw new CircuitFileError(`target slot is occupied: cols[${step}][${qubit}] = ${JSON.stringify(slot)}`);
+  }
+}
+
 function existingSlot(circuit: CircuitData, step: number, qubit: number): unknown[] {
   const col = circuit.cols[step];
 
@@ -232,6 +281,11 @@ function normalizeAfterRemoval(circuit: CircuitData): void {
   trimLeadingEmptyQubits(circuit);
   trimTrailingEmptyQubits(circuit);
   trimTrailingEmptySteps(circuit);
+}
+
+function normalizeAfterAdd(circuit: CircuitData): void {
+  trimLeadingEmptySteps(circuit);
+  trimLeadingEmptyQubits(circuit);
 }
 
 function trimLeadingEmptySteps(circuit: CircuitData): void {

--- a/src/commands/add_command.ts
+++ b/src/commands/add_command.ts
@@ -1,0 +1,152 @@
+import { CircuitFileError, currentCircuitFile } from '../circuit_file';
+import type { CommandHandlerContext } from '../dispatcher';
+import { runRubyFallbackSync } from '../process/process_compatibility';
+
+const FIXED_SINGLE_QUBIT_GATES = new Map<string, string>([
+  ['H', 'H'],
+  ['S', 'S'],
+  ['S†', 'S†'],
+  ['T', 'T'],
+  ['T†', 'T†'],
+  ['X', 'X'],
+  ['X^½', 'X^½'],
+  ['Y', 'Y'],
+  ['Z', 'Z'],
+  ['√X', 'X^½']
+]);
+
+interface AddOptions {
+  readonly qubit: number;
+  readonly step: number;
+}
+
+export function runAddCommand(argv: string[], context: CommandHandlerContext): number {
+  if (!fixedSingleQubitAdd(argv)) {
+    return runRubyFallbackSync({
+      argv,
+      cwd: context.cwd,
+      env: context.env,
+      projectRoot: context.projectRoot
+    }).exitStatus ?? 1;
+  }
+
+  try {
+    const gate = normalizedFixedGate(argv[1]);
+    const options = parseAddOptions(argv.slice(2));
+
+    currentCircuitFile(context.cwd).addGate(gate, options.step, options.qubit);
+    return 0;
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}
+
+function fixedSingleQubitAdd(argv: string[]): boolean {
+  if (argv.length < 2) {
+    return false;
+  }
+
+  if (argv[1] === '--help' || argv[1] === '-h') {
+    return false;
+  }
+
+  if (!FIXED_SINGLE_QUBIT_GATES.has(normalizedGateName(argv[1]))) {
+    return false;
+  }
+
+  return fixedAddOptionsOnly(argv.slice(2));
+}
+
+function normalizedFixedGate(gate: string): string {
+  const normalizedGate = FIXED_SINGLE_QUBIT_GATES.get(normalizedGateName(gate));
+
+  if (!normalizedGate) {
+    throw new CircuitFileError(`unsupported gate: ${gate}`);
+  }
+
+  return normalizedGate;
+}
+
+function normalizedGateName(gate: string): string {
+  return gate.toUpperCase();
+}
+
+function fixedAddOptionsOnly(args: string[]): boolean {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    const match = /^--(?<name>qubit|step)(?:=.*)?$/u.exec(arg);
+
+    if (!match?.groups) {
+      return false;
+    }
+
+    if (!arg.includes('=')) {
+      index += 1;
+    }
+  }
+
+  return true;
+}
+
+function parseAddOptions(args: string[]): AddOptions {
+  const values = new Map<string, string>();
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    const match = /^--(?<name>qubit|step)(?:=(?<value>.*))?$/u.exec(arg);
+
+    if (!match?.groups) {
+      throw new CircuitFileError(`unknown option: ${arg}`);
+    }
+
+    const value = match.groups.value ?? args[index + 1];
+
+    if (match.groups.value === undefined) {
+      index += 1;
+    }
+
+    values.set(match.groups.name, value ?? '');
+  }
+
+  return {
+    qubit: requiredSingleNonNegativeInteger(values.get('qubit'), 'qubit'),
+    step: requiredNonNegativeInteger(values.get('step'), 'step')
+  };
+}
+
+function requiredSingleNonNegativeInteger(value: string | undefined, name: string): number {
+  if (!value) {
+    throw new CircuitFileError(`${name} is required`);
+  }
+
+  const values = value.split(',');
+
+  if (values.length !== 1) {
+    throw new CircuitFileError(`${name} must contain exactly 1 index`);
+  }
+
+  return parseNonNegativeInteger(values[0], name);
+}
+
+function requiredNonNegativeInteger(value: string | undefined, name: string): number {
+  if (!value) {
+    throw new CircuitFileError(`${name} is required`);
+  }
+
+  return parseNonNegativeInteger(value, name);
+}
+
+function parseNonNegativeInteger(value: string, name: string): number {
+  if (!/^[+-]?\d+$/u.test(value)) {
+    throw new CircuitFileError(`${name} must be an integer`);
+  }
+
+  const parsedValue = Number.parseInt(value, 10);
+
+  if (parsedValue < 0) {
+    throw new CircuitFileError(`${name} must be >= 0`);
+  }
+
+  return parsedValue;
+}

--- a/src/commands/add_command.ts
+++ b/src/commands/add_command.ts
@@ -77,11 +77,11 @@ function fixedAddOptionsOnly(args: string[]): boolean {
     const arg = args[index];
     const match = /^--(?<name>qubit|step)(?:=.*)?$/u.exec(arg);
 
-    if (!match?.groups) {
+    if (arg.startsWith('--') && !match?.groups) {
       return false;
     }
 
-    if (!arg.includes('=')) {
+    if (match?.groups && !arg.includes('=')) {
       index += 1;
     }
   }

--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -2,6 +2,7 @@ import {
   chooseCommandImplementation,
   runRubyFallbackSync
 } from './process/process_compatibility';
+import { runAddCommand } from './commands/add_command';
 import { runGateCommand } from './commands/gate_command';
 import { runRemoveCommand } from './commands/remove_command';
 import { runStateCommand } from './commands/state_command';
@@ -28,6 +29,7 @@ interface CommandRoute {
 }
 
 const TYPESCRIPT_ROUTES = new Map<string, CommandHandler>([
+  ['add', runAddCommand],
   ['gate', runGateCommand],
   ['rm', runRemoveCommand],
   ['state', runStateCommand],

--- a/test/typescript/add_command.test.ts
+++ b/test/typescript/add_command.test.ts
@@ -1,0 +1,216 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import { createDispatcher } from '../../src/dispatcher';
+
+interface CapturedRun {
+  readonly exitStatus: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}
+
+async function withTempDir<T>(callback: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'qni-cli-add-'));
+
+  try {
+    return await callback(dir);
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+}
+
+function captureDispatcherRun(
+  cwd: string,
+  argv: string[],
+  env: NodeJS.ProcessEnv = { PATH: '' }
+): CapturedRun {
+  let stdout = '';
+  let stderr = '';
+  const originalStdoutWrite = process.stdout.write;
+  const originalStderrWrite = process.stderr.write;
+
+  process.stdout.write = ((
+    chunk: string | Uint8Array,
+    encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+    callback?: (error?: Error | null) => void
+  ): boolean => {
+    stdout += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk.toString();
+    if (typeof encodingOrCallback === 'function') {
+      encodingOrCallback();
+    }
+    if (callback) {
+      callback();
+    }
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = ((
+    chunk: string | Uint8Array,
+    encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+    callback?: BufferEncoding | ((error?: Error | null) => void)
+  ): boolean => {
+    stderr += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk.toString();
+    if (typeof encodingOrCallback === 'function') {
+      encodingOrCallback();
+    }
+    if (typeof callback === 'function') {
+      callback();
+    }
+    return true;
+  }) as typeof process.stderr.write;
+
+  try {
+    const dispatcher = createDispatcher({
+      cwd,
+      env,
+      projectRoot: process.cwd()
+    });
+
+    return {
+      exitStatus: dispatcher.run(argv),
+      stderr,
+      stdout
+    };
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+}
+
+async function writeCircuit(dir: string, circuit: unknown): Promise<string> {
+  const circuitPath = path.join(dir, 'circuit.json');
+  await writeFile(circuitPath, `${JSON.stringify(circuit, null, 2)}\n`);
+
+  return circuitPath;
+}
+
+async function readCircuit(circuitPath: string): Promise<unknown> {
+  return JSON.parse(await readFile(circuitPath, 'utf8'));
+}
+
+describe('add command TypeScript route', () => {
+  it('adds fixed single-qubit gates without invoking Ruby fallback', async () => {
+    const examples = [
+      ['H', 'H'],
+      ['X', 'X'],
+      ['Y', 'Y'],
+      ['Z', 'Z'],
+      ['S', 'S'],
+      ['S†', 'S†'],
+      ['T', 'T'],
+      ['T†', 'T†'],
+      ['√X', 'X^½']
+    ];
+
+    for (const [gate, storedGate] of examples) {
+      await withTempDir(async (dir) => {
+        const result = captureDispatcherRun(dir, ['add', gate, '--qubit', '0', '--step', '0']);
+
+        assert.equal(result.exitStatus, 0);
+        assert.equal(result.stdout, '');
+        assert.equal(result.stderr, '');
+        assert.deepEqual(await readCircuit(path.join(dir, 'circuit.json')), {
+          qubits: 1,
+          cols: [[storedGate]]
+        });
+      });
+    }
+  });
+
+  it('auto-expands and normalizes leading empty steps like Ruby', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, ['add', 'H', '--qubit', '0', '--step', '1']);
+
+      assert.equal(result.exitStatus, 0);
+      assert.deepEqual(await readCircuit(path.join(dir, 'circuit.json')), {
+        qubits: 1,
+        cols: [['H']]
+      });
+    });
+  });
+
+  it('auto-expands and normalizes leading empty qubits like Ruby', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, ['add', 'H', '--qubit', '1', '--step', '0']);
+
+      assert.equal(result.exitStatus, 0);
+      assert.deepEqual(await readCircuit(path.join(dir, 'circuit.json')), {
+        qubits: 1,
+        cols: [['H']]
+      });
+    });
+  });
+
+  it('reports occupied slots without mutating circuit.json', async () => {
+    await withTempDir(async (dir) => {
+      const originalCircuit = {
+        qubits: 1,
+        cols: [['H']]
+      };
+      const circuitPath = await writeCircuit(dir, originalCircuit);
+
+      const result = captureDispatcherRun(dir, ['add', 'X', '--qubit', '0', '--step', '0']);
+
+      assert.equal(result.exitStatus, 1);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, 'target slot is occupied: cols[0][0] = "H"\n');
+      assert.deepEqual(await readCircuit(circuitPath), originalCircuit);
+    });
+  });
+
+  it('leaves angled gates on Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, ['add', 'Ry', '--angle', 'theta', '--qubit', '0', '--step', '0']);
+
+      assert.equal(result.exitStatus, 127);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, 'spawnSync bundle ENOENT\n');
+    });
+  });
+
+  it('leaves controlled gates on Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, ['add', 'X', '--control', '0', '--qubit', '1', '--step', '0']);
+
+      assert.equal(result.exitStatus, 127);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, 'spawnSync bundle ENOENT\n');
+    });
+  });
+
+  it('leaves SWAP on Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, ['add', 'SWAP', '--qubit', '0,1', '--step', '0']);
+
+      assert.equal(result.exitStatus, 127);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, 'spawnSync bundle ENOENT\n');
+    });
+  });
+
+  it('leaves unknown option handling on Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, ['add', 'H', '--qubit', '0', '--step', '0', '--unexpected']);
+
+      assert.equal(result.exitStatus, 127);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, 'spawnSync bundle ENOENT\n');
+    });
+  });
+
+  it('honors QNI_USE_RUBY for add', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, ['add', 'H', '--qubit', '0', '--step', '0'], {
+        PATH: '',
+        QNI_USE_RUBY: '1'
+      });
+
+      assert.equal(result.exitStatus, 127);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, 'spawnSync bundle ENOENT\n');
+    });
+  });
+});

--- a/test/typescript/add_command.test.ts
+++ b/test/typescript/add_command.test.ts
@@ -201,6 +201,16 @@ describe('add command TypeScript route', () => {
     });
   });
 
+  it('rejects malformed fixed gate options without invoking Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, ['add', 'H', '--qubit', '--step', '0']);
+
+      assert.equal(result.exitStatus, 1);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, 'unknown option: 0\n');
+    });
+  });
+
   it('honors QNI_USE_RUBY for add', async () => {
     await withTempDir(async (dir) => {
       const result = captureDispatcherRun(dir, ['add', 'H', '--qubit', '0', '--step', '0'], {


### PR DESCRIPTION
## 概要

- fixed single-qubit gate の `qni add` を TypeScript route に移行しました。
- H / X / Y / Z / S / S† / T / T† / √X の配置、auto-expand、先頭 auto-shrink、slot occupancy error を TypeScript 側で扱います。
- angled gate / controlled gate / SWAP / unknown option / `QNI_USE_RUBY=1` は Ruby fallback のまま維持しています。

## 検証

- `npm run test:ts`
- `npm run build && npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress "features/cli/add/*.feature.md" "features/circuit/*.feature.md"`
- `bundle exec rake check`

## 関連

- Linear: YAS-220
- GitHub issue: #74


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 量子回路にゲートを追加する `add` コマンドを実装しました。
  * `--qubit` および `--step` オプションで位置を指定できます。
  * サポートされていないゲートは自動的にフォールバック処理が行われます。

* **テスト**
  * `add` コマンドの実行パスと動作を検証する包括的なテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->