### PR TITLE
Ruby / TypeScript 性能比較 harness を追加する

### DIFF
--- a/features/cli/performance_comparison_harness.feature.md
+++ b/features/cli/performance_comparison_harness.feature.md
@@ -1,0 +1,25 @@
+# Feature: Ruby / TypeScript performance comparison harness
+
+Ruby から TypeScript へ command migration を進める前に、
+同じ input と command で wall-clock / memory regression を比較できる
+ローカル保存可能な harness が必要である。
+
+## Scenario: performance comparison harness script が存在する
+
+- Then リポジトリファイル "scripts/compare_ruby_typescript_performance.js" は存在する
+
+## Scenario: representative large-circuit workload が存在する
+
+- Then リポジトリファイル "test/fixtures/performance/large_add_h_workload.json" は存在する
+
+## Scenario: harness は JSON artifact を出力する
+
+- Then リポジトリファイル "src/performance/comparison_harness.ts" は "writePerformanceComparison" を含む
+
+## Scenario: harness は warm-up と repeat を扱う
+
+- Then リポジトリファイル "src/performance/comparison_harness.ts" は "warmUp" を含む
+
+## Scenario: harness は 20% threshold を扱う
+
+- Then リポジトリファイル "src/performance/comparison_harness.ts" は "thresholdRatio" を含む

--- a/features/cli/performance_comparison_harness.feature.md
+++ b/features/cli/performance_comparison_harness.feature.md
@@ -23,3 +23,7 @@ Ruby から TypeScript へ command migration を進める前に、
 ## Scenario: harness は 20% threshold を扱う
 
 - Then リポジトリファイル "src/performance/comparison_harness.ts" は "thresholdRatio" を含む
+
+## Scenario: harness は TypeScript 測定で Ruby override を引き継がない
+
+- Then リポジトリファイル "src/performance/comparison_harness.ts" は "withoutRubyOverrideEnvironment" を含む

--- a/scripts/compare_ruby_typescript_performance.js
+++ b/scripts/compare_ruby_typescript_performance.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const projectRoot = path.resolve(__dirname, '..');
+const harnessPath = path.join(projectRoot, 'dist', 'performance', 'comparison_harness.js');
+
+const result = spawnSync('npm', ['run', 'build'], {
+  cwd: projectRoot,
+  stdio: 'inherit'
+});
+
+if (result.status !== 0) {
+  process.exit(result.status || 1);
+}
+
+const { main } = require(harnessPath);
+
+main(process.argv.slice(2)).catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+});

--- a/src/performance/comparison_harness.ts
+++ b/src/performance/comparison_harness.ts
@@ -291,6 +291,10 @@ function residentMemoryBytes(pid: number | undefined): number {
     return 0;
   }
 
