### PR TITLE
numeric run と expect を TypeScript へ移行する

### DIFF
--- a/features/cli/run/initial_states.feature.md
+++ b/features/cli/run/initial_states.feature.md
@@ -17,3 +17,38 @@ qni run が変数解決済みの初期状態を使うことを確認したい。
   ```text
   0.8,0.6
   ```
+
+## Scenario: qni run は短い initial_state を |0> suffix qubits で拡張して数値実行する
+
+- Given 次の circuit.json がある:
+
+  ```json
+  {
+    "qubits": 2,
+    "cols": [
+      [
+        1,
+        "X"
+      ]
+    ],
+    "initial_state": {
+      "format": "ket_sum_v1",
+      "terms": [
+        {
+          "basis": "0",
+          "coefficient": "0.7071067811865476"
+        },
+        {
+          "basis": "1",
+          "coefficient": "0.7071067811865476"
+        }
+      ]
+    }
+  }
+  ```
+- When "qni run" を実行
+- Then 標準出力:
+
+  ```text
+  0.0,0.7071067811865476,0.0,0.7071067811865476
+  ```

--- a/lib/qni/simulator.rb
+++ b/lib/qni/simulator.rb
@@ -83,13 +83,32 @@ module Qni
     end
 
     def starting_state_vector
-      initial_state = data['initial_state']
-      return StateVector.zero(qubits) unless initial_state
+      initial_state_data = data['initial_state']
+      return StateVector.zero(qubits) unless initial_state_data
 
+      initial_state = InitialState.from_h(initial_state_data)
       StateVector.new(
         qubits:,
-        amplitudes: InitialState.from_h(initial_state).resolve_numeric(variables)
+        amplitudes: expanded_initial_amplitudes(initial_state)
       )
+    end
+
+    def expanded_initial_amplitudes(initial_state)
+      initial_qubits = initial_state.qubits
+      raise Error, 'initial state qubit count cannot exceed circuit qubit count' if initial_qubits > qubits
+
+      amplitudes = initial_state.resolve_numeric(variables)
+      return amplitudes if initial_qubits == qubits
+
+      expand_initial_amplitudes(amplitudes, suffix_states: 2**(qubits - initial_qubits))
+    end
+
+    def expand_initial_amplitudes(amplitudes, suffix_states:)
+      expanded = Array.new(2**qubits, 0.0)
+      amplitudes.each_with_index do |amplitude, index|
+        expanded[index * suffix_states] = amplitude
+      end
+      expanded
     end
 
     def apply_col(state_vector, col)

