### PR TITLE
state set と initial_state parser を TypeScript に移行する

### DIFF
--- a/features/cli/state/set.feature.md
+++ b/features/cli/state/set.feature.md
@@ -37,3 +37,17 @@ qni state set を使いたい
     ]
   }
   ```
+
+## Scenario: qni state set は空文字の初期状態で失敗する
+
+- When "qni state set \"\"" を実行
+- Then コマンドは失敗
+
+## Scenario: qni state set は空文字の初期状態でエラーを表示する
+
+- When "qni state set \"\"" を実行
+- Then 標準エラー:
+
+  ```text
+  initial state expression is required
+  ```

--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -31,11 +31,13 @@ function splitCommand(command) {
   let current = '';
   let quote = null;
   let escaping = false;
+  let tokenStarted = false;
 
   for (const char of command) {
     if (escaping) {
       current += char;
       escaping = false;
+      tokenStarted = true;
       continue;
     }
 
@@ -55,29 +57,33 @@ function splitCommand(command) {
 
     if (char === "'" || char === '"') {
       quote = char;
+      tokenStarted = true;
       continue;
     }
 
     if (/\s/.test(char)) {
-      if (current.length > 0) {
+      if (tokenStarted) {
         words.push(current);
         current = '';
+        tokenStarted = false;
       }
       continue;
     }
 
     current += char;
+    tokenStarted = true;
   }
 
   if (escaping) {
     current += '\\';
+    tokenStarted = true;
   }
 
   if (quote) {
     throw new Error(`unterminated quote in command: ${command}`);
   }
 
-  if (current.length > 0) {
+  if (tokenStarted) {
     words.push(current);
   }
 

--- a/src/circuit_file.ts
+++ b/src/circuit_file.ts
@@ -2,7 +2,12 @@ import { readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 import { AngleExpression, AngleExpressionError, validAngleIdentifier } from './angle_expression';
-import { formatInitialState, initialStateQubitCount, zeroInitialStateText } from './initial_state';
+import {
+  formatInitialState,
+  initialStateQubitCount,
+  parseInitialState,
+  zeroInitialStateText
+} from './initial_state';
 
 export class CircuitFileError extends Error {}
 
@@ -114,6 +119,16 @@ export class CircuitFile {
 
     normalizeAfterRemoval(circuit);
     this.write(circuit);
+  }
+
+  setInitialState(expression: unknown): boolean {
+    const initialState = parseInitialState(expression);
+    const circuit = this.existingCircuit() ?? emptyCircuit(0, 0);
+
+    expandQubitsTo(circuit, initialStateQubitCount(initialState) - 1);
+    circuit.initial_state = initialState;
+    this.write(circuit);
+    return true;
   }
 
   setVariable(name: string, value: unknown): boolean {

--- a/src/circuit_file.ts
+++ b/src/circuit_file.ts
@@ -122,9 +122,10 @@ export class CircuitFile {
   }
 
   setInitialState(expression: unknown): boolean {
-    const initialState = parseInitialState(expression);
     const circuit = this.existingCircuit() ?? emptyCircuit(0, 0);
 
+    validateInitialState(circuit);
+    const initialState = parseInitialState(expression);
     expandQubitsTo(circuit, initialStateQubitCount(initialState) - 1);
     circuit.initial_state = initialState;
     this.write(circuit);

--- a/src/commands/state_command.ts
+++ b/src/commands/state_command.ts
@@ -1,6 +1,5 @@
 import { CircuitFileError, currentCircuitFile } from '../circuit_file';
 import type { CommandHandlerContext } from '../dispatcher';
-import { runRubyFallbackSync } from '../process/process_compatibility';
 
 const HELP_TEXT = `Usage:
   qni state set "alpha|0> + beta|1>"