+  if (process.platform !== 'linux') {
+    return psResidentMemoryBytes(pid);
+  }
+
   try {
     const status = readFileSync(`/proc/${pid}/status`, 'utf8');
     const peak = status.match(/^VmHWM:\s+(\d+)\s+kB/mu);
@@ -301,6 +305,20 @@ function residentMemoryBytes(pid: number | undefined): number {
   } catch {
     return 0;
   }
+}
+
+function psResidentMemoryBytes(pid: number): number {
+  const result = spawnSync('ps', ['-o', 'rss=', '-p', String(pid)], {
+    encoding: 'utf8'
+  });
+
+  if (result.status !== 0) {
+    return 0;
+  }
+
+  const kilobytes = Number(result.stdout.trim());
+
+  return Number.isFinite(kilobytes) ? kilobytes * 1024 : 0;
 }
 
 function compareImplementations(
@@ -383,7 +401,9 @@ function qniCommandLine(command: readonly string[]): string {
 
 function ensureCommandSucceeded(commandLine: string, run: MeasuredRun): void {
   if (run.exit_status !== 0) {
-    throw new Error(`command failed (${run.exit_status}): ${commandLine}`);
+    const reason = run.signal === null ? `exit ${run.exit_status}` : `killed by signal ${run.signal}`;
+
+    throw new Error(`command failed (${reason}): ${commandLine}`);
   }
 }
 

--- a/src/performance/comparison_harness.ts
+++ b/src/performance/comparison_harness.ts
@@ -93,14 +93,18 @@ const DEFAULT_REPEAT = 5;
 const DEFAULT_THRESHOLD_RATIO = 1.2;
 const DEFAULT_WARM_UP = 1;
 const IDENTITY = 1;
+const MEMORY_SAMPLING_INTERVAL_MS = process.platform === 'linux' ? 5 : 50;
 
 export async function writePerformanceComparison(argv: readonly string[]): Promise<PerformanceReport> {
   const args = parseHarnessArgs(argv);
   ensureTypeScriptDispatcher(args.projectRoot);
 
-  const workloads = await Promise.all(
-    args.workloads.map(async (workloadPath) => runWorkload(workloadPath, args))
-  );
+  const workloads: WorkloadReport[] = [];
+
+  for (const workloadPath of args.workloads) {
+    workloads.push(await runWorkload(workloadPath, args));
+  }
+
   const investigations = workloads
     .filter((workload) => workload.comparison.investigation_required)
     .map((workload) => workload.name);
@@ -258,7 +262,7 @@ function runMeasuredCommand(command: CommandSpec, cwd: string): Promise<Measured
     const sampleMemory = (): void => {
       peakMemoryBytes = Math.max(peakMemoryBytes, residentMemoryBytes(child.pid));
     };
-    const sampler = setInterval(sampleMemory, 5);
+    const sampler = setInterval(sampleMemory, MEMORY_SAMPLING_INTERVAL_MS);
 
     sampler.unref();
     sampleMemory();
@@ -348,8 +352,21 @@ function compareImplementations(
 
 function parseWorkload(json: string, workloadPath: string): WorkloadFile {
   const parsed = JSON.parse(json) as Partial<WorkloadFile>;
+  const input = parsed.input;
 
-  if (!parsed.name || !Array.isArray(parsed.command) || parsed.input?.kind !== 'generated-circuit') {
+  if (
+    !parsed.name ||
+    !Array.isArray(parsed.command) ||
+    parsed.command.some((part) => typeof part !== 'string') ||
+    input?.kind !== 'generated-circuit' ||
+    !Number.isInteger(input.depth) ||
+    input.depth <= 0 ||
+    !Number.isInteger(input.qubits) ||
+    input.qubits <= 0 ||
+    !Array.isArray(input.pattern) ||
+    input.pattern.length === 0 ||
+    input.pattern.some((gate) => typeof gate !== 'string')
+  ) {
     throw new Error(`invalid performance workload: ${workloadPath}`);
   }
 

--- a/src/performance/comparison_harness.ts
+++ b/src/performance/comparison_harness.ts
@@ -1,0 +1,478 @@
+import { spawn, spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+interface GeneratedCircuitInput {
+  readonly depth: number;
+  readonly kind: 'generated-circuit';
+  readonly pattern: readonly string[];
+  readonly qubits: number;
+}
+
+interface WorkloadFile {
+  readonly command: readonly string[];
+  readonly input: GeneratedCircuitInput;
+  readonly name: string;
+}
+
+interface HarnessArgs {
+  readonly output: string;
+  readonly projectRoot: string;
+  readonly repeat: number;
+  readonly thresholdRatio: number;
+  readonly warmUp: number;
+  readonly workloads: readonly string[];
+}
+
+interface MeasuredRun {
+  readonly exit_status: number | null;
+  readonly peak_memory_bytes: number;
+  readonly signal: NodeJS.Signals | null;
+  readonly wall_clock_ms: number;
+}
+
+interface ImplementationReport {
+  readonly command: string;
+  readonly median_peak_memory_bytes: number;
+  readonly median_wall_clock_ms: number;
+  readonly runs: readonly MeasuredRun[];
+}
+
+interface WorkloadReport {
+  readonly command: string;
+  readonly comparison: {
+    readonly investigation_required: boolean;
+    readonly peak_memory_ratio: number | null;
+    readonly reasons: readonly string[];
+    readonly wall_clock_ratio: number | null;
+  };
+  readonly implementations: {
+    readonly ruby: ImplementationReport;
+    readonly typescript: ImplementationReport;
+  };
+  readonly input_size_bytes: number;
+  readonly name: string;
+}
+
+interface PerformanceReport {
+  readonly commit_sha: string;
+  readonly generated_at: string;
+  readonly repeat: number;
+  readonly runtime_versions: {
+    readonly node: string;
+    readonly ruby: string;
+    readonly typescript: string;
+  };
+  readonly schema_version: 1;
+  readonly summary: {
+    readonly investigation_required: boolean;
+    readonly investigations: readonly string[];
+  };
+  readonly threshold_ratio: number;
+  readonly warm_up: number;
+  readonly workloads: readonly WorkloadReport[];
+}
+
+interface CommandSpec {
+  readonly args: readonly string[];
+  readonly command: string;
+  readonly commandLine: string;
+  readonly env: NodeJS.ProcessEnv;
+}
+
+const DEFAULT_REPEAT = 5;
+const DEFAULT_THRESHOLD_RATIO = 1.2;
+const DEFAULT_WARM_UP = 1;
+const IDENTITY = 1;
+
+export async function writePerformanceComparison(argv: readonly string[]): Promise<PerformanceReport> {
+  const args = parseHarnessArgs(argv);
+  ensureTypeScriptDispatcher(args.projectRoot);
+
+  const workloads = await Promise.all(
+    args.workloads.map(async (workloadPath) => runWorkload(workloadPath, args))
+  );
+  const investigations = workloads
+    .filter((workload) => workload.comparison.investigation_required)
+    .map((workload) => workload.name);
+  const report: PerformanceReport = {
+    commit_sha: commandOutput('git', ['rev-parse', 'HEAD'], args.projectRoot),
+    generated_at: new Date().toISOString(),
+    repeat: args.repeat,
+    runtime_versions: {
+      node: process.version,
+      ruby: commandOutput('ruby', ['--version'], args.projectRoot),
+      typescript: commandOutput('npx', ['tsc', '--version'], args.projectRoot)
+    },
+    schema_version: 1,
+    summary: {
+      investigation_required: investigations.length > 0,
+      investigations
+    },
+    threshold_ratio: args.thresholdRatio,
+    warm_up: args.warmUp,
+    workloads
+  };
+
+  mkdirSync(path.dirname(args.output), { recursive: true });
+  writeFileSync(args.output, `${JSON.stringify(report, null, 2)}\n`);
+  return report;
+}
+
+export async function main(argv: readonly string[]): Promise<void> {
+  const report = await writePerformanceComparison(argv);
+  const status = report.summary.investigation_required ? 'investigation-required' : 'ok';
+
+  process.stdout.write(`performance comparison ${status}: ${report.workloads.length} workload(s)\n`);
+}
+
+function parseHarnessArgs(argv: readonly string[]): HarnessArgs {
+  const workloads: string[] = [];
+  let output = 'tmp/ruby_typescript_performance_comparison.json';
+  let projectRoot = process.cwd();
+  let repeat = DEFAULT_REPEAT;
+  let thresholdRatio = DEFAULT_THRESHOLD_RATIO;
+  let warmUp = DEFAULT_WARM_UP;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    switch (arg) {
+      case '--workload':
+        workloads.push(requiredValue(argv, index, arg));
+        index += 1;
+        break;
+      case '--output':
+        output = requiredValue(argv, index, arg);
+        index += 1;
+        break;
+      case '--project-root':
+        projectRoot = requiredValue(argv, index, arg);
+        index += 1;
+        break;
+      case '--repeat':
+        repeat = positiveInteger(requiredValue(argv, index, arg), arg);
+        index += 1;
+        break;
+      case '--threshold-ratio':
+        thresholdRatio = positiveNumber(requiredValue(argv, index, arg), arg);
+        index += 1;
+        break;
+      case '--warm-up':
+        warmUp = nonNegativeInteger(requiredValue(argv, index, arg), arg);
+        index += 1;
+        break;
+      default:
+        throw new Error(`unknown option: ${arg}`);
+    }
+  }
+
+  if (workloads.length === 0) {
+    workloads.push('test/fixtures/performance/large_add_h_workload.json');
+  }
+
+  return {
+    output: path.resolve(projectRoot, output),
+    projectRoot: path.resolve(projectRoot),
+    repeat,
+    thresholdRatio,
+    warmUp,
+    workloads: workloads.map((workload) => path.resolve(projectRoot, workload))
+  };
+}
+
+async function runWorkload(workloadPath: string, args: HarnessArgs): Promise<WorkloadReport> {
+  const workload = parseWorkload(await readFile(workloadPath, 'utf8'), workloadPath);
+  const circuitJson = `${JSON.stringify(generatedCircuit(workload.input), null, 2)}\n`;
+  const implementations = {
+    ruby: await runImplementation(rubyCommand(workload, args.projectRoot), circuitJson, args),
+    typescript: await runImplementation(typeScriptCommand(workload, args.projectRoot), circuitJson, args)
+  };
+
+  return {
+    command: qniCommandLine(workload.command),
+    comparison: compareImplementations(implementations.ruby, implementations.typescript, args.thresholdRatio),
+    implementations,
+    input_size_bytes: Buffer.byteLength(circuitJson),
+    name: workload.name
+  };
+}
+
+async function runImplementation(
+  command: CommandSpec,
+  circuitJson: string,
+  args: HarnessArgs
+): Promise<ImplementationReport> {
+  for (let index = 0; index < args.warmUp; index += 1) {
+    const warmUp = await runMeasuredQni(command, circuitJson);
+    ensureCommandSucceeded(command.commandLine, warmUp);
+  }
+
+  const runs: MeasuredRun[] = [];
+
+  for (let index = 0; index < args.repeat; index += 1) {
+    const run = await runMeasuredQni(command, circuitJson);
+
+    ensureCommandSucceeded(command.commandLine, run);
+    runs.push(run);
+  }
+
+  return {
+    command: command.commandLine,
+    median_peak_memory_bytes: median(runs.map((run) => run.peak_memory_bytes)),
+    median_wall_clock_ms: median(runs.map((run) => run.wall_clock_ms)),
+    runs
+  };
+}
+
+async function runMeasuredQni(command: CommandSpec, circuitJson: string): Promise<MeasuredRun> {
+  const cwd = mkdtempSync(path.join(tmpdir(), 'qni-perf-workload-'));
+
+  try {
+    writeFileSync(path.join(cwd, 'circuit.json'), circuitJson);
+    return await runMeasuredCommand(command, cwd);
+  } finally {
+    rmSync(cwd, { force: true, recursive: true });
+  }
+}
+
+function runMeasuredCommand(command: CommandSpec, cwd: string): Promise<MeasuredRun> {
+  return new Promise((resolve, reject) => {
+    const startedAt = process.hrtime.bigint();
+    let peakMemoryBytes = 0;
+    const child = spawn(command.command, [...command.args], {
+      cwd,
+      env: command.env,
+      stdio: ['ignore', 'ignore', 'pipe']
+    });
+    const stderrChunks: Buffer[] = [];
+    const sampleMemory = (): void => {
+      peakMemoryBytes = Math.max(peakMemoryBytes, residentMemoryBytes(child.pid));
+    };
+    const sampler = setInterval(sampleMemory, 5);
+
+    sampler.unref();
+    sampleMemory();
+    child.stderr.on('data', (chunk: Buffer) => stderrChunks.push(chunk));
+    child.once('error', (error) => {
+      clearInterval(sampler);
+      reject(error);
+    });
+    child.once('close', (exitStatus, signal) => {
+      clearInterval(sampler);
+      const finishedAt = process.hrtime.bigint();
+      const wallClockMs = Number(finishedAt - startedAt) / 1_000_000;
+
+      if (exitStatus !== 0) {
+        process.stderr.write(Buffer.concat(stderrChunks).toString('utf8'));
+      }
+
+      resolve({
+        exit_status: exitStatus,
+        peak_memory_bytes: peakMemoryBytes,
+        signal,
+        wall_clock_ms: wallClockMs
+      });
+    });
+  });
+}
+
+function residentMemoryBytes(pid: number | undefined): number {
+  if (pid === undefined) {
+    return 0;
+  }
+
+  try {
+    const status = readFileSync(`/proc/${pid}/status`, 'utf8');
+    const peak = status.match(/^VmHWM:\s+(\d+)\s+kB/mu);
+    const current = status.match(/^VmRSS:\s+(\d+)\s+kB/mu);
+    const kilobytes = Number((peak ?? current)?.[1] ?? '0');
+
+    return kilobytes * 1024;
+  } catch {
+    return 0;
+  }
+}
+
+function compareImplementations(
+  ruby: ImplementationReport,
+  typescript: ImplementationReport,
+  thresholdRatio: number
+): WorkloadReport['comparison'] {
+  const wallClockRatio = ratio(typescript.median_wall_clock_ms, ruby.median_wall_clock_ms);
+  const peakMemoryRatio = ratio(typescript.median_peak_memory_bytes, ruby.median_peak_memory_bytes);
+  const reasons: string[] = [];
+
+  if (wallClockRatio !== null && wallClockRatio > thresholdRatio) {
+    reasons.push('wall-clock');
+  }
+
+  if (peakMemoryRatio !== null && peakMemoryRatio > thresholdRatio) {
+    reasons.push('peak-memory');
+  }
+
+  return {
+    investigation_required: reasons.length > 0,
+    peak_memory_ratio: peakMemoryRatio,
+    reasons,
+    wall_clock_ratio: wallClockRatio
+  };
+}
+
+function parseWorkload(json: string, workloadPath: string): WorkloadFile {
+  const parsed = JSON.parse(json) as Partial<WorkloadFile>;
+
+  if (!parsed.name || !Array.isArray(parsed.command) || parsed.input?.kind !== 'generated-circuit') {
+    throw new Error(`invalid performance workload: ${workloadPath}`);
+  }
+
+  return parsed as WorkloadFile;
+}
+
+function generatedCircuit(input: GeneratedCircuitInput): Record<string, unknown> {
+  return {
+    cols: Array.from({ length: input.depth }, (_, step) => (
+      Array.from({ length: input.qubits }, (_, qubit) => gateAt(input.pattern, step, qubit))
+    )),
+    qubits: input.qubits
+  };
+}
+
+function gateAt(pattern: readonly string[], step: number, qubit: number): string | number {
+  const gate = pattern[(step + qubit) % pattern.length];
+
+  return gate === '1' ? IDENTITY : gate;
+}
+
+function rubyCommand(workload: WorkloadFile, projectRoot: string): CommandSpec {
+  return {
+    args: ['exec', path.join(projectRoot, 'bin', 'qni'), ...workload.command],
+    command: 'bundle',
+    commandLine: ['bundle', 'exec', 'bin/qni', ...workload.command].join(' '),
+    env: {
+      ...process.env,
+      BUNDLE_GEMFILE: path.join(projectRoot, 'Gemfile')
+    }
+  };
+}
+
+function typeScriptCommand(workload: WorkloadFile, projectRoot: string): CommandSpec {
+  return {
+    args: [path.join(projectRoot, 'dist', 'bin', 'qni.js'), ...workload.command],
+    command: process.execPath,
+    commandLine: ['node', 'dist/bin/qni.js', ...workload.command].join(' '),
+    env: {
+      ...process.env,
+      BUNDLE_GEMFILE: path.join(projectRoot, 'Gemfile')
+    }
+  };
+}
+
+function qniCommandLine(command: readonly string[]): string {
+  return ['qni', ...command].join(' ');
+}
+
+function ensureCommandSucceeded(commandLine: string, run: MeasuredRun): void {
+  if (run.exit_status !== 0) {
+    throw new Error(`command failed (${run.exit_status}): ${commandLine}`);
+  }
+}
+
+function ensureTypeScriptDispatcher(projectRoot: string): void {
+  const dispatcherPath = path.join(projectRoot, 'dist', 'bin', 'qni.js');
+
+  if (existsSync(dispatcherPath)) {
+    return;
+  }
+
+  const result = spawnSync('npm', ['run', 'build'], {
+    cwd: projectRoot,
+    encoding: 'utf8',
+    stdio: 'inherit'
+  });
+
+  if (result.status !== 0) {
+    throw new Error('failed to build TypeScript dispatcher');
+  }
+}
+
+function commandOutput(command: string, args: readonly string[], cwd: string): string {
+  const result = spawnSync(command, [...args], {
+    cwd,
+    encoding: 'utf8'
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`failed to run ${command} ${args.join(' ')}`);
+  }
+
+  return result.stdout.trim();
+}
+
+function median(values: readonly number[]): number {
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+
+  if (sorted.length % 2 === 1) {
+    return sorted[middle] ?? 0;
+  }
+
+  return ((sorted[middle - 1] ?? 0) + (sorted[middle] ?? 0)) / 2;
+}
+
+function ratio(numerator: number, denominator: number): number | null {
+  if (denominator === 0) {
+    return null;
+  }
+
+  return Number((numerator / denominator).toFixed(3));
+}
+
+function positiveInteger(value: string, option: string): number {
+  const parsed = nonNegativeInteger(value, option);
+
+  if (parsed === 0) {
+    throw new Error(`${option} must be greater than zero`);
+  }
+
+  return parsed;
+}
+
+function nonNegativeInteger(value: string, option: string): number {
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${option} must be a non-negative integer`);
+  }
+
+  return parsed;
+}
+
+function positiveNumber(value: string, option: string): number {
+  const parsed = Number(value);
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${option} must be greater than zero`);
+  }
+
+  return parsed;
+}
+
+function requiredValue(argv: readonly string[], index: number, option: string): string {
+  const value = argv[index + 1];
+
+  if (!value) {
+    throw new Error(`${option} requires a value`);
+  }
+
+  return value;
+}

--- a/src/performance/comparison_harness.ts
+++ b/src/performance/comparison_harness.ts
@@ -405,8 +405,15 @@ function typeScriptCommand(workload: WorkloadFile, projectRoot: string): Command
     args: [path.join(projectRoot, 'dist', 'bin', 'qni.js'), ...workload.command],
     command: process.execPath,
     commandLine: ['node', 'dist/bin/qni.js', ...workload.command].join(' '),
-    env: process.env
+    env: withoutRubyOverrideEnvironment()
   };
+}
+
+function withoutRubyOverrideEnvironment(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+
+  delete env.QNI_USE_RUBY;
+  return env;
 }
 
 function qniCommandLine(command: readonly string[]): string {

--- a/src/performance/comparison_harness.ts
+++ b/src/performance/comparison_harness.ts
@@ -388,10 +388,7 @@ function typeScriptCommand(workload: WorkloadFile, projectRoot: string): Command
     args: [path.join(projectRoot, 'dist', 'bin', 'qni.js'), ...workload.command],
     command: process.execPath,
     commandLine: ['node', 'dist/bin/qni.js', ...workload.command].join(' '),
-    env: {
-      ...process.env,
-      BUNDLE_GEMFILE: path.join(projectRoot, 'Gemfile')
-    }
+    env: process.env
   };
 }
 

--- a/test/fixtures/performance/large_add_h_workload.json
+++ b/test/fixtures/performance/large_add_h_workload.json
@@ -1,0 +1,10 @@
+{
+  "name": "large-add-h-8q-160steps",
+  "command": ["add", "H", "--qubit", "0", "--step", "160"],
+  "input": {
+    "kind": "generated-circuit",
+    "qubits": 8,
+    "depth": 160,
+    "pattern": ["H", "X", "Y", "Z", "S", "T", "1", "1"]
+  }
+}

--- a/test/typescript/performance_comparison_harness.test.ts
+++ b/test/typescript/performance_comparison_harness.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -64,6 +64,69 @@ describe('Ruby / TypeScript performance comparison harness', () => {
       assert.ok(workload.implementations.ruby.median_peak_memory_bytes > 0);
       assert.ok(workload.implementations.typescript.median_peak_memory_bytes > 0);
       assert.equal(typeof workload.comparison.investigation_required, 'boolean');
+    });
+  });
+
+  it('does not let QNI_USE_RUBY force the TypeScript measurement through Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      const fakeBinDir = path.join(dir, 'bin');
+      const fakeBundlePath = path.join(fakeBinDir, 'bundle');
+      const bundleLogPath = path.join(dir, 'bundle-calls.log');
+      const outputPath = path.join(dir, 'comparison.json');
+      const realBundle = spawnSync('which', ['bundle'], {
+        encoding: 'utf8',
+        timeout: 10_000
+      });
+
+      assert.equal(realBundle.error, undefined, realBundle.error?.message);
+      assert.equal(realBundle.status, 0, realBundle.stderr);
+      await mkdir(fakeBinDir);
+      await writeFile(
+        fakeBundlePath,
+        [
+          '#!/bin/sh',
+          'printf "%s\\n" "$*" >> "$QNI_FAKE_BUNDLE_LOG"',
+          'exec "$QNI_REAL_BUNDLE" "$@"',
+          ''
+        ].join('\n')
+      );
+      await chmod(fakeBundlePath, 0o755);
+
+      const result = spawnSync(
+        process.execPath,
+        [
+          'scripts/compare_ruby_typescript_performance.js',
+          '--workload',
+          'test/fixtures/performance/large_add_h_workload.json',
+          '--repeat',
+          '1',
+          '--warm-up',
+          '0',
+          '--output',
+          outputPath
+        ],
+        {
+          cwd: process.cwd(),
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            PATH: `${fakeBinDir}:${process.env.PATH ?? ''}`,
+            QNI_FAKE_BUNDLE_LOG: bundleLogPath,
+            QNI_REAL_BUNDLE: realBundle.stdout.trim(),
+            QNI_USE_RUBY: '1'
+          },
+          timeout: 120_000
+        }
+      );
+
+      assert.equal(result.error, undefined, result.error?.message);
+      assert.equal(result.signal, null, `script terminated with signal ${result.signal}`);
+      assert.equal(result.status, 0, result.stderr);
+
+      const bundleCalls = (await readFile(bundleLogPath, 'utf8')).trim().split('\n');
+
+      assert.equal(bundleCalls.length, 1);
+      assert.equal(bundleCalls[0], `exec ${path.join(process.cwd(), 'bin', 'qni')} add H --qubit 0 --step 160`);
     });
   });
 });

