### PR TITLE
controlled / SWAP / angled gate の add を TypeScript 化する

### DIFF
--- a/features/cli/add/add_cnot.feature.md
+++ b/features/cli/add/add_cnot.feature.md
@@ -39,3 +39,17 @@ qni-cli のユーザとして、コマンドラインから量子回路を組み
     ]
   }
   ```
+
+## Scenario: CNOT ゲートは decimal step でも circuit.json を作成
+
+- When "qni add X --control 0 --qubit 1 --step 0.0" を実行
+- Then "circuit.json" の内容:
+
+  ```json
+  {
+    "qubits": 2,
+    "cols": [
+      ["•", "X"]
+    ]
+  }
+  ```

--- a/features/cli/add/add_rx_gate.feature.md
+++ b/features/cli/add/add_rx_gate.feature.md
@@ -50,6 +50,20 @@ qni-cli のユーザとして、コマンドラインから量子回路を組み
   }
   ```
 
+## Scenario: Rx ゲートは decimal step でも circuit.json を作成
+
+- When "qni add Rx --angle π/2 --qubit 0 --step 0.0" を実行
+- Then "circuit.json" の内容:
+
+  ```json
+  {
+    "qubits": 1,
+    "cols": [
+      ["Rx(π/2)"]
+    ]
+  }
+  ```
+
 ## Scenario: Rx ゲートは angle がないと追加できない
 
 - When "qni add Rx --qubit 0 --step 0" を実行