--- a/src/angle_expression.ts
+++ b/src/angle_expression.ts
@@ -13,6 +13,7 @@ export function validAngleIdentifier(value: string): boolean {
 
 interface AngleTerm {
   readonly concrete: boolean;
+  readonly radians: (variables: Readonly<Record<string, string>>) => number;
   readonly text: string;
 }
 
@@ -25,6 +26,10 @@ export class AngleExpression {
 
   concrete(): boolean {
     return this.parse().concrete;
+  }
+
+  radians(variables: Readonly<Record<string, string>> = {}): number {
+    return this.parse().radians(variables);
   }
 
   toString(): string {
@@ -71,7 +76,7 @@ function parseNumericLiteral(value: string): AngleTerm | undefined {
     return undefined;
   }
 
-  return { concrete: true, text: value };
+  return { concrete: true, radians: () => Number(value), text: value };
 }
 
 function parseSignedIdentifier(value: string): AngleTerm | undefined {
@@ -81,10 +86,12 @@ function parseSignedIdentifier(value: string): AngleTerm | undefined {
     return undefined;
   }
 
-  const identifier = match.groups.identifier ?? '';
+  const groups = match.groups;
+  const identifier = groups.identifier ?? '';
   return {
     concrete: false,
-    text: match.groups.sign === '-' ? `-${identifier}` : identifier
+    radians: (variables) => variableRadians(identifier, variables) * (groups.sign === '-' ? -1 : 1),
+    text: groups.sign === '-' ? `-${identifier}` : identifier
   };
 }
 
@@ -93,7 +100,7 @@ function parseVariableReference(value: string): AngleTerm | undefined {
     return undefined;
   }
 
-  return { concrete: false, text: value };
+  return { concrete: false, radians: (variables) => variableRadians(value, variables), text: value };
 }
 
 function parsePiTerm(value: string): AngleTerm | undefined {
@@ -111,6 +118,7 @@ function parsePiTerm(value: string): AngleTerm | undefined {
 
   return {
     concrete: true,
+    radians: () => signValue(sign) * Number(coefficient) * Math.PI / Number(denominator),
     text: `${sign}${coefficientPrefix}π${denominatorSuffix}`
   };
 }
@@ -127,6 +135,27 @@ function parseProduct(value: string): AngleTerm | undefined {
 
   return {
     concrete: inner.concrete,
+    radians: (variables) => Number(coefficient) * inner.radians(variables),
     text: `${coefficient}*${inner.text}`
   };
+}
+
+function variableRadians(name: string, variables: Readonly<Record<string, string>>): number {
+  const resolvedValue = variables[name];
+
+  if (resolvedValue === undefined) {
+    throw new AngleExpressionError(`unresolved angle variable: ${name}`);
+  }
+
+  const angle = new AngleExpression(resolvedValue);
+
+  if (!angle.concrete()) {
+    throw new AngleExpressionError(`variable value must be concrete: ${name}`);
+  }
+
+  return angle.radians();
+}
+
+function signValue(sign: string): number {
+  return sign === '-' ? -1 : 1;
 }

--- a/src/circuit_file.ts
+++ b/src/circuit_file.ts
@@ -15,7 +15,7 @@ const CONTROL_SYMBOL = '•';
 const EMPTY_SLOT = 1;
 const SWAP_SYMBOL = 'Swap';
 
-interface CircuitData {
+export interface CircuitData {
   cols: unknown[][];
   initial_state?: unknown;
   qubits: number;
@@ -39,6 +39,10 @@ export class CircuitFile {
     }
 
     return false;
+  }
+
+  load(): CircuitData {
+    return this.requiredCircuit();
   }
 
   clearInitialState(): boolean {

--- a/src/commands/expect_command.ts
+++ b/src/commands/expect_command.ts
@@ -1,0 +1,28 @@
+import { currentCircuitFile } from '../circuit_file';
+import type { CommandHandlerContext } from '../dispatcher';
+import { runRubyFallbackSync } from '../process/process_compatibility';
+import { Simulator } from '../simulator';
+
+export function runExpectCommand(argv: string[], context: CommandHandlerContext): number {
+  if (!typeScriptExpect(argv)) {
+    return runRubyFallbackSync({
+      argv,
+      cwd: context.cwd,
+      env: context.env,
+      projectRoot: context.projectRoot
+    }).exitStatus ?? 1;
+  }
+
+  try {
+    const pauliStrings = argv.slice(1).map((pauliString) => pauliString.toUpperCase());
+    process.stdout.write(`${new Simulator(currentCircuitFile(context.cwd).load()).renderExpectationValues(pauliStrings)}\n`);
+    return 0;
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}
+
+function typeScriptExpect(argv: readonly string[]): boolean {
+  return argv.length > 1 && argv[0] === 'expect' && argv.slice(1).every((arg) => !arg.startsWith('-'));
+}

--- a/src/commands/run_command.ts
+++ b/src/commands/run_command.ts
@@ -1,0 +1,27 @@
+import { currentCircuitFile } from '../circuit_file';
+import type { CommandHandlerContext } from '../dispatcher';
+import { runRubyFallbackSync } from '../process/process_compatibility';
+import { Simulator } from '../simulator';
+
+export function runRunCommand(argv: string[], context: CommandHandlerContext): number {
+  if (!typeScriptRun(argv)) {
+    return runRubyFallbackSync({
+      argv,
+      cwd: context.cwd,
+      env: context.env,
+      projectRoot: context.projectRoot
+    }).exitStatus ?? 1;
+  }
+
+  try {
+    process.stdout.write(`${new Simulator(currentCircuitFile(context.cwd).load()).renderStateVector()}\n`);
+    return 0;
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}
+
+function typeScriptRun(argv: readonly string[]): boolean {
+  return argv.length === 1 && argv[0] === 'run';
+}

--- a/src/complex.ts
+++ b/src/complex.ts
@@ -1,0 +1,40 @@
+export class Complex {
+  readonly imaginary: number;
+  readonly real: number;
+
+  constructor(real: number, imaginary = 0) {
+    this.real = real;
+    this.imaginary = imaginary;
+  }
+
+  add(other: Complex): Complex {
+    return new Complex(this.real + other.real, this.imaginary + other.imaginary);
+  }
+
+  subtract(other: Complex): Complex {
+    return new Complex(this.real - other.real, this.imaginary - other.imaginary);
+  }
+
+  multiply(other: Complex | number): Complex {
+    if (typeof other === 'number') {
+      return new Complex(this.real * other, this.imaginary * other);
+    }
+
+    return new Complex(
+      (this.real * other.real) - (this.imaginary * other.imaginary),
+      (this.real * other.imaginary) + (this.imaginary * other.real)
+    );
+  }
+
+  conjugate(): Complex {
+    return new Complex(this.real, -this.imaginary);
+  }
+
+  absSquared(): number {
+    return (this.real * this.real) + (this.imaginary * this.imaginary);
+  }
+}
+
+export function complex(value: number | Complex): Complex {
+  return value instanceof Complex ? value : new Complex(value);
+}

--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -4,7 +4,9 @@ import {
 } from './process/process_compatibility';
 import { runAddCommand } from './commands/add_command';
 import { runGateCommand } from './commands/gate_command';
+import { runExpectCommand } from './commands/expect_command';
 import { runRemoveCommand } from './commands/remove_command';
+import { runRunCommand } from './commands/run_command';
 import { runStateCommand } from './commands/state_command';
 import { runVariableCommand } from './commands/variable_command';
 
@@ -30,8 +32,10 @@ interface CommandRoute {
 
 const TYPESCRIPT_ROUTES = new Map<string, CommandHandler>([
   ['add', runAddCommand],
+  ['expect', runExpectCommand],
   ['gate', runGateCommand],
   ['rm', runRemoveCommand],
+  ['run', runRunCommand],
   ['state', runStateCommand],
   ['variable', runVariableCommand]
 ]);

--- a/src/initial_state.ts
+++ b/src/initial_state.ts
@@ -1,3 +1,6 @@
+import { AngleExpression, AngleExpressionError } from './angle_expression';
+import { Complex } from './complex';
+
 export class InitialStateError extends Error {}
 
 const FORMAT = 'ket_sum_v1';
@@ -57,6 +60,25 @@ export function initialStateQubitCount(value: unknown): number {
   const basis = terms[0]?.basis;
 
   return basis ? qubitCount(basis) : 1;
+}
+
+export function resolveNumericInitialState(
+  value: unknown,
+  variables: Readonly<Record<string, string>>
+): Complex[] {
+  const terms = loadTerms(value);
+  const amplitudes = Array.from({ length: 1 << initialStateQubitCount(value) }, () => new Complex(0));
+
+  for (const term of terms) {
+    const coefficient = resolveCoefficient(term.coefficient, variables);
+
+    for (const [index, scale] of basisComponents(term.basis)) {
+      amplitudes[index] = amplitudes[index].add(coefficient.multiply(scale));
+    }
+  }
+
+  ensureNormalized(amplitudes);
+  return amplitudes;
 }
 
 function loadTerms(value: unknown): InitialStateTerm[] {
@@ -209,6 +231,28 @@ function qubitCount(basis: string): number {
   return BELL_BASES.has(basis) ? 2 : 0;
 }
 
+function basisComponents(basis: string): Array<[number, number]> {
+  if (COMPUTATIONAL_BASIS_PATTERN.test(basis)) {
+    return [[Number.parseInt(basis, 2), 1]];
+  }
+
+  const factor = Math.sqrt(0.5);
+  const components = new Map<string, Array<[number, number]>>([
+    ['Φ+', [[0, factor], [3, factor]]],
+    ['Φ-', [[0, factor], [3, -factor]]],
+    ['Ψ+', [[1, factor], [2, factor]]],
+    ['Ψ-', [[1, factor], [2, -factor]]]
+  ]);
+
+  const result = components.get(basis);
+
+  if (!result) {
+    throw new InitialStateError(`unsupported basis state: ${basis}`);
+  }
+
+  return result;
+}
+
 function validatedCoefficient(value: unknown): string {
   const coefficient = String(value).trim();
 
@@ -226,6 +270,63 @@ function supportedCoefficient(coefficient: string): boolean {
     NUMERIC_PATTERN,
     IMAGINARY_NUMERIC_PATTERN
   ].some((pattern) => pattern.test(coefficient));
+}
+
+function resolveCoefficient(
+  coefficient: string,
+  variables: Readonly<Record<string, string>>
+): Complex {
+  if (NUMERIC_PATTERN.test(coefficient)) {
+    return new Complex(Number(coefficient));
+  }
+
+  if (IMAGINARY_NUMERIC_PATTERN.test(coefficient)) {
+    return new Complex(0, Number(coefficient.slice(0, -1)));
+  }
+
+  const signedIdentifier = /^([+-])([a-zA-Z_][a-zA-Z0-9_]*)$/u.exec(coefficient);
+
+  if (signedIdentifier) {
+    const sign = signedIdentifier[1] === '-' ? -1 : 1;
+    return resolveIdentifier(signedIdentifier[2] ?? '', variables).multiply(sign);
+  }
+
+  return resolveIdentifier(coefficient, variables);
+}
+
+function resolveIdentifier(
+  identifier: string,
+  variables: Readonly<Record<string, string>>
+): Complex {
+  const resolvedValue = variables[identifier];
+
+  if (resolvedValue === undefined) {
+    throw new InitialStateError(`unresolved initial state variable: ${identifier}`);
+  }
+
+  try {
+    const expression = new AngleExpression(resolvedValue);
+
+    if (!expression.concrete()) {
+      throw new InitialStateError(`variable value must be concrete: ${identifier}`);
+    }
+
+    return new Complex(expression.radians());
+  } catch (error) {
+    if (error instanceof AngleExpressionError) {
+      throw new InitialStateError(error.message);
+    }
+
+    throw error;
+  }
+}
+
+function ensureNormalized(amplitudes: readonly Complex[]): void {
+  const norm = amplitudes.reduce((sum, amplitude) => sum + amplitude.absSquared(), 0);
+
+  if (Math.abs(norm - 1) > 1e-12) {
+    throw new InitialStateError('initial state must be normalized');
+  }
 }
 
 function formatTerms(terms: InitialStateTerm[]): string {

--- a/src/simulator.ts
+++ b/src/simulator.ts
@@ -10,7 +10,7 @@ type GateOperator = (zero: Complex, one: Complex) => [Complex, Complex];
 const CONTROL_SYMBOL = '•';
 const EMPTY_SLOT = 1;
 const H_SCALE = 1 / Math.sqrt(2);
-const MAX_BITWISE_QUBITS = 30;
+const MAX_IN_MEMORY_QUBITS = 30;
 const SWAP_SYMBOL = 'Swap';
 
 const FIXED_GATE_OPERATORS = new Map<string, GateOperator>([
@@ -489,7 +489,7 @@ function ensureSupportedQubitCount(qubits: number): void {
     throw new SimulatorError(`invalid qubit count for run: ${qubits}`);
   }
 
-  if (qubits > MAX_BITWISE_QUBITS) {
+  if (qubits > MAX_IN_MEMORY_QUBITS) {
     throw new SimulatorError(`too many qubits for TypeScript numeric run: ${qubits}`);
   }
 }

--- a/src/simulator.ts
+++ b/src/simulator.ts
@@ -1,7 +1,7 @@
 import { AngleExpression, AngleExpressionError } from './angle_expression';
 import { Complex } from './complex';
 import type { CircuitData } from './circuit_file';
-import { InitialStateError, resolveNumericInitialState } from './initial_state';
+import { InitialStateError, initialStateQubitCount, resolveNumericInitialState } from './initial_state';
 
 export class SimulatorError extends Error {}
 
@@ -10,6 +10,7 @@ type GateOperator = (zero: Complex, one: Complex) => [Complex, Complex];
 const CONTROL_SYMBOL = '•';
 const EMPTY_SLOT = 1;
 const H_SCALE = 1 / Math.sqrt(2);
+const MAX_BITWISE_QUBITS = 30;
 const SWAP_SYMBOL = 'Swap';
 
 const FIXED_GATE_OPERATORS = new Map<string, GateOperator>([
@@ -51,6 +52,8 @@ export class Simulator {
 
   private stateVector(): StateVector {
     try {
+      ensureSupportedQubitCount(this.data.qubits);
+
       return this.data.cols.reduce(
         (current, col) => new StepOperation(col, this.gateOperatorFor.bind(this)).apply(current),
         this.startingStateVector()
@@ -73,7 +76,17 @@ export class Simulator {
       return StateVector.zero(this.data.qubits);
     }
 
-    return new StateVector(this.data.qubits, resolveNumericInitialState(this.data.initial_state, this.variables()));
+    const initialQubits = initialStateQubitCount(this.data.initial_state);
+    ensureInitialStateFitsCircuit(initialQubits, this.data.qubits);
+
+    return new StateVector(
+      this.data.qubits,
+      expandInitialState(
+        resolveNumericInitialState(this.data.initial_state, this.variables()),
+        initialQubits,
+        this.data.qubits
+      )
+    );
   }
 
   private gateOperatorFor(gate: unknown): GateOperator {
@@ -103,7 +116,7 @@ class StateVector {
   private readonly qubits: number;
 
   static zero(qubits: number): StateVector {
-    const amplitudes = Array.from({ length: 1 << qubits }, () => new Complex(0));
+    const amplitudes = Array.from({ length: stateVectorSize(qubits) }, () => new Complex(0));
     amplitudes[0] = new Complex(1);
 
     return new StateVector(qubits, amplitudes);
@@ -445,6 +458,46 @@ function requiredAmplitude(amplitudes: readonly Complex[], index: number): Compl
   }
 
   return amplitude;
+}
+
+function expandInitialState(
+  amplitudes: readonly Complex[],
+  initialQubits: number,
+  circuitQubits: number
+): readonly Complex[] {
+  if (initialQubits === circuitQubits) {
+    return amplitudes;
+  }
+
+  const suffixStates = stateVectorSize(circuitQubits - initialQubits);
+  const expanded = Array.from({ length: stateVectorSize(circuitQubits) }, () => new Complex(0));
+
+  amplitudes.forEach((amplitude, index) => {
+    expanded[index * suffixStates] = amplitude;
+  });
+
+  return expanded;
+}
+
+function ensureInitialStateFitsCircuit(initialQubits: number, circuitQubits: number): void {
+  if (initialQubits > circuitQubits) {
+    throw new SimulatorError('initial state qubit count cannot exceed circuit qubit count');
+  }
+}
+
+function ensureSupportedQubitCount(qubits: number): void {
+  if (!Number.isInteger(qubits) || qubits < 0) {
+    throw new SimulatorError(`invalid qubit count for run: ${qubits}`);
+  }
+
+  if (qubits > MAX_BITWISE_QUBITS) {
+    throw new SimulatorError(`too many qubits for TypeScript numeric run: ${qubits}`);
+  }
+}
+
+function stateVectorSize(qubits: number): number {
+  ensureSupportedQubitCount(qubits);
+  return 2 ** qubits;
 }
 
 function bitMask(qubits: number, qubit: number): number {

--- a/src/simulator.ts
+++ b/src/simulator.ts
@@ -119,7 +119,7 @@ class StateVector {
     const amplitudes = Array.from({ length: stateVectorSize(qubits) }, () => new Complex(0));
     amplitudes[0] = new Complex(1);
 
-    return new StateVector(qubits, amplitudes);
+    return new StateVector(qubits, amplitudes, false);
   }
 
   static formatAmplitude(amplitude: Complex): string {
@@ -137,9 +137,9 @@ class StateVector {
     return `${formatRubyFloat(real)}${imaginary > 0 ? '+' : ''}${formatRubyFloat(imaginary)}i`;
   }
 
-  constructor(qubits: number, amplitudes: readonly Complex[]) {
+  constructor(qubits: number, amplitudes: readonly Complex[], copy = true) {
     this.qubits = qubits;
-    this.amplitudes = [...amplitudes];
+    this.amplitudes = copy ? [...amplitudes] : amplitudes;
   }
 
   applySingleQubitGate(qubit: number, gateOperator: GateOperator): StateVector {
@@ -165,7 +165,7 @@ class StateVector {
       result[destination] = amplitude;
     });
 
-    return new StateVector(this.qubits, result);
+    return new StateVector(this.qubits, result, false);
   }
 
   expectation(pauliString: string): Complex {
@@ -185,10 +185,10 @@ class StateVector {
     const result = [...this.amplitudes];
 
     for (let blockIndex = 0; blockIndex < this.amplitudes.length / layout.blockSize; blockIndex += 1) {
-      layout.applyBlock(result, this.amplitudes.slice(blockIndex * layout.blockSize, (blockIndex + 1) * layout.blockSize), blockIndex);
+      layout.applyBlock(result, this.amplitudes, blockIndex * layout.blockSize);
     }
 
-    return new StateVector(this.qubits, result);
+    return new StateVector(this.qubits, result, false);
   }
 }
 
@@ -205,24 +205,23 @@ class SingleQubitGateLayout {
     this.gateOperator = gateOperator;
   }
 
-  applyBlock(result: Complex[], block: readonly Complex[], blockIndex: number): void {
-    this.eachTransformedPair(block, blockIndex, (zeroIndex, transformed) => {
+  applyBlock(result: Complex[], source: readonly Complex[], baseIndex: number): void {
+    this.eachTransformedPair(source, baseIndex, (zeroIndex, transformed) => {
       result[zeroIndex] = transformed[0];
       result[zeroIndex + this.stride] = transformed[1];
     });
   }
 
   protected eachTransformedPair(
-    block: readonly Complex[],
-    blockIndex: number,
+    source: readonly Complex[],
+    baseIndex: number,
     callback: (zeroIndex: number, transformed: [Complex, Complex]) => void
   ): void {
-    const baseIndex = blockIndex * this.blockSize;
-
     for (let offset = 0; offset < this.stride; offset += 1) {
+      const zeroIndex = baseIndex + offset;
       callback(
-        baseIndex + offset,
-        this.gateOperator(requiredAmplitude(block, offset), requiredAmplitude(block, offset + this.stride))
+        zeroIndex,
+        this.gateOperator(requiredAmplitude(source, zeroIndex), requiredAmplitude(source, zeroIndex + this.stride))
       );
     }
   }
@@ -236,8 +235,8 @@ class ControlledSingleQubitGateLayout extends SingleQubitGateLayout {
     this.controls = controls;
   }
 
-  override applyBlock(result: Complex[], block: readonly Complex[], blockIndex: number): void {
-    this.eachTransformedPair(block, blockIndex, (zeroIndex, transformed) => {
+  override applyBlock(result: Complex[], source: readonly Complex[], baseIndex: number): void {
+    this.eachTransformedPair(source, baseIndex, (zeroIndex, transformed) => {
       if (!this.controlsActive(zeroIndex)) {
         return;
       }

--- a/src/simulator.ts
+++ b/src/simulator.ts
@@ -1,0 +1,473 @@
+import { AngleExpression, AngleExpressionError } from './angle_expression';
+import { Complex } from './complex';
+import type { CircuitData } from './circuit_file';
+import { InitialStateError, resolveNumericInitialState } from './initial_state';
+
+export class SimulatorError extends Error {}
+
+type GateOperator = (zero: Complex, one: Complex) => [Complex, Complex];
+
+const CONTROL_SYMBOL = '•';
+const EMPTY_SLOT = 1;
+const H_SCALE = 1 / Math.sqrt(2);
+const SWAP_SYMBOL = 'Swap';
+
+const FIXED_GATE_OPERATORS = new Map<string, GateOperator>([
+  ['H', (zero, one) => [zero.add(one).multiply(H_SCALE), zero.subtract(one).multiply(H_SCALE)]],
+  ['S', (zero, one) => [zero, new Complex(0, 1).multiply(one)]],
+  ['S†', (zero, one) => [zero, new Complex(0, -1).multiply(one)]],
+  ['T', phaseGate(Math.PI / 4)],
+  ['T†', phaseGate(-Math.PI / 4)],
+  ['X', (zero, one) => [one, zero]],
+  [
+    'X^½',
+    (zero, one) => [
+      new Complex(0.5, 0.5).multiply(zero).add(new Complex(0.5, -0.5).multiply(one)),
+      new Complex(0.5, -0.5).multiply(zero).add(new Complex(0.5, 0.5).multiply(one))
+    ]
+  ],
+  ['Y', (zero, one) => [new Complex(0, -1).multiply(one), new Complex(0, 1).multiply(zero)]],
+  ['Z', (zero, one) => [zero, one.multiply(-1)]]
+]);
+
+export class Simulator {
+  private readonly data: CircuitData;
+
+  constructor(data: CircuitData) {
+    this.data = data;
+  }
+
+  renderStateVector(): string {
+    return this.stateVector().toCsv();
+  }
+
+  renderExpectationValues(pauliStrings: readonly string[]): string {
+    const stateVector = this.stateVector();
+
+    return pauliStrings
+      .map((pauliString) => `${pauliString}=${StateVector.formatAmplitude(stateVector.expectation(pauliString))}`)
+      .join('\n');
+  }
+
+  private stateVector(): StateVector {
+    try {
+      return this.data.cols.reduce(
+        (current, col) => new StepOperation(col, this.gateOperatorFor.bind(this)).apply(current),
+        this.startingStateVector()
+      );
+    } catch (error) {
+      if (
+        error instanceof AngleExpressionError ||
+        error instanceof InitialStateError ||
+        error instanceof PauliStringError
+      ) {
+        throw new SimulatorError(error.message);
+      }
+
+      throw error;
+    }
+  }
+
+  private startingStateVector(): StateVector {
+    if (this.data.initial_state == null) {
+      return StateVector.zero(this.data.qubits);
+    }
+
+    return new StateVector(this.data.qubits, resolveNumericInitialState(this.data.initial_state, this.variables()));
+  }
+
+  private gateOperatorFor(gate: unknown): GateOperator {
+    const gateName = String(gate);
+    const fixedGate = FIXED_GATE_OPERATORS.get(gateName);
+
+    if (fixedGate) {
+      return fixedGate;
+    }
+
+    const angledGate = angledGateOperator(gateName, this.variables());
+
+    if (!angledGate) {
+      throw new SimulatorError(`unsupported gate for run: ${JSON.stringify(gateName)}`);
+    }
+
+    return angledGate;
+  }
+
+  private variables(): Readonly<Record<string, string>> {
+    return this.data.variables ?? {};
+  }
+}
+
+class StateVector {
+  private readonly amplitudes: readonly Complex[];
+  private readonly qubits: number;
+
+  static zero(qubits: number): StateVector {
+    const amplitudes = Array.from({ length: 1 << qubits }, () => new Complex(0));
+    amplitudes[0] = new Complex(1);
+
+    return new StateVector(qubits, amplitudes);
+  }
+
+  static formatAmplitude(amplitude: Complex): string {
+    const real = normalizedScalar(amplitude.real);
+    const imaginary = normalizedScalar(amplitude.imaginary);
+
+    if (imaginary === 0) {
+      return formatRubyFloat(real);
+    }
+
+    if (real === 0) {
+      return `${formatRubyFloat(imaginary)}i`;
+    }
+
+    return `${formatRubyFloat(real)}${imaginary > 0 ? '+' : ''}${formatRubyFloat(imaginary)}i`;
+  }
+
+  constructor(qubits: number, amplitudes: readonly Complex[]) {
+    this.qubits = qubits;
+    this.amplitudes = [...amplitudes];
+  }
+
+  applySingleQubitGate(qubit: number, gateOperator: GateOperator): StateVector {
+    return this.applyGateLayout(new SingleQubitGateLayout(this.qubits, qubit, gateOperator));
+  }
+
+  applyControlledSingleQubitGate(
+    controls: readonly number[],
+    qubit: number,
+    gateOperator: GateOperator
+  ): StateVector {
+    return this.applyGateLayout(new ControlledSingleQubitGateLayout(this.qubits, qubit, controls, gateOperator));
+  }
+
+  applySwap(firstQubit: number, secondQubit: number): StateVector {
+    const firstMask = bitMask(this.qubits, firstQubit);
+    const secondMask = bitMask(this.qubits, secondQubit);
+    const result = Array.from({ length: this.amplitudes.length }, () => new Complex(0));
+
+    this.amplitudes.forEach((amplitude, index) => {
+      const destination =
+        bitSet(index, firstMask) === bitSet(index, secondMask) ? index : index ^ firstMask ^ secondMask;
+      result[destination] = amplitude;
+    });
+
+    return new StateVector(this.qubits, result);
+  }
+
+  expectation(pauliString: string): Complex {
+    const observable = new PauliString(pauliString, this.qubits);
+
+    return this.amplitudes.reduce((sum, amplitude, index) => {
+      const mapped = observable.mappedState(index);
+      return sum.add(amplitude.conjugate().multiply(mapped.phase).multiply(this.amplitudes[mapped.index]));
+    }, new Complex(0));
+  }
+
+  toCsv(): string {
+    return this.amplitudes.map((amplitude) => StateVector.formatAmplitude(amplitude)).join(',');
+  }
+
+  private applyGateLayout(layout: SingleQubitGateLayout): StateVector {
+    const result = [...this.amplitudes];
+
+    for (let blockIndex = 0; blockIndex < this.amplitudes.length / layout.blockSize; blockIndex += 1) {
+      layout.applyBlock(result, this.amplitudes.slice(blockIndex * layout.blockSize, (blockIndex + 1) * layout.blockSize), blockIndex);
+    }
+
+    return new StateVector(this.qubits, result);
+  }
+}
+
+class SingleQubitGateLayout {
+  readonly blockSize: number;
+  protected readonly gateOperator: GateOperator;
+  protected readonly qubits: number;
+  protected readonly stride: number;
+
+  constructor(qubits: number, qubit: number, gateOperator: GateOperator) {
+    this.qubits = qubits;
+    this.stride = 1 << (qubits - qubit - 1);
+    this.blockSize = this.stride * 2;
+    this.gateOperator = gateOperator;
+  }
+
+  applyBlock(result: Complex[], block: readonly Complex[], blockIndex: number): void {
+    this.eachTransformedPair(block, blockIndex, (zeroIndex, transformed) => {
+      result[zeroIndex] = transformed[0];
+      result[zeroIndex + this.stride] = transformed[1];
+    });
+  }
+
+  protected eachTransformedPair(
+    block: readonly Complex[],
+    blockIndex: number,
+    callback: (zeroIndex: number, transformed: [Complex, Complex]) => void
+  ): void {
+    const baseIndex = blockIndex * this.blockSize;
+
+    for (let offset = 0; offset < this.stride; offset += 1) {
+      callback(
+        baseIndex + offset,
+        this.gateOperator(requiredAmplitude(block, offset), requiredAmplitude(block, offset + this.stride))
+      );
+    }
+  }
+}
+
+class ControlledSingleQubitGateLayout extends SingleQubitGateLayout {
+  private readonly controls: readonly number[];
+
+  constructor(qubits: number, qubit: number, controls: readonly number[], gateOperator: GateOperator) {
+    super(qubits, qubit, gateOperator);
+    this.controls = controls;
+  }
+
+  override applyBlock(result: Complex[], block: readonly Complex[], blockIndex: number): void {
+    this.eachTransformedPair(block, blockIndex, (zeroIndex, transformed) => {
+      if (!this.controlsActive(zeroIndex)) {
+        return;
+      }
+
+      result[zeroIndex] = transformed[0];
+      result[zeroIndex + this.stride] = transformed[1];
+    });
+  }
+
+  private controlsActive(zeroIndex: number): boolean {
+    return this.controls.every((control) => bitSet(zeroIndex, bitMask(this.qubits, control)));
+  }
+}
+
+class StepOperation {
+  private readonly col: readonly unknown[];
+  private readonly gateOperatorFor: (gate: unknown) => GateOperator;
+
+  constructor(col: readonly unknown[], gateOperatorFor: (gate: unknown) => GateOperator) {
+    this.col = col;
+    this.gateOperatorFor = gateOperatorFor;
+  }
+
+  apply(stateVector: StateVector): StateVector {
+    if (this.swap()) {
+      return this.applySwap(stateVector);
+    }
+
+    if (this.controlled()) {
+      return this.applyControlled(stateVector);
+    }
+
+    return this.applyUncontrolled(stateVector);
+  }
+
+  private applySwap(stateVector: StateVector): StateVector {
+    if (!this.validSwapStep()) {
+      throw new SimulatorError(`unsupported swap step: ${JSON.stringify(this.col)}`);
+    }
+
+    const swapQubits = this.slotIndices(SWAP_SYMBOL);
+    return stateVector.applySwap(swapQubits[0] ?? 0, swapQubits[1] ?? 0);
+  }
+
+  private applyControlled(stateVector: StateVector): StateVector {
+    const target = this.target();
+
+    return stateVector.applyControlledSingleQubitGate(
+      this.slotIndices(CONTROL_SYMBOL),
+      target.qubit,
+      this.gateOperatorFor(target.gate)
+    );
+  }
+
+  private applyUncontrolled(stateVector: StateVector): StateVector {
+    return this.col.reduce<StateVector>((current, gate, qubit) => {
+      if (gate === EMPTY_SLOT) {
+        return current;
+      }
+
+      return current.applySingleQubitGate(qubit, this.gateOperatorFor(gate));
+    }, stateVector);
+  }
+
+  private target(): { gate: unknown; qubit: number } {
+    const targets = this.col
+      .map((gate, qubit) => ({ gate, qubit }))
+      .filter(({ gate }) => gate !== EMPTY_SLOT && gate !== CONTROL_SYMBOL);
+
+    if (targets.length !== 1) {
+      throw new SimulatorError(`unsupported controlled step: ${JSON.stringify(this.col)}`);
+    }
+
+    return targets[0] as { gate: unknown; qubit: number };
+  }
+
+  private swap(): boolean {
+    return this.col.includes(SWAP_SYMBOL);
+  }
+
+  private controlled(): boolean {
+    return this.col.includes(CONTROL_SYMBOL);
+  }
+
+  private validSwapStep(): boolean {
+    return this.slotIndices(SWAP_SYMBOL).length === 2 && this.col.every((slot) => slot === EMPTY_SLOT || slot === SWAP_SYMBOL);
+  }
+
+  private slotIndices(symbol: string): number[] {
+    return this.col
+      .map((slot, index) => ({ index, slot }))
+      .filter(({ slot }) => slot === symbol)
+      .map(({ index }) => index);
+  }
+}
+
+class PauliStringError extends Error {}
+
+class PauliString {
+  private readonly qubits: number;
+  private readonly symbols: readonly string[];
+
+  constructor(rawValue: string, qubits: number) {
+    this.symbols = rawValue.toUpperCase().split('');
+    this.qubits = qubits;
+    this.ensureValid(rawValue.toUpperCase());
+  }
+
+  mappedState(index: number): { index: number; phase: Complex } {
+    return this.symbols.reduce(
+      (current, symbol, qubit) => this.transform(current, symbol, qubit),
+      { index, phase: new Complex(1) }
+    );
+  }
+
+  private ensureValid(rawValue: string): void {
+    if (this.symbols.length !== this.qubits) {
+      throw new PauliStringError(`Pauli string length must match qubit count: ${rawValue}`);
+    }
+
+    if (!this.symbols.every((symbol) => ['I', 'X', 'Y', 'Z'].includes(symbol))) {
+      throw new PauliStringError(`Pauli string must use only I, X, Y, and Z: ${rawValue}`);
+    }
+  }
+
+  private transform(
+    state: { index: number; phase: Complex },
+    symbol: string,
+    qubit: number
+  ): { index: number; phase: Complex } {
+    const mask = bitMask(this.qubits, qubit);
+
+    switch (symbol) {
+      case 'I':
+        return state;
+      case 'X':
+        return { index: state.index ^ mask, phase: state.phase };
+      case 'Y':
+        return {
+          index: state.index ^ mask,
+          phase: state.phase.multiply(bitSet(state.index, mask) ? new Complex(0, -1) : new Complex(0, 1))
+        };
+      case 'Z':
+        return { index: state.index, phase: state.phase.multiply(bitSet(state.index, mask) ? -1 : 1) };
+      default:
+        throw new PauliStringError(`Pauli string must use only I, X, Y, and Z: ${this.symbols.join('')}`);
+    }
+  }
+}
+
+function angledGateOperator(
+  serializedGate: string,
+  variables: Readonly<Record<string, string>>
+): GateOperator | undefined {
+  const match = /^(?<gate>P|Rx|Ry|Rz)\((?<angle>.+)\)$/u.exec(serializedGate);
+
+  if (!match?.groups) {
+    return undefined;
+  }
+
+  const angle = new AngleExpression(match.groups.angle).radians(variables);
+
+  switch (match.groups.gate) {
+    case 'P':
+      return phaseGate(angle);
+    case 'Rx':
+      return rxGate(angle);
+    case 'Ry':
+      return ryGate(angle);
+    case 'Rz':
+      return rzGate(angle);
+    default:
+      return undefined;
+  }
+}
+
+function phaseGate(angle: number): GateOperator {
+  const phase = new Complex(Math.cos(angle), Math.sin(angle));
+
+  return (zero, one) => [zero, phase.multiply(one)];
+}
+
+function rxGate(angle: number): GateOperator {
+  const halfAngle = angle / 2;
+  const cosine = Math.cos(halfAngle);
+  const imaginarySine = new Complex(0, Math.sin(halfAngle));
+
+  return (zero, one) => [
+    zero.multiply(cosine).subtract(imaginarySine.multiply(one)),
+    imaginarySine.multiply(zero).multiply(-1).add(one.multiply(cosine))
+  ];
+}
+
+function ryGate(angle: number): GateOperator {
+  const halfAngle = angle / 2;
+  const cosine = Math.cos(halfAngle);
+  const sine = Math.sin(halfAngle);
+
+  return (zero, one) => [
+    zero.multiply(cosine).subtract(one.multiply(sine)),
+    zero.multiply(sine).add(one.multiply(cosine))
+  ];
+}
+
+function rzGate(angle: number): GateOperator {
+  const halfAngle = angle / 2;
+  const negativePhase = new Complex(Math.cos(halfAngle), -Math.sin(halfAngle));
+  const positivePhase = new Complex(Math.cos(halfAngle), Math.sin(halfAngle));
+
+  return (zero, one) => [negativePhase.multiply(zero), positivePhase.multiply(one)];
+}
+
+function requiredAmplitude(amplitudes: readonly Complex[], index: number): Complex {
+  const amplitude = amplitudes[index];
+
+  if (!amplitude) {
+    throw new SimulatorError(`state vector index out of range: ${index}`);
+  }
+
+  return amplitude;
+}
+
+function bitMask(qubits: number, qubit: number): number {
+  return 1 << (qubits - qubit - 1);
+}
+
+function bitSet(value: number, mask: number): boolean {
+  return (value & mask) !== 0;
+}
+
+function normalizedScalar(value: number): number {
+  if (Math.abs(value) < Number.EPSILON) {
+    return 0;
+  }
+
+  const nearestInteger = Math.round(value);
+  return Math.abs(value - nearestInteger) <= Number.EPSILON ? nearestInteger : value;
+}
+
+function formatRubyFloat(value: number): string {
+  if (Number.isInteger(value)) {
+    return `${value}.0`;
+  }
+
+  return String(value);
+}

--- a/test/fixtures/performance/large_expect_numeric_workload.json
+++ b/test/fixtures/performance/large_expect_numeric_workload.json
@@ -1,0 +1,10 @@
+{
+  "name": "large-expect-numeric-8q-160steps",
+  "command": ["expect", "ZZZZZZZZ", "XXXXXXXX"],
+  "input": {
+    "kind": "generated-circuit",
+    "qubits": 8,
+    "depth": 160,
+    "pattern": ["H", "X", "Y", "Z", "S", "T", "1", "1"]
+  }
+}

--- a/test/fixtures/performance/large_run_numeric_workload.json
+++ b/test/fixtures/performance/large_run_numeric_workload.json
@@ -1,0 +1,10 @@
+{
+  "name": "large-run-numeric-8q-160steps",
+  "command": ["run"],
+  "input": {
+    "kind": "generated-circuit",
+    "qubits": 8,
+    "depth": 160,
+    "pattern": ["H", "X", "Y", "Z", "S", "T", "1", "1"]
+  }
+}

--- a/test/qni/gate_operator_abstraction_test.rb
+++ b/test/qni/gate_operator_abstraction_test.rb
@@ -53,6 +53,20 @@ module Qni
       assert_equal '0.0,0.0,0.0,1.0', result.to_csv
     end
 
+    def test_simulator_expands_initial_state_with_zero_suffix_qubits
+      simulator = Simulator.new(
+        CircuitDouble.new(
+          {
+            'qubits' => 2,
+            'cols' => [[1, XGate::SYMBOL]],
+            'initial_state' => InitialState.parse('|+>').to_h
+          }
+        )
+      )
+
+      assert_equal '0.0,0.7071067811865476,0.0,0.7071067811865476', simulator.render_state_vector
+    end
+
     private
 
     def build_simulator(variables: {})

--- a/test/typescript/numeric_runtime_compatibility.test.ts
+++ b/test/typescript/numeric_runtime_compatibility.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { describe, it } from 'node:test';
+
+import { Simulator } from '../../src/simulator';
+import type { CircuitData } from '../../src/circuit_file';
+
+async function withCircuit<T>(circuit: CircuitData, callback: (dir: string) => T): Promise<T> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'qni-cli-runtime-'));
+
+  try {
+    await writeFile(path.join(dir, 'circuit.json'), `${JSON.stringify(circuit, null, 2)}\n`);
+    return callback(dir);
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+}
+
+function rubyOutput(dir: string, command: readonly string[]): string {
+  const projectRoot = process.cwd();
+  const result = spawnSync('bundle', ['exec', path.join(projectRoot, 'bin', 'qni'), ...command], {
+    cwd: dir,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      BUNDLE_GEMFILE: path.join(projectRoot, 'Gemfile')
+    },
+    timeout: 30_000
+  });
+
+  assert.equal(result.error, undefined, result.error?.message);
+  assert.equal(result.signal, null, `Ruby oracle terminated with signal ${result.signal}`);
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim();
+}
+
+describe('TypeScript numeric simulator compatibility', () => {
+  it('matches Ruby oracle for numeric Bell state run and expectations', async () => {
+    const circuit: CircuitData = {
+      cols: [['H', 1], ['•', 'X']],
+      qubits: 2
+    };
+
+    await withCircuit(circuit, (dir) => {
+      const simulator = new Simulator(circuit);
+
+      assert.equal(simulator.renderStateVector(), rubyOutput(dir, ['run']));
+      assert.equal(simulator.renderExpectationValues(['ZZ', 'XX']), rubyOutput(dir, ['expect', 'ZZ', 'XX']));
+    });
+  });
+
+  it('matches Ruby oracle for variables, initial_state, and angled gates', async () => {
+    const circuit: CircuitData = {
+      cols: [['X'], ['Ry(2*theta)']],
+      initial_state: {
+        format: 'ket_sum_v1',
+        terms: [
+          { basis: '0', coefficient: 'alpha' },
+          { basis: '1', coefficient: 'beta' }
+        ]
+      },
+      qubits: 1,
+      variables: {
+        alpha: '0.6',
+        beta: '0.8',
+        theta: 'π/4'
+      }
+    };
+
+    await withCircuit(circuit, (dir) => {
+      const simulator = new Simulator(circuit);
+
+      assert.equal(simulator.renderStateVector(), rubyOutput(dir, ['run']));
+      assert.equal(simulator.renderExpectationValues(['X', 'Z']), rubyOutput(dir, ['expect', 'X', 'Z']));
+    });
+  });
+});

--- a/test/typescript/numeric_runtime_compatibility.test.ts
+++ b/test/typescript/numeric_runtime_compatibility.test.ts
@@ -8,12 +8,13 @@ import { describe, it } from 'node:test';
 import { Simulator } from '../../src/simulator';
 import type { CircuitData } from '../../src/circuit_file';
 
-async function withCircuit<T>(circuit: CircuitData, callback: (dir: string) => T): Promise<T> {
+async function withCircuit<T>(circuit: CircuitData, callback: (dir: string) => Promise<T> | T): Promise<T> {
   const dir = await mkdtemp(path.join(tmpdir(), 'qni-cli-runtime-'));
 
   try {
     await writeFile(path.join(dir, 'circuit.json'), `${JSON.stringify(circuit, null, 2)}\n`);
-    return callback(dir);
+    const result = await callback(dir);
+    return result;
   } finally {
     await rm(dir, { force: true, recursive: true });
   }

--- a/test/typescript/numeric_runtime_compatibility.test.ts
+++ b/test/typescript/numeric_runtime_compatibility.test.ts
@@ -77,4 +77,35 @@ describe('TypeScript numeric simulator compatibility', () => {
       assert.equal(simulator.renderExpectationValues(['X', 'Z']), rubyOutput(dir, ['expect', 'X', 'Z']));
     });
   });
+
+  it('extends a shorter initial_state with zeroed suffix qubits', () => {
+    const circuit: CircuitData = {
+      cols: [[1, 'X']],
+      initial_state: {
+        format: 'ket_sum_v1',
+        terms: [
+          { basis: '0', coefficient: '0.7071067811865476' },
+          { basis: '1', coefficient: '0.7071067811865476' }
+        ]
+      },
+      qubits: 2
+    };
+
+    const simulator = new Simulator(circuit);
+
+    assert.equal(simulator.renderStateVector(), '0.0,0.7071067811865476,0.0,0.7071067811865476');
+    assert.equal(simulator.renderExpectationValues(['IZ']), 'IZ=-1.0');
+  });
+
+  it('rejects qubit counts that would overflow JavaScript bitwise state indexing', () => {
+    const circuit: CircuitData = {
+      cols: [],
+      qubits: 32
+    };
+
+    assert.throws(
+      () => new Simulator(circuit).renderStateVector(),
+      /too many qubits for TypeScript numeric run: 32/u
+    );
+  });
 });


### PR DESCRIPTION
## 概要

YAS-224

numeric `qni run` と `qni expect` を TypeScript dispatcher の実行経路へ移行しました。`run --symbolic`、help、no-arg `expect` は Ruby fallback 境界に残しています。

## 変更内容

- TypeScript に numeric state-vector simulator を追加
- 固定 gate、angled gate、controlled gate、SWAP、initial_state、Pauli expectation を実装
- `run` / `expect` の numeric 実行を TypeScript route に接続
- Ruby oracle と比較する TypeScript テストを追加
- numeric run / expect の performance workload を追加
- PR feedback 対応として、短い `initial_state` の `|0>` suffix 拡張、Ruby fallback parity、32+ qubits guard、state-vector allocation 削減、test helper cleanup 修正を追加

## 検証

- `bundle exec ruby -Itest -Ilib test/qni/gate_operator_abstraction_test.rb`
- `npm run test:ts`
- `npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress "features/cli/run/initial_states.feature.md"`
- `npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress "features/cli/run/*.feature.md" "features/cli/expect/*.feature.md"`
- `node scripts/compare_ruby_typescript_performance.js --workload test/fixtures/performance/large_run_numeric_workload.json --workload test/fixtures/performance/large_expect_numeric_workload.json --repeat 1 --warm-up 0 --output tmp/yas-224-performance.json`
- `bundle exec rake check`

## performance 調査

- `large-run-numeric-8q-160steps`: wall 0.132x / peak memory 3.05x
- `large-expect-numeric-8q-160steps`: wall 0.143x / peak memory 3.071x
- wall-clock は Ruby より速い一方、Node 起動・ランタイム常駐分で peak-memory が threshold を超えました。