--- a/test/typescript/performance_comparison_harness.test.ts
+++ b/test/typescript/performance_comparison_harness.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { describe, it } from 'node:test';
+
+async function withTempDir<T>(callback: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'qni-cli-perf-test-'));
+
+  try {
+    return await callback(dir);
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+}
+
+describe('Ruby / TypeScript performance comparison harness', () => {
+  it('writes a JSON artifact comparing the same workload through Ruby and TypeScript', async () => {
+    await withTempDir(async (dir) => {
+      const outputPath = path.join(dir, 'comparison.json');
+      const result = spawnSync(
+        process.execPath,
+        [
+          'scripts/compare_ruby_typescript_performance.js',
+          '--workload',
+          'test/fixtures/performance/large_add_h_workload.json',
+          '--repeat',
+          '1',
+          '--warm-up',
+          '0',
+          '--output',
+          outputPath
+        ],
+        {
+          cwd: process.cwd(),
+          encoding: 'utf8'
+        }
+      );
+
+      assert.equal(result.status, 0, result.stderr);
+
+      const report = JSON.parse(await readFile(outputPath, 'utf8'));
+      const workload = report.workloads[0];
+
+      assert.equal(report.schema_version, 1);
+      assert.equal(report.repeat, 1);
+      assert.equal(report.warm_up, 0);
+      assert.equal(report.threshold_ratio, 1.2);
+      assert.match(report.commit_sha, /^[0-9a-f]{7,40}$/u);
+      assert.match(report.runtime_versions.node, /^v/u);
+      assert.match(report.runtime_versions.ruby, /^ruby /u);
+      assert.match(report.runtime_versions.typescript, /^Version /u);
+      assert.equal(workload.name, 'large-add-h-8q-160steps');
+      assert.equal(workload.command, 'qni add H --qubit 0 --step 160');
+      assert.ok(workload.input_size_bytes > 1_000);
+      assert.equal(workload.implementations.ruby.runs.length, 1);
+      assert.equal(workload.implementations.typescript.runs.length, 1);
+      assert.ok(workload.implementations.ruby.median_wall_clock_ms >= 0);
+      assert.ok(workload.implementations.typescript.median_wall_clock_ms >= 0);
+      assert.ok(workload.implementations.ruby.median_peak_memory_bytes > 0);
+      assert.ok(workload.implementations.typescript.median_peak_memory_bytes > 0);
+      assert.equal(typeof workload.comparison.investigation_required, 'boolean');
+    });
+  });
+});