--- a/features/cli/add/add_swap_gate.feature.md
+++ b/features/cli/add/add_swap_gate.feature.md
@@ -49,6 +49,20 @@ qni add SWAP を実行したい。
   }
   ```
 
+## Scenario: qni add SWAP は decimal step でも circuit.json に Swap を 2 つ追加
+
+- When "qni add SWAP --qubit 0,1 --step 0.0" を実行
+- Then "circuit.json" の内容:
+
+  ```json
+  {
+    "qubits": 2,
+    "cols": [
+      ["Swap", "Swap"]
+    ]
+  }
+  ```
+
 ## Scenario: qni add SWAP は target qubit が 1 つだと失敗
 
 - When "qni add SWAP --qubit 0 --step 0" を実行

--- a/src/circuit_file.ts
+++ b/src/circuit_file.ts
@@ -61,6 +61,23 @@ export class CircuitFile {
     this.write(circuit);
   }
 
+  addControlledGate(gate: string, step: number, controls: number[], target: number): void {
+    validateControls(controls, target);
+    this.addPlacement(step, new Map([...controls.map((control) => [control, CONTROL_SYMBOL] as const), [target, gate]]));
+  }
+
+  addSwapGate(step: number, targets: number[]): void {
+    if (targets.length !== 2) {
+      throw new CircuitFileError('SWAP requires exactly 2 target qubits');
+    }
+
+    if (new Set(targets).size !== targets.length) {
+      throw new CircuitFileError('SWAP target qubits must be different');
+    }
+
+    this.addPlacement(step, new Map(targets.map((target) => [target, SWAP_SYMBOL] as const)));
+  }
+
   initialStateText(): string {
     const circuit = this.existingCircuit();
 
@@ -172,6 +189,25 @@ export class CircuitFile {
       rmSync(tempPath, { force: true });
     }
   }
+
+  private addPlacement(step: number, symbols: Map<number, string>): void {
+    const maxQubit = Math.max(...symbols.keys());
+    const circuit = this.existingCircuit() ?? emptyCircuit(step, maxQubit);
+
+    expandQubitsTo(circuit, maxQubit);
+    expandStepsTo(circuit, step);
+
+    for (const qubit of symbols.keys()) {
+      ensureAddSlotAvailable(circuit, step, qubit);
+    }
+
+    for (const [qubit, symbol] of symbols.entries()) {
+      circuit.cols[step][qubit] = symbol;
+    }
+
+    normalizeAfterAdd(circuit);
+    this.write(circuit);
+  }
 }
 
 function emptyCircuit(step: number, qubit: number): CircuitData {
@@ -208,6 +244,20 @@ function ensureAddSlotAvailable(circuit: CircuitData, step: number, qubit: numbe
 
   if (slot !== EMPTY_SLOT) {
     throw new CircuitFileError(`target slot is occupied: cols[${step}][${qubit}] = ${JSON.stringify(slot)}`);
+  }
+}
+
+function validateControls(controls: number[], target: number): void {
+  if (controls.length === 0) {
+    throw new CircuitFileError('control must not be empty');
+  }
+
+  if (new Set(controls).size !== controls.length) {
+    throw new CircuitFileError('control must not contain duplicates');
+  }
+
+  if (controls.includes(target)) {
+    throw new CircuitFileError('control and target must be different');
   }
 }
 

--- a/src/commands/add_command.ts
+++ b/src/commands/add_command.ts
@@ -1,8 +1,9 @@
+import { AngleExpression, AngleExpressionError } from '../angle_expression';
 import { CircuitFileError, currentCircuitFile } from '../circuit_file';
 import type { CommandHandlerContext } from '../dispatcher';
 import { runRubyFallbackSync } from '../process/process_compatibility';
 
-const FIXED_SINGLE_QUBIT_GATES = new Map<string, string>([
+const FIXED_GATES = new Map<string, string>([
   ['H', 'H'],
   ['S', 'S'],
   ['S†', 'S†'],
@@ -15,13 +16,24 @@ const FIXED_SINGLE_QUBIT_GATES = new Map<string, string>([
   ['√X', 'X^½']
 ]);
 
+const ANGLED_GATES = new Map<string, string>([
+  ['P', 'P'],
+  ['RX', 'Rx'],
+  ['RY', 'Ry'],
+  ['RZ', 'Rz']
+]);
+const ANGLED_GATE_SYMBOLS = new Set(ANGLED_GATES.values());
+const SWAP_GATE = 'Swap';
+
 interface AddOptions {
-  readonly qubit: number;
+  readonly angle?: string;
+  readonly controls: number[];
+  readonly qubits: number[];
   readonly step: number;
 }
 
 export function runAddCommand(argv: string[], context: CommandHandlerContext): number {
-  if (!fixedSingleQubitAdd(argv)) {
+  if (!typeScriptAdd(argv)) {
     return runRubyFallbackSync({
       argv,
       cwd: context.cwd,
@@ -31,10 +43,23 @@ export function runAddCommand(argv: string[], context: CommandHandlerContext): n
   }
 
   try {
-    const gate = normalizedFixedGate(argv[1]);
+    const gate = normalizedSupportedGate(argv[1]);
     const options = parseAddOptions(argv.slice(2));
+    validateAngleUsage(gate, options);
+    const circuitFile = currentCircuitFile(context.cwd);
 
-    currentCircuitFile(context.cwd).addGate(gate, options.step, options.qubit);
+    if (gate === SWAP_GATE) {
+      if (controlled(options)) {
+        throw new CircuitFileError('SWAP does not support --control yet');
+      }
+
+      circuitFile.addSwapGate(options.step, options.qubits);
+    } else if (controlled(options)) {
+      circuitFile.addControlledGate(serializedGate(gate, options), options.step, options.controls, singleQubit(options));
+    } else {
+      circuitFile.addGate(serializedGate(gate, options), options.step, singleQubit(options));
+    }
+
     return 0;
   } catch (error) {
     process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
@@ -42,7 +67,7 @@ export function runAddCommand(argv: string[], context: CommandHandlerContext): n
   }
 }
 
-function fixedSingleQubitAdd(argv: string[]): boolean {
+function typeScriptAdd(argv: string[]): boolean {
   if (argv.length < 2) {
     return false;
   }
@@ -51,15 +76,16 @@ function fixedSingleQubitAdd(argv: string[]): boolean {
     return false;
   }
 
-  if (!FIXED_SINGLE_QUBIT_GATES.has(normalizedGateName(argv[1]))) {
+  if (!supportedGateName(argv[1])) {
     return false;
   }
 
-  return fixedAddOptionsOnly(argv.slice(2));
+  return knownAddOptionsOnly(argv.slice(2));
 }
 
-function normalizedFixedGate(gate: string): string {
-  const normalizedGate = FIXED_SINGLE_QUBIT_GATES.get(normalizedGateName(gate));
+function normalizedSupportedGate(gate: string): string {
+  const normalizedName = normalizedGateName(gate);
+  const normalizedGate = normalizedGateSymbol(normalizedName);
 
   if (!normalizedGate) {
     throw new CircuitFileError(`unsupported gate: ${gate}`);
@@ -68,14 +94,28 @@ function normalizedFixedGate(gate: string): string {
   return normalizedGate;
 }
 
+function normalizedGateSymbol(normalizedName: string): string | undefined {
+  return FIXED_GATES.get(normalizedName) ?? ANGLED_GATES.get(normalizedName) ?? swapGateSymbol(normalizedName);
+}
+
+function swapGateSymbol(normalizedName: string): string | undefined {
+  return normalizedName === 'SWAP' ? SWAP_GATE : undefined;
+}
+
 function normalizedGateName(gate: string): string {
   return gate.toUpperCase();
 }
 
-function fixedAddOptionsOnly(args: string[]): boolean {
+function supportedGateName(gate: string): boolean {
+  const normalizedName = normalizedGateName(gate);
+
+  return FIXED_GATES.has(normalizedName) || ANGLED_GATES.has(normalizedName) || normalizedName === 'SWAP';
+}
+
+function knownAddOptionsOnly(args: string[]): boolean {
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
-    const match = /^--(?<name>qubit|step)(?:=.*)?$/u.exec(arg);
+    const match = /^--(?<name>angle|control|qubit|step)(?:=.*)?$/u.exec(arg);
 
     if (arg.startsWith('--') && !match?.groups) {
       return false;
@@ -94,7 +134,7 @@ function parseAddOptions(args: string[]): AddOptions {
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
-    const match = /^--(?<name>qubit|step)(?:=(?<value>.*))?$/u.exec(arg);
+    const match = /^--(?<name>angle|control|qubit|step)(?:=(?<value>.*))?$/u.exec(arg);
 
     if (!match?.groups) {
       throw new CircuitFileError(`unknown option: ${arg}`);
@@ -110,31 +150,85 @@ function parseAddOptions(args: string[]): AddOptions {
   }
 
   return {
-    qubit: requiredSingleNonNegativeInteger(values.get('qubit'), 'qubit'),
+    angle: values.get('angle'),
+    controls: optionalNonNegativeIntegers(values.get('control'), 'control'),
+    qubits: requiredNonNegativeIntegers(values.get('qubit'), 'qubit'),
     step: requiredNonNegativeInteger(values.get('step'), 'step')
   };
 }
 
-function requiredSingleNonNegativeInteger(value: string | undefined, name: string): number {
+function singleQubit(options: AddOptions): number {
+  if (options.qubits.length !== 1) {
+    throw new CircuitFileError('qubit must contain exactly 1 index');
+  }
+
+  return options.qubits[0];
+}
+
+function controlled(options: AddOptions): boolean {
+  return options.controls.length > 0;
+}
+
+function serializedGate(gate: string, options: AddOptions): string {
+  if (!angledGate(gate)) {
+    return gate;
+  }
+
+  try {
+    return `${gate}(${new AngleExpression(requiredAngle(options, gate)).toString()})`;
+  } catch (error) {
+    if (error instanceof AngleExpressionError) {
+      throw new CircuitFileError(error.message);
+    }
+
+    throw error;
+  }
+}
+
+function validateAngleUsage(gate: string, options: AddOptions): void {
+  if (options.angle && !angledGate(gate)) {
+    throw new CircuitFileError('angle is only supported for P, Rx, Ry, and Rz');
+  }
+}
+
+function requiredAngle(options: AddOptions, gate: string): string {
+  if (!options.angle) {
+    throw new CircuitFileError(`angle is required for ${gate}`);
+  }
+
+  return options.angle;
+}
+
+function angledGate(gate: string): boolean {
+  return ANGLED_GATE_SYMBOLS.has(gate);
+}
+
+function requiredNonNegativeIntegers(value: string | undefined, name: string): number[] {
   if (!value) {
-    throw new CircuitFileError(`${name} is required`);
+    throw new CircuitFileError(requiredOptionMessage(name));
   }
 
-  const values = value.split(',');
+  return value.split(',').map((entry) => parseNonNegativeInteger(entry, name));
+}
 
-  if (values.length !== 1) {
-    throw new CircuitFileError(`${name} must contain exactly 1 index`);
+function optionalNonNegativeIntegers(value: string | undefined, name: string): number[] {
+  if (!value) {
+    return [];
   }
 
-  return parseNonNegativeInteger(values[0], name);
+  return value.split(',').map((entry) => parseNonNegativeInteger(entry, name));
 }
 
 function requiredNonNegativeInteger(value: string | undefined, name: string): number {
   if (!value) {
-    throw new CircuitFileError(`${name} is required`);
+    throw new CircuitFileError(requiredOptionMessage(name));
   }
 
   return parseNonNegativeInteger(value, name);
+}
+
+function requiredOptionMessage(name: string): string {
+  return `No value provided for required options '--${name}'`;
 }
 
 function parseNonNegativeInteger(value: string, name: string): number {

--- a/src/commands/add_command.ts
+++ b/src/commands/add_command.ts
@@ -153,7 +153,7 @@ function parseAddOptions(args: string[]): AddOptions {
     angle: values.get('angle'),
     controls: optionalNonNegativeIntegers(values.get('control'), 'control'),
     qubits: requiredNonNegativeIntegers(values.get('qubit'), 'qubit'),
-    step: requiredNonNegativeInteger(values.get('step'), 'step')
+    step: requiredNonNegativeStep(values.get('step'))
   };
 }
 
@@ -227,6 +227,14 @@ function requiredNonNegativeInteger(value: string | undefined, name: string): nu
   return parseNonNegativeInteger(value, name);
 }
 
+function requiredNonNegativeStep(value: string | undefined): number {
+  if (!value) {
+    throw new CircuitFileError(requiredOptionMessage('step'));
+  }
+
+  return parseNonNegativeNumericStep(value);
+}
+
 function requiredOptionMessage(name: string): string {
   return `No value provided for required options '--${name}'`;
 }
@@ -240,6 +248,20 @@ function parseNonNegativeInteger(value: string, name: string): number {
 
   if (parsedValue < 0) {
     throw new CircuitFileError(`${name} must be >= 0`);
+  }
+
+  return parsedValue;
+}
+
+function parseNonNegativeNumericStep(value: string): number {
+  if (!/^[+-]?(?:\d+|\d+\.\d+|\.\d+)$/u.test(value)) {
+    throw new CircuitFileError(`Expected numeric value for '--step'; got "${value}"`);
+  }
+
+  const parsedValue = Math.trunc(Number(value));
+
+  if (parsedValue < 0) {
+    throw new CircuitFileError('step must be >= 0');
   }
 
   return parsedValue;

--- a/test/typescript/add_command.test.ts
+++ b/test/typescript/add_command.test.ts
@@ -207,6 +207,20 @@ describe('add command TypeScript route', () => {
     });
   });
 
+  it('adds multi-control gates without invoking Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, ['add', 'X', '--control', '0,1', '--qubit', '2', '--step', '0']);
+
+      assert.equal(result.exitStatus, 0);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, '');
+      assert.deepEqual(await readCircuit(path.join(dir, 'circuit.json')), {
+        qubits: 3,
+        cols: [['•', '•', 'X']]
+      });
+    });
+  });
+
   it('adds controlled angled gates without invoking Ruby fallback', async () => {
     await withTempDir(async (dir) => {
       const result = captureDispatcherRun(dir, [

--- a/test/typescript/add_command.test.ts
+++ b/test/typescript/add_command.test.ts
@@ -260,6 +260,43 @@ describe('add command TypeScript route', () => {
     });
   });
 
+  it('accepts decimal numeric step values like Ruby for migrated gate variants', async () => {
+    const examples = [
+      {
+        argv: ['add', 'SWAP', '--qubit', '0,1', '--step', '0.0'],
+        circuit: {
+          qubits: 2,
+          cols: [['Swap', 'Swap']]
+        }
+      },
+      {
+        argv: ['add', 'Rx', '--angle', 'pi/2', '--qubit', '0', '--step', '0.0'],
+        circuit: {
+          qubits: 1,
+          cols: [['Rx(π/2)']]
+        }
+      },
+      {
+        argv: ['add', 'X', '--control', '0', '--qubit', '1', '--step', '0.0'],
+        circuit: {
+          qubits: 2,
+          cols: [['•', 'X']]
+        }
+      }
+    ];
+
+    for (const example of examples) {
+      await withTempDir(async (dir) => {
+        const result = captureDispatcherRun(dir, example.argv);
+
+        assert.equal(result.exitStatus, 0);
+        assert.equal(result.stdout, '');
+        assert.equal(result.stderr, '');
+        assert.deepEqual(await readCircuit(path.join(dir, 'circuit.json')), example.circuit);
+      });
+    }
+  });
+
   it('rejects invalid controlled gate placement without invoking Ruby fallback', async () => {
     await withTempDir(async (dir) => {
       const duplicateControl = captureDispatcherRun(dir, [

--- a/test/typescript/add_command.test.ts
+++ b/test/typescript/add_command.test.ts
@@ -161,33 +161,169 @@ describe('add command TypeScript route', () => {
     });
   });
 
-  it('leaves angled gates on Ruby fallback', async () => {
-    await withTempDir(async (dir) => {
-      const result = captureDispatcherRun(dir, ['add', 'Ry', '--angle', 'theta', '--qubit', '0', '--step', '0']);
+  it('adds angled gates without invoking Ruby fallback', async () => {
+    const examples = [
+      ['P', 'π/3', 'P(π/3)'],
+      ['Rx', 'pi/4', 'Rx(π/4)'],
+      ['Ry', 'theta', 'Ry(theta)'],
+      ['Rz', '2*alpha', 'Rz(2*alpha)']
+    ];
 
-      assert.equal(result.exitStatus, 127);
-      assert.equal(result.stdout, '');
-      assert.equal(result.stderr, 'spawnSync bundle ENOENT\n');
-    });
+    for (const [gate, angle, storedGate] of examples) {
+      await withTempDir(async (dir) => {
+        const result = captureDispatcherRun(dir, [
+          'add',
+          gate,
+          '--angle',
+          angle,
+          '--qubit',
+          '0',
+          '--step',
+          '0'
+        ]);
+
+        assert.equal(result.exitStatus, 0);
+        assert.equal(result.stdout, '');
+        assert.equal(result.stderr, '');
+        assert.deepEqual(await readCircuit(path.join(dir, 'circuit.json')), {
+          qubits: 1,
+          cols: [[storedGate]]
+        });
+      });
+    }
   });
 
-  it('leaves controlled gates on Ruby fallback', async () => {
+  it('adds controlled gates without invoking Ruby fallback', async () => {
     await withTempDir(async (dir) => {
       const result = captureDispatcherRun(dir, ['add', 'X', '--control', '0', '--qubit', '1', '--step', '0']);
 
-      assert.equal(result.exitStatus, 127);
+      assert.equal(result.exitStatus, 0);
       assert.equal(result.stdout, '');
-      assert.equal(result.stderr, 'spawnSync bundle ENOENT\n');
+      assert.equal(result.stderr, '');
+      assert.deepEqual(await readCircuit(path.join(dir, 'circuit.json')), {
+        qubits: 2,
+        cols: [['•', 'X']]
+      });
     });
   });
 
-  it('leaves SWAP on Ruby fallback', async () => {
+  it('adds controlled angled gates without invoking Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, [
+        'add',
+        'Rz',
+        '--angle',
+        'pi/4',
+        '--control',
+        '0',
+        '--qubit',
+        '1',
+        '--step',
+        '0'
+      ]);
+
+      assert.equal(result.exitStatus, 0);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, '');
+      assert.deepEqual(await readCircuit(path.join(dir, 'circuit.json')), {
+        qubits: 2,
+        cols: [['•', 'Rz(π/4)']]
+      });
+    });
+  });
+
+  it('adds SWAP without invoking Ruby fallback', async () => {
     await withTempDir(async (dir) => {
       const result = captureDispatcherRun(dir, ['add', 'SWAP', '--qubit', '0,1', '--step', '0']);
 
-      assert.equal(result.exitStatus, 127);
+      assert.equal(result.exitStatus, 0);
       assert.equal(result.stdout, '');
-      assert.equal(result.stderr, 'spawnSync bundle ENOENT\n');
+      assert.equal(result.stderr, '');
+      assert.deepEqual(await readCircuit(path.join(dir, 'circuit.json')), {
+        qubits: 2,
+        cols: [['Swap', 'Swap']]
+      });
+    });
+  });
+
+  it('rejects invalid controlled gate placement without invoking Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      const duplicateControl = captureDispatcherRun(dir, [
+        'add',
+        'X',
+        '--control',
+        '0,0',
+        '--qubit',
+        '1',
+        '--step',
+        '0'
+      ]);
+
+      assert.equal(duplicateControl.exitStatus, 1);
+      assert.equal(duplicateControl.stdout, '');
+      assert.equal(duplicateControl.stderr, 'control must not contain duplicates\n');
+
+      const overlappingTarget = captureDispatcherRun(dir, [
+        'add',
+        'X',
+        '--control',
+        '0',
+        '--qubit',
+        '0',
+        '--step',
+        '0'
+      ]);
+
+      assert.equal(overlappingTarget.exitStatus, 1);
+      assert.equal(overlappingTarget.stdout, '');
+      assert.equal(overlappingTarget.stderr, 'control and target must be different\n');
+    });
+  });
+
+  it('rejects invalid SWAP targets without invoking Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      const missingTargets = captureDispatcherRun(dir, ['add', 'SWAP', '--step', '0']);
+
+      assert.equal(missingTargets.exitStatus, 1);
+      assert.equal(missingTargets.stdout, '');
+      assert.equal(missingTargets.stderr, "No value provided for required options '--qubit'\n");
+
+      const tooFewTargets = captureDispatcherRun(dir, ['add', 'SWAP', '--qubit', '0', '--step', '0']);
+
+      assert.equal(tooFewTargets.exitStatus, 1);
+      assert.equal(tooFewTargets.stdout, '');
+      assert.equal(tooFewTargets.stderr, 'SWAP requires exactly 2 target qubits\n');
+
+      const duplicatedTargets = captureDispatcherRun(dir, ['add', 'SWAP', '--qubit', '0,0', '--step', '0']);
+
+      assert.equal(duplicatedTargets.exitStatus, 1);
+      assert.equal(duplicatedTargets.stdout, '');
+      assert.equal(duplicatedTargets.stderr, 'SWAP target qubits must be different\n');
+    });
+  });
+
+  it('rejects invalid angle usage without invoking Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      const missingAngle = captureDispatcherRun(dir, ['add', 'Rx', '--qubit', '0', '--step', '0']);
+
+      assert.equal(missingAngle.exitStatus, 1);
+      assert.equal(missingAngle.stdout, '');
+      assert.equal(missingAngle.stderr, 'angle is required for Rx\n');
+
+      const unsupportedAngle = captureDispatcherRun(dir, [
+        'add',
+        'H',
+        '--angle',
+        'π/2',
+        '--qubit',
+        '0',
+        '--step',
+        '0'
+      ]);
+
+      assert.equal(unsupportedAngle.exitStatus, 1);
+      assert.equal(unsupportedAngle.stdout, '');
+      assert.equal(unsupportedAngle.stderr, 'angle is only supported for P, Rx, Ry, and Rz\n');
     });
   });
 


### PR DESCRIPTION
## 概要

- controlled gate / SWAP / P/Rx/Ry/Rz angled gate の `qni add` を TypeScript route で処理するようにしました。
- TypeScript circuit model に controlled / SWAP の multi-slot placement を追加し、angle serialization は既存 `AngleExpression` に合わせました。
- `add --step 0.0` のような Ruby 互換 numeric step を migrated variants でも受け付けるようにしました。
- `QNI_USE_RUBY=1` の Ruby fallback と未知 option の fallback は維持しています。

## Linear

- YAS-221: https://linear.app/yasuhito/issue/YAS-221/controlled-swap-angled-gate-の-circuit-model-を-typescript-化する

## 検証

- `npm run test:ts -- --test-name-pattern="add command TypeScript route"` -> 46 tests passed
- `npm run build && npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress features/cli/add/*.feature.md` -> 92 scenarios / 216 steps passed
- Ruby oracle comparison: `SWAP --step 0.0` / `Rx --step 0.0` / `X --control 0 --step 0.0` で status/stdout/stderr/circuit が一致
- Ruby oracle comparison: controlled success / SWAP success / angled controlled success / angle missing error / SWAP duplicate error / SWAP missing qubit error / angle unsupported error
- `bundle exec rake check` -> RuboCop clean、TypeScript 46 tests passed、Cucumber 517 scenarios / 1428 steps passed、Minitest 64 runs / 184 assertions passed