@@ -19,9 +18,9 @@ Examples:
   qni state clear`;
 
 type StateSubcommand = 'clear' | 'set' | 'show';
-type TypeScriptStateSubcommand = Exclude<StateSubcommand, 'set'>;
+type TypeScriptStateSubcommand = StateSubcommand;
 
-const TYPESCRIPT_SUBCOMMANDS = new Set<TypeScriptStateSubcommand>(['clear', 'show']);
+const TYPESCRIPT_SUBCOMMANDS = new Set<TypeScriptStateSubcommand>(['clear', 'set', 'show']);
 
 export function runStateCommand(argv: string[], context: CommandHandlerContext): number {
   const subcommand = argv[1];
@@ -29,15 +28,6 @@ export function runStateCommand(argv: string[], context: CommandHandlerContext):
   if (!subcommand || subcommand === '--help' || subcommand === '-h') {
     process.stdout.write(`${HELP_TEXT}\n`);
     return 0;
-  }
-
-  if (subcommand === 'set') {
-    return runRubyFallbackSync({
-      argv,
-      cwd: context.cwd,
-      env: context.env,
-      projectRoot: context.projectRoot
-    }).exitStatus ?? 1;
   }
 
   try {
@@ -63,13 +53,17 @@ function executeSubcommand(
   args: string[],
   context: CommandHandlerContext
 ): string {
-  requireArgumentCount(args, 0);
   const circuitFile = currentCircuitFile(context.cwd);
 
   switch (subcommand) {
     case 'clear':
+      requireArgumentCount(args, 0);
       return circuitFile.clearInitialState() ? '0' : '';
+    case 'set':
+      requireArgumentCount(args, 1);
+      return circuitFile.setInitialState(args[0]) ? '0' : '';
     case 'show':
+      requireArgumentCount(args, 0);
       return circuitFile.initialStateText();
   }
 }

--- a/src/commands/state_command.ts
+++ b/src/commands/state_command.ts
@@ -61,6 +61,7 @@ function executeSubcommand(
       return circuitFile.clearInitialState() ? '0' : '';
     case 'set':
       requireArgumentCount(args, 1);
+      requireStateExpression(args[0]);
       return circuitFile.setInitialState(args[0]) ? '0' : '';
     case 'show':
       requireArgumentCount(args, 0);
@@ -75,5 +76,11 @@ function isTypeScriptStateSubcommand(value: string): value is TypeScriptStateSub
 function requireArgumentCount(args: string[], expected: number): void {
   if (args.length !== expected) {
     throw new CircuitFileError('wrong number of arguments');
+  }
+}
+
+function requireStateExpression(value: string): void {
+  if (value.length === 0) {
+    throw new CircuitFileError('initial state expression is required');
   }
 }

--- a/src/initial_state.ts
+++ b/src/initial_state.ts
@@ -14,8 +14,38 @@ interface InitialStateTerm {
   readonly coefficient: string;
 }
 
+interface InitialStateData {
+  readonly format: typeof FORMAT;
+  readonly terms: InitialStateTerm[];
+}
+
+const ONE_QUBIT_SPECIAL_STATES = new Map<string, string>([
+  ['|+>', SQRT_HALF_TEXT],
+  ['|->', `-${SQRT_HALF_TEXT}`],
+  ['|+i>', `${SQRT_HALF_TEXT}i`],
+  ['|-i>', `-${SQRT_HALF_TEXT}i`]
+]);
+
+const BELL_SHORTHANDS = new Map<string, string>([
+  ['|Φ+>', 'Φ+'],
+  ['|Φ->', 'Φ-'],
+  ['|Ψ+>', 'Ψ+'],
+  ['|Ψ->', 'Ψ-']
+]);
+
+const BELL_PLACEHOLDERS = new Map<string, string>([
+  ['Φ+', '__QNI_BELL_PHI_PLUS__'],
+  ['Φ-', '__QNI_BELL_PHI_MINUS__'],
+  ['Ψ+', '__QNI_BELL_PSI_PLUS__'],
+  ['Ψ-', '__QNI_BELL_PSI_MINUS__']
+]);
+
 export function zeroInitialStateText(): string {
   return '1|0>';
+}
+
+export function parseInitialState(rawValue: unknown): InitialStateData {
+  return specialInitialState(rawValue) ?? parseKetSum(rawValue);
 }
 
 export function formatInitialState(value: unknown): string {
@@ -54,6 +84,84 @@ function loadTerm(value: unknown): InitialStateTerm {
     basis: validatedBasis(value.basis),
     coefficient: validatedCoefficient(value.coefficient)
   };
+}
+
+function parseKetSum(rawValue: unknown): InitialStateData {
+  const normalized = normalizedText(rawValue);
+
+  if (normalized.length === 0) {
+    throw new InitialStateError('initial state is required');
+  }
+
+  return {
+    format: FORMAT,
+    terms: normalizedTerms(normalized.split(' + ').map(parseTerm))
+  };
+}
+
+function parseTerm(rawValue: string): InitialStateTerm {
+  const match = /^(?<coefficient>.+)\|(?<basis>[^>]+)>$/u.exec(rawValue);
+
+  if (!match?.groups) {
+    throw new InitialStateError(`invalid initial state term: ${rawValue}`);
+  }
+
+  return {
+    basis: validatedBasis(match.groups.basis),
+    coefficient: validatedCoefficient(match.groups.coefficient)
+  };
+}
+
+function specialInitialState(rawValue: unknown): InitialStateData | undefined {
+  const text = String(rawValue).trim();
+  const oneQubitCoefficient = ONE_QUBIT_SPECIAL_STATES.get(text);
+
+  if (oneQubitCoefficient) {
+    return {
+      format: FORMAT,
+      terms: [
+        { basis: '0', coefficient: SQRT_HALF_TEXT },
+        { basis: '1', coefficient: oneQubitCoefficient }
+      ]
+    };
+  }
+
+  const bellBasis = BELL_SHORTHANDS.get(text);
+
+  if (bellBasis) {
+    return {
+      format: FORMAT,
+      terms: [{ basis: bellBasis, coefficient: '1' }]
+    };
+  }
+
+  return undefined;
+}
+
+function normalizedText(rawValue: unknown): string {
+  return restoreBellShorthands(
+    protectBellShorthands(String(rawValue))
+      .replaceAll('α', 'alpha')
+      .replaceAll('β', 'beta')
+      .trim()
+      .replace(/\s+/gu, ' ')
+      .replace(/\s*-\s*/gu, ' + -')
+      .replace(/\s*\+\s*/gu, ' + ')
+  );
+}
+
+function protectBellShorthands(text: string): string {
+  return [...BELL_PLACEHOLDERS].reduce(
+    (current, [basis, placeholder]) => current.replaceAll(`|${basis}>`, placeholder),
+    text
+  );
+}
+
+function restoreBellShorthands(text: string): string {
+  return [...BELL_PLACEHOLDERS].reduce(
+    (current, [basis, placeholder]) => current.replaceAll(placeholder, `|${basis}>`),
+    text
+  );
 }
 
 function normalizedTerms(terms: InitialStateTerm[]): InitialStateTerm[] {

--- a/test/typescript/state_command.test.ts
+++ b/test/typescript/state_command.test.ts
@@ -73,6 +73,86 @@ function captureDispatcherRun(
 }
 
 describe('state command TypeScript route', () => {
+  it('sets a ket-sum initial state without invoking Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      const circuitPath = path.join(dir, 'circuit.json');
+      const result = captureDispatcherRun(dir, ['state', 'set', 'alpha|0> + beta|1>']);
+
+      assert.equal(result.exitStatus, 0);
+      assert.equal(result.stdout, '0\n');
+      assert.equal(result.stderr, '');
+      assert.deepEqual(JSON.parse(await readFile(circuitPath, 'utf8')), {
+        qubits: 1,
+        cols: [[1]],
+        initial_state: {
+          format: 'ket_sum_v1',
+          terms: [
+            { basis: '0', coefficient: 'alpha' },
+            { basis: '1', coefficient: 'beta' }
+          ]
+        }
+      });
+    });
+  });
+
+  it('round-trips one-qubit shorthand through state show', async () => {
+    await withTempDir(async (dir) => {
+      const circuitPath = path.join(dir, 'circuit.json');
+      const setResult = captureDispatcherRun(dir, ['state', 'set', '|+>']);
+      const showResult = captureDispatcherRun(dir, ['state', 'show']);
+
+      assert.equal(setResult.exitStatus, 0);
+      assert.equal(setResult.stdout, '0\n');
+      assert.equal(setResult.stderr, '');
+      assert.equal(showResult.exitStatus, 0);
+      assert.equal(showResult.stdout, '|+>\n');
+      assert.equal(showResult.stderr, '');
+      assert.deepEqual(JSON.parse(await readFile(circuitPath, 'utf8')), {
+        qubits: 1,
+        cols: [[1]],
+        initial_state: {
+          format: 'ket_sum_v1',
+          terms: [
+            { basis: '0', coefficient: Math.sqrt(0.5).toString() },
+            { basis: '1', coefficient: Math.sqrt(0.5).toString() }
+          ]
+        }
+      });
+    });
+  });
+
+  it('sets Bell-basis shorthand with Ruby-compatible coefficient normalization', async () => {
+    await withTempDir(async (dir) => {
+      const circuitPath = path.join(dir, 'circuit.json');
+      const result = captureDispatcherRun(dir, ['state', 'set', 'α|Φ+> + β|Φ->']);
+
+      assert.equal(result.exitStatus, 0);
+      assert.equal(result.stdout, '0\n');
+      assert.equal(result.stderr, '');
+      assert.deepEqual(JSON.parse(await readFile(circuitPath, 'utf8')), {
+        qubits: 2,
+        cols: [[1, 1]],
+        initial_state: {
+          format: 'ket_sum_v1',
+          terms: [
+            { basis: 'Φ+', coefficient: 'alpha' },
+            { basis: 'Φ-', coefficient: 'beta' }
+          ]
+        }
+      });
+    });
+  });
+
+  it('rejects invalid state expressions with the Ruby oracle message', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, ['state', 'set', 'foo']);
+
+      assert.equal(result.exitStatus, 1);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, 'invalid initial state term: foo\n');
+    });
+  });
+
   it('shows a stored initial state without invoking Ruby fallback', async () => {
     await withTempDir(async (dir) => {
       await writeFile(
@@ -142,9 +222,9 @@ describe('state command TypeScript route', () => {
     });
   });
 
-  it('keeps state set on the Ruby fallback route', async () => {
+  it('honors QNI_USE_RUBY for state set', async () => {
     await withTempDir(async (dir) => {
-      const result = captureDispatcherRun(dir, ['state', 'set', '1|0>']);
+      const result = captureDispatcherRun(dir, ['state', 'set', '1|0>'], { PATH: '', QNI_USE_RUBY: '1' });
 
       assert.equal(result.exitStatus, 127);
       assert.equal(result.stdout, '');

--- a/test/typescript/state_command.test.ts
+++ b/test/typescript/state_command.test.ts
@@ -153,6 +153,32 @@ describe('state command TypeScript route', () => {
     });
   });
 
+  it('validates the existing initial state before replacing it', async () => {
+    await withTempDir(async (dir) => {
+      const circuitPath = path.join(dir, 'circuit.json');
+      const originalCircuit = `${JSON.stringify(
+        {
+          qubits: 1,
+          cols: [[1]],
+          initial_state: {
+            format: 'bad',
+            terms: [{ basis: '0', coefficient: '1' }]
+          }
+        },
+        null,
+        2
+      )}\n`;
+      await writeFile(circuitPath, originalCircuit);
+
+      const result = captureDispatcherRun(dir, ['state', 'set', 'alpha|0> + beta|1>']);
+
+      assert.equal(result.exitStatus, 1);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, 'unsupported initial state format: bad\n');
+      assert.equal(await readFile(circuitPath, 'utf8'), originalCircuit);
+    });
+  });
+
   it('shows a stored initial state without invoking Ruby fallback', async () => {
     await withTempDir(async (dir) => {
       await writeFile(

--- a/test/typescript/state_command.test.ts
+++ b/test/typescript/state_command.test.ts
@@ -153,6 +153,16 @@ describe('state command TypeScript route', () => {
     });
   });
 
+  it('rejects an empty state expression before parsing with the Ruby oracle message', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, ['state', 'set', '']);
+
+      assert.equal(result.exitStatus, 1);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, 'initial state expression is required\n');
+    });
+  });
+
   it('validates the existing initial state before replacing it', async () => {
     await withTempDir(async (dir) => {
       const circuitPath = path.join(dir, 'circuit.json');


### PR DESCRIPTION
## 概要

- `qni state set` を TypeScript route に移行しました。
- ket sum / one-qubit shorthand / Bell shorthand の parse と保存形式を Ruby oracle に合わせました。
- 既存 `initial_state` が壊れている場合も、Ruby fallback と同じ順序で検証して失敗し、`circuit.json` を保持するようにしました。
- `qni state set ""` は TypeScript route でも Ruby と同じ `initial state expression is required` を返すようにしました。
- `QNI_USE_RUBY=1` の Ruby fallback は dispatcher 経由で維持しています。

## 検証

- `npx tsc -p tsconfig.test.json && node --test tmp/typescript-tests/test/typescript/state_command.test.js`
- `npm run test:ts`
- `npm run build && npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress features/cli/state/set.feature.md features/cli/state/shorthand.feature.md features/cli/state/bell.feature.md`
- `bundle exec rake check`

## Linear

YAS-222


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * コマンドでの初期状態設定がネイティブ対応になりました（`state set`が直接動作）。
  * ケット和表記や1量子ビット記法、Bell基底短縮記法を含む文字列解析を追加しました。

* **Bug Fixes**
  * 既存の未対応な初期状態フォーマットは置換前に検査し、保持して警告されます。
  * コマンド引数の検証を強化し、空入力や不正表現を適切に拒否します。

* **Tests / Docs**
  * `state set`/`state show` のテストとCLIシナリオを拡充。コマンドトークン化の挙動も改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->