--- a/test/typescript/performance_comparison_harness.test.ts
+++ b/test/typescript/performance_comparison_harness.test.ts
@@ -34,10 +34,13 @@ describe('Ruby / TypeScript performance comparison harness', () => {
         ],
         {
           cwd: process.cwd(),
-          encoding: 'utf8'
+          encoding: 'utf8',
+          timeout: 120_000
         }
       );
 
+      assert.equal(result.error, undefined, result.error?.message);
+      assert.equal(result.signal, null, `script terminated with signal ${result.signal}`);
       assert.equal(result.status, 0, result.stderr);
 
       const report = JSON.parse(await readFile(outputPath, 'utf8'));


### PR DESCRIPTION
## 概要

- Ruby 実装と TypeScript dispatcher を同じ generated large-circuit input で実行する performance comparison harness を追加しました。
- `large-add-h-8q-160steps` workload を追加し、wall-clock / peak memory / command / input size / commit SHA / runtime versions / warm-up / repeat / 20% threshold 判定を JSON artifact に記録します。
- Linux の `/proc` sampler に加えて非 Linux では `ps` fallback を使い、signal 終了時の diagnostics と test timeout も明示しました。
- CodeRabbit feedback を反映し、複数 workload は逐次実行、非 Linux の memory sampling は 50ms、workload schema validation は command / input まで検証するようにしました。
- 親環境に `QNI_USE_RUBY=1` が残っていても TypeScript 側測定が Ruby fallback に強制されないよう、TypeScript command の環境から `QNI_USE_RUBY` だけを除去しました。
- feature-first の Cucumber coverage と TypeScript の artifact / Ruby override 回帰テストを追加しました。

## Linear

- YAS-223: https://linear.app/yasuhito/issue/YAS-223/ruby-typescript-performance-comparison-harness-を追加する

## 検証

- `npm run test:ts`
- `npm run build && npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress "features/cli/performance_comparison_harness.feature.md"`
- `node scripts/compare_ruby_typescript_performance.js --workload test/fixtures/performance/large_add_h_workload.json --warm-up 1 --repeat 2 --output tmp/yas-223-performance-comparison.json`
- `bundle exec rake check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * RubyとTypeScript実装間のパフォーマンス比較ツールを追加。壁時計時間とピークメモリ使用量を測定し、閾値に基づいて差分を検出。JSONレポートとして結果を出力。

* **Tests**
  * パフォーマンス比較ハーネスのテストと検証シナリオを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->