### PR TITLE
view を TypeScript に移行する

### DIFF
--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -7,7 +7,6 @@ const assert = require('node:assert/strict');
 const { Given, Then, When } = require('@cucumber/cucumber');
 
 const PROJECT_ROOT = path.resolve(__dirname, '../..');
-const QNI_BIN = path.join(PROJECT_ROOT, 'bin', 'qni');
 const NODE_QNI_BIN = path.join(PROJECT_ROOT, 'dist', 'bin', 'qni.js');
 const PYTHON_SYMBOLIC = path.join(PROJECT_ROOT, '.python-symbolic', 'bin', 'python');
 const MPLCONFIGDIR = process.env.MPLCONFIGDIR || path.join(os.tmpdir(), 'qni-cli-matplotlib');
@@ -148,7 +147,7 @@ function runQniCommandInTty(scenarioDir, command, extraEnv = {}) {
     throw new Error(`command must start with qni: ${command}`);
   }
 
-  const ttyCommand = ['bundle', 'exec', QNI_BIN, ...argv.slice(1)]
+  const ttyCommand = ['node', NODE_QNI_BIN, ...argv.slice(1)]
     .map(shellQuote)
     .join(' ');
 
@@ -240,17 +239,26 @@ function appendCircuitJson(scenarioDir, data) {
 
 function parseAsciiCircuit(asciiArt) {
   const script = [
-    'begin',
-    '  circuit = Qni::View::AsciiCircuitParser.new(STDIN.read).parse',
-    '  puts JSON.generate(ok: true, circuit: circuit.to_h)',
-    'rescue Qni::View::AsciiCircuitParser::Error => e',
-    '  puts JSON.generate(ok: false, error: e.message)',
-    'end'
+    'const { parseAsciiCircuit, AsciiCircuitParserError } = require("./dist/view/ascii_circuit_parser");',
+    'let input = "";',
+    'process.stdin.setEncoding("utf8");',
+    'process.stdin.on("data", (chunk) => { input += chunk; });',
+    'process.stdin.on("end", () => {',
+    '  try {',
+    '    process.stdout.write(JSON.stringify({ ok: true, circuit: parseAsciiCircuit(input) }));',
+    '  } catch (error) {',
+    '    if (error instanceof AsciiCircuitParserError) {',
+    '      process.stdout.write(JSON.stringify({ ok: false, error: error.message }));',
+    '    } else {',
+    '      throw error;',
+    '    }',
+    '  }',
+    '});'
   ].join('\n');
 
   return JSON.parse(execFileSync(
-    'bundle',
-    ['exec', 'ruby', '-Ilib', '-rjson', '-rqni/view/ascii_circuit_parser', '-e', script],
+    'node',
+    ['-e', script],
     {
       cwd: PROJECT_ROOT,
       env: bundlerEnv(),

--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -89,7 +89,7 @@ function splitCommand(command) {
   return words;
 }
 
-function bundlerEnv(extraEnv = {}) {
+function scenarioEnv(extraEnv = {}) {
   return {
     ...process.env,
     ...extraEnv,
@@ -116,7 +116,7 @@ function runNodeQniCommand(scenarioDir, command, extraEnv = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn('node', [NODE_QNI_BIN, ...argv.slice(1)], {
       cwd: scenarioDir,
-      env: bundlerEnv(extraEnv)
+      env: scenarioEnv(extraEnv)
     });
 
     const stdout = [];
@@ -154,7 +154,7 @@ function runQniCommandInTty(scenarioDir, command, extraEnv = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn('script', ['-qfec', ttyCommand, '/dev/null'], {
       cwd: scenarioDir,
-      env: bundlerEnv(extraEnv)
+      env: scenarioEnv(extraEnv)
     });
 
     const stdout = [];
@@ -261,7 +261,7 @@ function parseAsciiCircuit(asciiArt) {
     ['-e', script],
     {
       cwd: PROJECT_ROOT,
-      env: bundlerEnv(),
+      env: scenarioEnv(),
       input: asciiArt,
       encoding: 'utf8'
     }
@@ -303,7 +303,7 @@ function directInitialState(state) {
     ['exec', 'ruby', '-Ilib', '-rjson', '-rqni/initial_state', '-e', script],
     {
       cwd: PROJECT_ROOT,
-      env: bundlerEnv(),
+      env: scenarioEnv(),
       input: state,
       encoding: 'utf8'
     }

--- a/src/commands/view_command.ts
+++ b/src/commands/view_command.ts
@@ -1,0 +1,54 @@
+import { CircuitFileError, currentCircuitFile } from '../circuit_file';
+import type { CommandHandlerContext } from '../dispatcher';
+import { runRubyFallbackSync } from '../process/process_compatibility';
+import { TextRenderer } from '../view/text_renderer';
+
+const HELP_TEXT = `Usage:
+  qni view
+
+Overview:
+  Render ./circuit.json as an ASCII circuit diagram.
+  Output uses plain box-drawing text in non-TTY contexts.
+
+Examples:
+  qni view
+`;
+
+export function runViewCommand(argv: string[], context: CommandHandlerContext): number {
+  if (!typeScriptView(argv)) {
+    return runRubyFallbackSync({
+      argv,
+      cwd: context.cwd,
+      env: context.env,
+      projectRoot: context.projectRoot
+    }).exitStatus ?? 1;
+  }
+
+  if (helpRequest(argv)) {
+    process.stdout.write(HELP_TEXT);
+    return 0;
+  }
+
+  try {
+    const circuit = currentCircuitFile(context.cwd).load();
+    const renderer = new TextRenderer(circuit, { style: process.stdout.isTTY ? 'colorized' : 'plain' });
+
+    process.stdout.write(`${renderer.render()}\n`);
+    return 0;
+  } catch (error) {
+    if (error instanceof CircuitFileError) {
+      process.stderr.write(`${error.message}\n`);
+      return 1;
+    }
+
+    throw error;
+  }
+}
+
+function helpRequest(argv: string[]): boolean {
+  return argv.length === 2 && (argv[1] === '--help' || argv[1] === '-h');
+}
+
+function typeScriptView(argv: string[]): boolean {
+  return argv.length === 1 || helpRequest(argv);
+}

--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -9,6 +9,7 @@ import { runRemoveCommand } from './commands/remove_command';
 import { runRunCommand } from './commands/run_command';
 import { runStateCommand } from './commands/state_command';
 import { runVariableCommand } from './commands/variable_command';
+import { runViewCommand } from './commands/view_command';
 
 export interface CommandHandlerContext {
   readonly cwd: string;
@@ -37,7 +38,8 @@ const TYPESCRIPT_ROUTES = new Map<string, CommandHandler>([
   ['rm', runRemoveCommand],
   ['run', runRunCommand],
   ['state', runStateCommand],
-  ['variable', runVariableCommand]
+  ['variable', runVariableCommand],
+  ['view', runViewCommand]
 ]);
 
 export function createDispatcher(options: DispatcherOptions): Dispatcher {

--- a/src/process/process_compatibility.ts
+++ b/src/process/process_compatibility.ts
@@ -131,10 +131,12 @@ export function runRubyFallback(options: RunRubyFallbackOptions): Promise<Subpro
 
 export function runRubyFallbackSync(options: RunRubyFallbackSyncOptions): SubprocessResult {
   const invocation = createRubyFallbackInvocation(options);
+  const stdoutMode = options.stdout || !process.stdout.isTTY ? 'pipe' : 'inherit';
+  const stderrMode = options.stderr || !process.stderr.isTTY ? 'pipe' : 'inherit';
   const result = spawnSync(invocation.command, [...invocation.args], {
     cwd: invocation.cwd,
     env: invocation.env,
-    stdio: ['ignore', 'pipe', 'pipe']
+    stdio: ['ignore', stdoutMode, stderrMode]
   });
 
   if (result.error) {
@@ -142,8 +144,13 @@ export function runRubyFallbackSync(options: RunRubyFallbackSyncOptions): Subpro
     return { exitStatus: 127, signal: null };
   }
 
-  (options.stdout ?? process.stdout).write(result.stdout);
-  (options.stderr ?? process.stderr).write(result.stderr);
+  if (result.stdout) {
+    (options.stdout ?? process.stdout).write(result.stdout);
+  }
+
+  if (result.stderr) {
+    (options.stderr ?? process.stderr).write(result.stderr);
+  }
 
   return {
     exitStatus: result.status,

--- a/src/process/process_compatibility.ts
+++ b/src/process/process_compatibility.ts
@@ -40,6 +40,8 @@ export interface RunRubyFallbackSyncOptions extends RubyFallbackOptions {
   readonly stderr?: Writable;
 }
 
+export type RubyFallbackSyncStdio = ['ignore', 'pipe' | 'inherit', 'pipe' | 'inherit'];
+
 export interface CommandImplementationOptions {
   readonly argv: readonly string[];
   readonly env: NodeJS.ProcessEnv;
@@ -129,14 +131,19 @@ export function runRubyFallback(options: RunRubyFallbackOptions): Promise<Subpro
   });
 }
 
-export function runRubyFallbackSync(options: RunRubyFallbackSyncOptions): SubprocessResult {
-  const invocation = createRubyFallbackInvocation(options);
+export function rubyFallbackSyncStdio(options: Pick<RunRubyFallbackSyncOptions, 'stderr' | 'stdout'>): RubyFallbackSyncStdio {
   const stdoutMode = options.stdout || !process.stdout.isTTY ? 'pipe' : 'inherit';
   const stderrMode = options.stderr || !process.stderr.isTTY ? 'pipe' : 'inherit';
+
+  return ['ignore', stdoutMode, stderrMode];
+}
+
+export function runRubyFallbackSync(options: RunRubyFallbackSyncOptions): SubprocessResult {
+  const invocation = createRubyFallbackInvocation(options);
   const result = spawnSync(invocation.command, [...invocation.args], {
     cwd: invocation.cwd,
     env: invocation.env,
-    stdio: ['ignore', stdoutMode, stderrMode]
+    stdio: rubyFallbackSyncStdio(options)
   });
 
   if (result.error) {

--- a/src/view/ascii_circuit_parser.ts
+++ b/src/view/ascii_circuit_parser.ts
@@ -31,7 +31,7 @@ const FIXED_GATE_LABELS = new Map<string, string>([
 const ANGLED_GATE_LABELS = new Set(['P', 'Rx', 'Ry', 'Rz']);
 const ANGLED_GATE_ERROR = 'ASCII parser angled gates require a dedicated angle line above the box';
 const BOX_BORDER_PATTERN = /[┌┐└┘├┤]/u;
-const MID_LINE_PATTERN = /^q(?<qubit>\d+): (?<wire>.*)$/u;
+const MID_LINE_PATTERN = /^(?<prefix>\s*q(?<qubit>\d+): )(?<wire>.*)$/u;
 const UNEXPECTED_ANGLE_ERROR = 'ASCII parser angle lines are only supported for Rx, Ry, Rz, and P boxes';
 
 export class AsciiCircuitParser {
@@ -148,7 +148,7 @@ class LineSet {
   }
 
   private wireLabelWidth(): number {
-    return Math.max(...this.parsedMidLines().map(([_lineIndex, match]) => match.index + `q${match.groups?.qubit}: `.length));
+    return Math.max(...this.parsedMidLines().map(([_lineIndex, match]) => charLength(match.groups?.prefix ?? '')));
   }
 
   private wirePrefix(): string {

--- a/src/view/ascii_circuit_parser.ts
+++ b/src/view/ascii_circuit_parser.ts
@@ -180,7 +180,11 @@ class LineSet {
 
   private wireSegmentFor(line: string): string {
     if (!line.startsWith(this.wirePrefix())) {
-      throw new AsciiCircuitParserError('ASCII parser lines must align to whole step cells');
+      throw new AsciiCircuitParserError(
+        `ASCII parser wire label width/padding mismatch: expected prefix ${JSON.stringify(
+          this.wirePrefix()
+        )}, got ${JSON.stringify(line.slice(0, this.wirePrefix().length))}`
+      );
     }
 
     return line.slice(this.wirePrefix().length);
@@ -246,6 +250,7 @@ class WireRow {
 
 class AsciiWireLayout {
   private readonly asciiArt: string;
+  private lineSetCache?: LineSet;
 
   constructor(asciiArt: string) {
     this.asciiArt = asciiArt;
@@ -284,7 +289,9 @@ class AsciiWireLayout {
   }
 
   private lineSet(): LineSet {
-    return new LineSet(this.asciiArt);
+    this.lineSetCache ??= new LineSet(this.asciiArt);
+
+    return this.lineSetCache;
   }
 
   private paddedWireSegment(segment: string | undefined): string {

--- a/src/view/ascii_circuit_parser.ts
+++ b/src/view/ascii_circuit_parser.ts
@@ -52,6 +52,11 @@ export function parseAsciiCircuit(asciiArt: string): CircuitData {
 
 class LineSet {
   private readonly asciiArt: string;
+  private linesCache: string[] | undefined;
+  private parsedMidLinesCache: Array<readonly [number, RegExpExecArray]> | undefined;
+  private wireLabelWidthCache: number | undefined;
+  private wirePrefixCache: string | undefined;
+  private wireWidthCache: number | undefined;
 
   constructor(asciiArt: string) {
     this.asciiArt = asciiArt;
@@ -80,16 +85,26 @@ class LineSet {
   }
 
   parsedMidLines(): Array<readonly [number, RegExpExecArray]> {
+    if (this.parsedMidLinesCache) {
+      return this.parsedMidLinesCache;
+    }
+
     const midLines = this.collectMidLines();
 
     this.validateMidLinesPresent(midLines);
     this.validateQubitOrder(midLines);
+    this.parsedMidLinesCache = midLines;
 
     return midLines;
   }
 
   wireWidth(): number {
-    return Math.max(...this.parsedMidLines().map(([_lineIndex, match]) => charLength(match.groups?.wire ?? '')), 0);
+    this.wireWidthCache ??= Math.max(
+      ...this.parsedMidLines().map(([_lineIndex, match]) => charLength(match.groups?.wire ?? '')),
+      0
+    );
+
+    return this.wireWidthCache;
   }
 
   private annotationCandidateSegment(candidateIndex: number): string | undefined {
@@ -125,10 +140,12 @@ class LineSet {
   }
 
   private lines(): string[] {
-    return this.asciiArt
+    this.linesCache ??= this.asciiArt
       .split('\n')
       .map((line) => rstrip(line))
       .filter((line) => line !== '');
+
+    return this.linesCache;
   }
 
   private validateMidLinesPresent(midLines: Array<readonly [number, RegExpExecArray]>): void {
@@ -148,11 +165,17 @@ class LineSet {
   }
 
   private wireLabelWidth(): number {
-    return Math.max(...this.parsedMidLines().map(([_lineIndex, match]) => charLength(match.groups?.prefix ?? '')));
+    this.wireLabelWidthCache ??= Math.max(
+      ...this.parsedMidLines().map(([_lineIndex, match]) => charLength(match.groups?.prefix ?? ''))
+    );
+
+    return this.wireLabelWidthCache;
   }
 
   private wirePrefix(): string {
-    return ' '.repeat(this.wireLabelWidth());
+    this.wirePrefixCache ??= ' '.repeat(this.wireLabelWidth());
+
+    return this.wirePrefixCache;
   }
 
   private wireSegmentFor(line: string): string {

--- a/src/view/ascii_circuit_parser.ts
+++ b/src/view/ascii_circuit_parser.ts
@@ -1,0 +1,509 @@
+import type { CircuitData } from '../circuit_file';
+import { AngleExpression } from '../angle_expression';
+
+const CELL_WIDTH = 5;
+const CONTROL_SYMBOL = '•';
+const EMPTY_SLOT = 1;
+const SQRT_X_SYMBOL = 'X^½';
+const SQRT_X_VIEW_SYMBOL = '√X';
+const SWAP_SYMBOL = 'Swap';
+
+export class AsciiCircuitParserError extends Error {}
+
+interface StepSlice {
+  readonly annotation: string;
+  readonly bottom: string;
+  readonly mid: string;
+  readonly top: string;
+}
+
+const FIXED_GATE_LABELS = new Map<string, string>([
+  ['H', 'H'],
+  ['S', 'S'],
+  ['S†', 'S†'],
+  ['T', 'T'],
+  ['T†', 'T†'],
+  ['X', 'X'],
+  ['Y', 'Y'],
+  ['Z', 'Z'],
+  [SQRT_X_VIEW_SYMBOL, SQRT_X_SYMBOL]
+]);
+const ANGLED_GATE_LABELS = new Set(['P', 'Rx', 'Ry', 'Rz']);
+const ANGLED_GATE_ERROR = 'ASCII parser angled gates require a dedicated angle line above the box';
+const BOX_BORDER_PATTERN = /[┌┐└┘├┤]/u;
+const MID_LINE_PATTERN = /^q(?<qubit>\d+): (?<wire>.*)$/u;
+const UNEXPECTED_ANGLE_ERROR = 'ASCII parser angle lines are only supported for Rx, Ry, Rz, and P boxes';
+
+export class AsciiCircuitParser {
+  private readonly asciiArt: string;
+
+  constructor(asciiArt: string) {
+    this.asciiArt = asciiArt;
+  }
+
+  parse(): CircuitData {
+    return new AsciiWireLayout(this.asciiArt).toCircuitData();
+  }
+}
+
+export function parseAsciiCircuit(asciiArt: string): CircuitData {
+  return new AsciiCircuitParser(asciiArt).parse();
+}
+
+class LineSet {
+  private readonly asciiArt: string;
+
+  constructor(asciiArt: string) {
+    this.asciiArt = asciiArt;
+  }
+
+  adjacentWireSegment(lineIndex: number): string | undefined {
+    if (lineIndex < 0 || lineIndex >= this.lines().length) {
+      return undefined;
+    }
+
+    const line = this.lines()[lineIndex];
+
+    if (MID_LINE_PATTERN.test(line)) {
+      return undefined;
+    }
+
+    return this.wireSegmentFor(line);
+  }
+
+  annotationWireSegment(lineIndex: number): string | undefined {
+    if (!this.adjacentWireSegment(lineIndex - 1)?.match(BOX_BORDER_PATTERN)) {
+      return undefined;
+    }
+
+    return this.annotationCandidateSegment(lineIndex - 2);
+  }
+
+  parsedMidLines(): Array<readonly [number, RegExpExecArray]> {
+    const midLines = this.collectMidLines();
+
+    this.validateMidLinesPresent(midLines);
+    this.validateQubitOrder(midLines);
+
+    return midLines;
+  }
+
+  wireWidth(): number {
+    return Math.max(...this.parsedMidLines().map(([_lineIndex, match]) => charLength(match.groups?.wire ?? '')), 0);
+  }
+
+  private annotationCandidateSegment(candidateIndex: number): string | undefined {
+    if (candidateIndex < 0 || candidateIndex >= this.lines().length) {
+      return undefined;
+    }
+
+    const segment = this.annotationSegment(candidateIndex);
+
+    if (segment && segment.trim() !== '' && !BOX_BORDER_PATTERN.test(segment)) {
+      return segment;
+    }
+
+    return undefined;
+  }
+
+  private annotationSegment(candidateIndex: number): string | undefined {
+    const line = this.lines()[candidateIndex];
+
+    if (MID_LINE_PATTERN.test(line)) {
+      return undefined;
+    }
+
+    return this.wireSegmentFor(line);
+  }
+
+  private collectMidLines(): Array<readonly [number, RegExpExecArray]> {
+    return this.lines().flatMap((line, index) => {
+      const match = MID_LINE_PATTERN.exec(line);
+
+      return match ? [[index, match] as const] : [];
+    });
+  }
+
+  private lines(): string[] {
+    return this.asciiArt
+      .split('\n')
+      .map((line) => rstrip(line))
+      .filter((line) => line !== '');
+  }
+
+  private validateMidLinesPresent(midLines: Array<readonly [number, RegExpExecArray]>): void {
+    if (midLines.length === 0) {
+      throw new AsciiCircuitParserError('ASCII parser requires at least one qubit line');
+    }
+  }
+
+  private validateQubitOrder(midLines: Array<readonly [number, RegExpExecArray]>): void {
+    const qubits = midLines.map(([_lineIndex, match]) => Number(match.groups?.qubit ?? -1));
+
+    if (qubits.every((qubit, index) => qubit === index)) {
+      return;
+    }
+
+    throw new AsciiCircuitParserError('ASCII parser requires q0..qn qubit order');
+  }
+
+  private wireLabelWidth(): number {
+    return Math.max(...this.parsedMidLines().map(([_lineIndex, match]) => match.index + `q${match.groups?.qubit}: `.length));
+  }
+
+  private wirePrefix(): string {
+    return ' '.repeat(this.wireLabelWidth());
+  }
+
+  private wireSegmentFor(line: string): string {
+    if (!line.startsWith(this.wirePrefix())) {
+      throw new AsciiCircuitParserError('ASCII parser lines must align to whole step cells');
+    }
+
+    return line.slice(this.wirePrefix().length);
+  }
+}
+
+class BoxWidthDetector {
+  private readonly wire: string;
+
+  constructor(wire: string) {
+    this.wire = wire;
+  }
+
+  widthFrom(position: number): number | undefined {
+    const wireChars = chars(this.wire);
+    const startChar = wireChars[position];
+    const closingChar = startChar === '┌' ? '┐' : startChar === '└' ? '┘' : undefined;
+
+    if (!closingChar) {
+      return undefined;
+    }
+
+    const closingIndex = wireChars.findIndex((char, index) => index >= position && char === closingChar);
+
+    if (closingIndex === -1) {
+      return undefined;
+    }
+
+    return closingIndex - position + 1;
+  }
+}
+
+class WireRow {
+  private readonly annotation: string;
+  private readonly bottom: string;
+  private readonly mid: string;
+  private readonly top: string;
+
+  constructor(options: { annotation: string; bottom: string; mid: string; top: string }) {
+    this.annotation = options.annotation;
+    this.top = options.top;
+    this.mid = options.mid;
+    this.bottom = options.bottom;
+  }
+
+  boxWidthsAt(position: number): number[] {
+    return [this.top, this.bottom].flatMap((wire) => {
+      const width = new BoxWidthDetector(wire).widthFrom(position);
+
+      return width === undefined ? [] : [width];
+    });
+  }
+
+  stepSlice(position: number, stepWidth: number): StepSlice {
+    return {
+      annotation: sliceChars(this.annotation, position, stepWidth),
+      bottom: sliceChars(this.bottom, position, stepWidth),
+      mid: sliceChars(this.mid, position, stepWidth),
+      top: sliceChars(this.top, position, stepWidth)
+    };
+  }
+}
+
+class AsciiWireLayout {
+  private readonly asciiArt: string;
+
+  constructor(asciiArt: string) {
+    this.asciiArt = asciiArt;
+  }
+
+  toCircuitData(): CircuitData {
+    return {
+      cols: this.eachStep().map((stepSlices) => new AsciiStepParser(stepSlices).toSlots()),
+      qubits: this.qubitCount()
+    };
+  }
+
+  private buildWireRow(lineIndex: number, match: RegExpExecArray): WireRow {
+    return new WireRow({
+      annotation: this.paddedWireSegment(this.lineSet().annotationWireSegment(lineIndex)),
+      bottom: this.paddedWireSegment(this.lineSet().adjacentWireSegment(lineIndex + 1)),
+      mid: this.paddedWireSegment(match.groups?.wire ?? ''),
+      top: this.paddedWireSegment(this.lineSet().adjacentWireSegment(lineIndex - 1))
+    });
+  }
+
+  private boxWidthsAt(position: number): number[] {
+    return this.wireRows().flatMap((wireRow) => wireRow.boxWidthsAt(position));
+  }
+
+  private eachStep(): StepSlice[][] {
+    const result: StepSlice[][] = [];
+    let position = 0;
+
+    while (position < this.wireWidth()) {
+      result.push(this.stepSlices(position));
+      position += this.stepWidthAt(position);
+    }
+
+    return result;
+  }
+
+  private lineSet(): LineSet {
+    return new LineSet(this.asciiArt);
+  }
+
+  private paddedWireSegment(segment: string | undefined): string {
+    return ljust(segment ?? '', this.wireWidth());
+  }
+
+  private qubitCount(): number {
+    return this.lineSet().parsedMidLines().length;
+  }
+
+  private stepSlices(position: number): StepSlice[] {
+    const stepWidth = this.stepWidthAt(position);
+
+    return this.wireRows().map((wireRow) => wireRow.stepSlice(position, stepWidth));
+  }
+
+  private stepWidthAt(position: number): number {
+    const widths = this.boxWidthsAt(position);
+    const width = widths.length > 0 ? Math.max(...widths) : undefined;
+
+    if (width !== undefined) {
+      return width;
+    }
+
+    if (this.wireWidth() - position >= CELL_WIDTH) {
+      return CELL_WIDTH;
+    }
+
+    throw new AsciiCircuitParserError('ASCII parser lines must align to whole step cells');
+  }
+
+  private wireRows(): WireRow[] {
+    return this.lineSet().parsedMidLines().map(([lineIndex, match]) => this.buildWireRow(lineIndex, match));
+  }
+
+  private wireWidth(): number {
+    return this.lineSet().wireWidth();
+  }
+}
+
+class AsciiStepParser {
+  private readonly stepSlices: StepSlice[];
+
+  constructor(stepSlices: StepSlice[]) {
+    this.stepSlices = stepSlices;
+  }
+
+  toSlots(): unknown[] {
+    const state = new AsciiStepParseState(this.stepSlices.length);
+
+    for (const [qubit, stepSlice] of this.stepSlices.entries()) {
+      this.applyMidCell(stepSlice, qubit, state);
+    }
+
+    return state.finish();
+  }
+
+  private applyMidCell(stepSlice: StepSlice, qubit: number, state: AsciiStepParseState): void {
+    const action = this.slotActionFor(stepSlice);
+
+    if (action !== 'empty') {
+      state.mark(qubit, action);
+    }
+  }
+
+  private slotActionFor(stepSlice: StepSlice): SlotAction {
+    const gateSymbol = new AsciiGateSymbolResolver().resolve(stepSlice);
+
+    if (gateSymbol) {
+      return gateSymbol;
+    }
+
+    const action = new AsciiStepMidCell(stepSlice.mid).slotAction();
+
+    if (action !== 'unsupported') {
+      return action;
+    }
+
+    throw new AsciiCircuitParserError('ASCII parser currently supports boxed fixed gates and empty wires only');
+  }
+}
+
+type SlotAction = 'control' | 'empty' | 'swap' | string;
+
+class AsciiStepParseState {
+  private readonly controls: number[] = [];
+  private readonly gateTargets: number[] = [];
+  private readonly slots: unknown[];
+  private readonly swapTargets: number[] = [];
+
+  constructor(qubitCount: number) {
+    this.slots = Array.from({ length: qubitCount }, () => EMPTY_SLOT);
+  }
+
+  finish(): unknown[] {
+    this.validateShape();
+
+    return this.slots;
+  }
+
+  mark(qubit: number, action: SlotAction): void {
+    if (action === 'control') {
+      this.markControl(qubit);
+    } else if (action === 'swap') {
+      this.markSwap(qubit);
+    } else {
+      this.markGate(qubit, action);
+    }
+  }
+
+  private markControl(qubit: number): void {
+    this.slots[qubit] = CONTROL_SYMBOL;
+    this.controls.push(qubit);
+  }
+
+  private markGate(qubit: number, gateSymbol: string): void {
+    this.slots[qubit] = gateSymbol;
+    this.gateTargets.push(qubit);
+  }
+
+  private markSwap(qubit: number): void {
+    this.slots[qubit] = SWAP_SYMBOL;
+    this.swapTargets.push(qubit);
+  }
+
+  private validateShape(): void {
+    if (this.validShape()) {
+      return;
+    }
+
+    throw new AsciiCircuitParserError('ASCII parser currently supports one target gate or one swap per step');
+  }
+
+  private validShape(): boolean {
+    const noSpecialMarkers = this.controls.length === 0 && this.swapTargets.length === 0;
+    const controlledGateStep =
+      this.controls.length > 0 && this.gateTargets.length === 1 && this.swapTargets.length === 0;
+    const swapStep = this.swapTargets.length === 2 && this.controls.length === 0 && this.gateTargets.length === 0;
+
+    return noSpecialMarkers || controlledGateStep || swapStep;
+  }
+}
+
+class AsciiStepMidCell {
+  private static readonly BOX_PATTERN = /^┤(?<label>.+)├$/u;
+  private static readonly CONTROL_PATTERN = /^─*■─*$/u;
+  private static readonly EMPTY_PATTERN = /^─+$/u;
+  private static readonly SWAP_PATTERN = /^─*X─*$/u;
+  private static readonly VERTICAL_BRIDGE_PATTERN = /^─*│─*$/u;
+  private readonly midCell: string;
+
+  constructor(midCell: string) {
+    this.midCell = midCell;
+  }
+
+  gateLabel(): string | undefined {
+    return AsciiStepMidCell.BOX_PATTERN.exec(this.midCell)?.groups?.label?.trim();
+  }
+
+  slotAction(): 'control' | 'empty' | 'swap' | 'unsupported' {
+    if (AsciiStepMidCell.CONTROL_PATTERN.test(this.midCell)) {
+      return 'control';
+    }
+
+    if (AsciiStepMidCell.SWAP_PATTERN.test(this.midCell)) {
+      return 'swap';
+    }
+
+    if (AsciiStepMidCell.EMPTY_PATTERN.test(this.midCell) || AsciiStepMidCell.VERTICAL_BRIDGE_PATTERN.test(this.midCell)) {
+      return 'empty';
+    }
+
+    return 'unsupported';
+  }
+}
+
+class AsciiGateSymbolResolver {
+  resolve(stepSlice: StepSlice): string | undefined {
+    const label = new AsciiStepMidCell(stepSlice.mid).gateLabel();
+
+    if (!label) {
+      return undefined;
+    }
+
+    const annotation = stepSlice.annotation.trim();
+
+    if (/^[A-Za-z]+\(.+\)$/u.test(label)) {
+      throw new AsciiCircuitParserError(ANGLED_GATE_ERROR);
+    }
+
+    return this.angledGateSymbolFor(label, annotation) ?? this.fixedGateSymbolFor(label, annotation);
+  }
+
+  private angledGateSymbolFor(label: string, annotation: string): string | undefined {
+    if (!ANGLED_GATE_LABELS.has(label)) {
+      return undefined;
+    }
+
+    if (annotation === '') {
+      throw new AsciiCircuitParserError(ANGLED_GATE_ERROR);
+    }
+
+    return `${label}(${new AngleExpression(annotation).toString()})`;
+  }
+
+  private fixedGateSymbolFor(label: string, annotation: string): string {
+    if (annotation !== '') {
+      throw new AsciiCircuitParserError(UNEXPECTED_ANGLE_ERROR);
+    }
+
+    const symbol = FIXED_GATE_LABELS.get(label);
+
+    if (!symbol) {
+      throw new AsciiCircuitParserError(`unsupported ASCII gate label: ${JSON.stringify(label)}`);
+    }
+
+    return symbol;
+  }
+}
+
+function charLength(value: string): number {
+  return chars(value).length;
+}
+
+function chars(value: string): string[] {
+  return [...value];
+}
+
+function ljust(value: string, width: number): string {
+  const valueLength = charLength(value);
+
+  if (width <= valueLength) {
+    return value;
+  }
+
+  return value + ' '.repeat(width - valueLength);
+}
+
+function rstrip(value: string): string {
+  return value.replace(/\s+$/u, '');
+}
+
+function sliceChars(value: string, start: number, length: number): string {
+  return chars(value).slice(start, start + length).join('');
+}

--- a/src/view/text_renderer.ts
+++ b/src/view/text_renderer.ts
@@ -545,6 +545,11 @@ class TextLineMerger {
   ]);
   private readonly blankBottomDoubleVerticalChars = new Set(['║', '╫', '╬']);
   private readonly blankBottomVerticalChars = new Set(['│', '┼', '╪']);
+  private readonly bottomPriorityVerticalChars = new Set(['│', '┼', '╪', '┬']);
+  private readonly bottomTopCornerChars = new Set(['┐', '┌']);
+  private readonly topCornerBottomChars = new Set(['║', '│']);
+  private readonly topCornerChars = new Set(['┬', '╥']);
+  private readonly topPriorityBottomCorners = new Set(['┘', '└']);
 
   mergeBottom(topLine: string, bottomLine: string): string {
     return this.merge(topLine, bottomLine, (topChar, bottomChar) => {
@@ -606,7 +611,7 @@ class TextLineMerger {
   }
 
   private mergeBlankBottomWithBottomPriority(topChar: string): string {
-    if (new Set(['│', '┼', '╪', '┬']).has(topChar)) {
+    if (this.bottomPriorityVerticalChars.has(topChar)) {
       return '│';
     }
 
@@ -622,7 +627,7 @@ class TextLineMerger {
   }
 
   private mergeTopPriority(topChar: string, bottomChar: string): string | undefined {
-    if (new Set(['┬', '╥']).has(topChar) && new Set(['║', '│']).has(bottomChar)) {
+    if (this.topCornerChars.has(topChar) && this.topCornerBottomChars.has(bottomChar)) {
       return topChar;
     }
 
@@ -632,11 +637,11 @@ class TextLineMerger {
       return cornerMerge;
     }
 
-    if (new Set(['┐', '┌']).has(bottomChar)) {
+    if (this.bottomTopCornerChars.has(bottomChar)) {
       return '┬';
     }
 
-    if (new Set(['┘', '└']).has(topChar) && bottomChar === '─') {
+    if (this.topPriorityBottomCorners.has(topChar) && bottomChar === '─') {
       return '┴';
     }
 

--- a/src/view/text_renderer.ts
+++ b/src/view/text_renderer.ts
@@ -1,0 +1,876 @@
+import type { CircuitData } from '../circuit_file';
+
+const CONTROL_SYMBOL = '•';
+const DIM_SUFFIX_PATTERN = /┤ ([A-Z])([xyz†])├/gu;
+const DIM_WHITE = '\u001B[37;2m';
+const EMPTY_SLOT = 1;
+const RESET_FORMATTING = '\u001B[0m';
+const SQRT_X_SYMBOL = 'X^½';
+const SQRT_X_VIEW_SYMBOL = '√X';
+const SWAP_SYMBOL = 'Swap';
+
+class ConnectedLineStyle {
+  readonly background: string;
+  private readonly connect: string;
+  private readonly format: string;
+  private readonly pad: string;
+
+  constructor(options: { background?: string; connect?: string; format?: string; pad?: string } = {}) {
+    this.background = options.background ?? ' ';
+    this.connect = options.connect ?? ' ';
+    this.format = options.format ?? '%s';
+    this.pad = options.pad ?? ' ';
+  }
+
+  render(width: number): string {
+    return format(this.format, center(this.connect, width, this.pad));
+  }
+}
+
+class MidLineStyle {
+  readonly background: string;
+  private readonly format: string;
+  private readonly padding: string;
+
+  constructor(options: { background?: string; format?: string; padding?: string } = {}) {
+    this.background = options.background ?? ' ';
+    this.format = options.format ?? '%s';
+    this.padding = options.padding ?? ' ';
+  }
+
+  render(label: string, width: number): string {
+    return format(this.format, center(label, width, this.padding));
+  }
+}
+
+class CellStyle {
+  readonly bot: ConnectedLineStyle;
+  readonly mid: MidLineStyle;
+  readonly top: ConnectedLineStyle;
+
+  constructor(options: { bot: ConnectedLineStyle; mid: MidLineStyle; top: ConnectedLineStyle }) {
+    this.bot = options.bot;
+    this.mid = options.mid;
+    this.top = options.top;
+  }
+}
+
+const DEFAULT_STYLE = new CellStyle({
+  bot: new ConnectedLineStyle(),
+  mid: new MidLineStyle(),
+  top: new ConnectedLineStyle()
+});
+
+class DrawElement {
+  protected readonly annotationText: string;
+  protected readonly label: string;
+  protected layerWidth = 0;
+  protected readonly style: CellStyle;
+
+  constructor(label = '', style = DEFAULT_STYLE, annotationText = '') {
+    this.annotationText = annotationText;
+    this.label = label;
+    this.style = style;
+  }
+
+  annotation(): string {
+    return center(this.annotationText, Math.max(this.layerWidth, charLength(this.annotationText)), ' ');
+  }
+
+  bot(): string {
+    return this.renderConnectedLine(this.style.bot);
+  }
+
+  expandToLayer(width: number): void {
+    this.layerWidth = width;
+  }
+
+  length(): number {
+    return Math.max(
+      charLength(this.annotation()),
+      charLength(this.top()),
+      charLength(this.mid()),
+      charLength(this.bot())
+    );
+  }
+
+  mid(): string {
+    const middleStyle = this.style.mid;
+
+    return center(middleStyle.render(this.label, this.width()), this.layerWidth, middleStyle.background);
+  }
+
+  top(): string {
+    return this.renderConnectedLine(this.style.top);
+  }
+
+  protected width(): number {
+    return charLength(this.label);
+  }
+
+  private renderConnectedLine(lineStyle: ConnectedLineStyle): string {
+    return center(lineStyle.render(this.width()), this.layerWidth, lineStyle.background);
+  }
+}
+
+class BoxOnQuWire extends DrawElement {
+  private static readonly COMPACT_LABEL_PATTERN = /^[A-Z][xyz†]$/u;
+  private static readonly COMPACT_FORMAT = ['┌─%s┐', '┤ %s├', '└─%s┘'] as const;
+  private static readonly LEADING_COMPACT_FORMAT = ['┌─%s┐', '┤%s ├', '└─%s┘'] as const;
+  private static readonly LEADING_COMPACT_LABEL_PATTERN = /^√[A-Z]$/u;
+  private static readonly STANDARD_FORMAT = ['┌─%s─┐', '┤ %s ├', '└─%s─┘'] as const;
+
+  static build(label: string, options: { botConnect?: string; topConnect?: string } = {}): BoxOnQuWire {
+    return new BoxOnQuWire(label, {
+      formatParts: BoxOnQuWire.formatFor(label),
+      ...options
+    });
+  }
+
+  static formatFor(label: string): readonly [string, string, string] {
+    if (BoxOnQuWire.COMPACT_LABEL_PATTERN.test(label)) {
+      return BoxOnQuWire.COMPACT_FORMAT;
+    }
+
+    if (BoxOnQuWire.LEADING_COMPACT_LABEL_PATTERN.test(label)) {
+      return BoxOnQuWire.LEADING_COMPACT_FORMAT;
+    }
+
+    return BoxOnQuWire.STANDARD_FORMAT;
+  }
+
+  private static styleFor(options: {
+    botConnect: string;
+    formatParts: readonly [string, string, string];
+    topConnect: string;
+  }): CellStyle {
+    return new CellStyle({
+      bot: new ConnectedLineStyle({ connect: options.botConnect, format: options.formatParts[2], pad: '─' }),
+      mid: new MidLineStyle({ background: '─', format: options.formatParts[1] }),
+      top: new ConnectedLineStyle({ connect: options.topConnect, format: options.formatParts[0], pad: '─' })
+    });
+  }
+
+  constructor(
+    label: string,
+    options: {
+      annotationText?: string;
+      botConnect?: string;
+      formatParts?: readonly [string, string, string];
+      topConnect?: string;
+    } = {}
+  ) {
+    super(
+      label,
+      BoxOnQuWire.styleFor({
+        botConnect: options.botConnect ?? '─',
+        formatParts: options.formatParts ?? BoxOnQuWire.STANDARD_FORMAT,
+        topConnect: options.topConnect ?? '─'
+      }),
+      options.annotationText ?? ''
+    );
+  }
+}
+
+class AngledBoxOnQuWire extends BoxOnQuWire {
+  annotation(): string {
+    const annotationWidth = Math.max(this.layerWidth, charLength(this.annotationText));
+    const annotationTextLength = charLength(this.annotationText);
+
+    if (annotationWidth === annotationTextLength) {
+      return this.annotationText;
+    }
+
+    const padding = annotationWidth - annotationTextLength;
+    const leftPadding = Math.min(Math.floor(padding / 2) + 1, padding);
+
+    return ljust(rjust(this.annotationText, annotationTextLength + leftPadding), annotationWidth);
+  }
+}
+
+class DirectOnQuWire extends DrawElement {
+  constructor(label: string, options: { botConnect?: string; topConnect?: string } = {}) {
+    super(
+      label,
+      new CellStyle({
+        bot: new ConnectedLineStyle({ connect: options.botConnect ?? ' ', format: ' %s ' }),
+        mid: new MidLineStyle({ background: '─', format: '─%s─', padding: '─' }),
+        top: new ConnectedLineStyle({ connect: options.topConnect ?? ' ', format: ' %s ' })
+      })
+    );
+  }
+}
+
+class Bullet extends DirectOnQuWire {
+  constructor(options: { botConnect?: string; topConnect?: string } = {}) {
+    super('■', options);
+  }
+}
+
+class Ex extends DirectOnQuWire {
+  constructor(options: { botConnect?: string; topConnect?: string } = {}) {
+    super('X', options);
+  }
+}
+
+class VerticalBridge extends DirectOnQuWire {
+  constructor() {
+    super('│', { botConnect: '│', topConnect: '│' });
+  }
+}
+
+class EmptyWire extends DrawElement {
+  constructor(wire = '─') {
+    super(
+      '',
+      new CellStyle({
+        bot: new ConnectedLineStyle(),
+        mid: new MidLineStyle({ background: wire, padding: wire }),
+        top: new ConnectedLineStyle()
+      })
+    );
+  }
+}
+
+class TextGateCell {
+  private static readonly ANGLED_GATE_PATTERN = /^(?<symbol>[A-Za-z]+)\((?<angle>.+)\)$/u;
+  private readonly botConnect: string;
+  private readonly slot: unknown;
+  private readonly topConnect: string;
+
+  constructor(slot: unknown, options: { botConnect?: string; topConnect?: string } = {}) {
+    this.slot = slot;
+    this.topConnect = options.topConnect ?? '─';
+    this.botConnect = options.botConnect ?? '─';
+  }
+
+  build(): DrawElement {
+    const angledMatch = this.angledMatch();
+
+    if (!angledMatch?.groups) {
+      return BoxOnQuWire.build(this.label(), {
+        botConnect: this.botConnect,
+        topConnect: this.topConnect
+      });
+    }
+
+    return new AngledBoxOnQuWire(this.label(), {
+      annotationText: this.renderedAngle(angledMatch.groups.angle),
+      botConnect: this.botConnect,
+      formatParts: BoxOnQuWire.formatFor(this.label()),
+      topConnect: this.topConnect
+    });
+  }
+
+  private angledMatch(): RegExpExecArray | null {
+    return TextGateCell.ANGLED_GATE_PATTERN.exec(String(this.slot));
+  }
+
+  private label(): string {
+    const angledMatch = this.angledMatch();
+
+    if (this.slot === SQRT_X_SYMBOL) {
+      return SQRT_X_VIEW_SYMBOL;
+    }
+
+    return angledMatch?.groups?.symbol ?? String(this.slot);
+  }
+
+  private renderedAngle(angle: string): string {
+    return angle.replaceAll('theta', 'θ').replace(/(?<=\d)\*θ/gu, 'θ');
+  }
+}
+
+class GatePlacement {
+  readonly qubit: number;
+  private readonly slot: unknown;
+
+  constructor(slot: unknown, qubit: number) {
+    this.slot = slot;
+    this.qubit = qubit;
+  }
+
+  cell(options: { botConnect?: string; topConnect?: string } = {}): DrawElement {
+    return new TextGateCell(this.slot, options).build();
+  }
+
+  emptyWireOn(layer: TextLayer): boolean {
+    return layer.emptyWireAt(this.qubit);
+  }
+
+  placeOn(layer: TextLayer, options: { botConnect?: string; topConnect?: string } = {}): void {
+    layer.place(this.qubit, this.cell(options));
+  }
+
+  placeOnIfEmpty(layer: TextLayer): void {
+    if (this.emptyWireOn(layer)) {
+      this.placeOn(layer);
+    }
+  }
+}
+
+class TextStep {
+  private static readonly NON_GATE_SLOTS = new Set<unknown>([EMPTY_SLOT, CONTROL_SYMBOL, SWAP_SYMBOL]);
+  private readonly rawStep: unknown[];
+
+  constructor(rawStep: unknown[]) {
+    this.rawStep = rawStep;
+  }
+
+  controlQubits(): number[] {
+    return this.rawStep.flatMap((slot, index) => (slot === CONTROL_SYMBOL ? [index] : []));
+  }
+
+  controlledTarget(): GatePlacement | undefined {
+    const controlQubits = this.controlQubits();
+    const targetedGates = this.targetedGates();
+
+    if (controlQubits.length > 0 && targetedGates.length === 1) {
+      return targetedGates[0];
+    }
+
+    return undefined;
+  }
+
+  emptySlot(qubit: number): boolean {
+    return this.rawStep[qubit] === EMPTY_SLOT;
+  }
+
+  placeSingleGatesOn(layer: TextLayer): void {
+    for (const placement of this.singleGates()) {
+      placement.placeOnIfEmpty(layer);
+    }
+  }
+
+  swapPair(): readonly [number, number] | undefined {
+    const swapQubits = this.rawStep.flatMap((slot, index) => (slot === SWAP_SYMBOL ? [index] : []));
+
+    if (swapQubits.length !== 2) {
+      return undefined;
+    }
+
+    return [Math.min(...swapQubits), Math.max(...swapQubits)];
+  }
+
+  private singleGates(): GatePlacement[] {
+    return this.rawStep.flatMap((slot, qubit) =>
+      TextStep.NON_GATE_SLOTS.has(slot) ? [] : [new GatePlacement(slot, qubit)]
+    );
+  }
+
+  private targetedGates(): GatePlacement[] {
+    return this.singleGates();
+  }
+}
+
+class TextLayer {
+  private readonly cells: DrawElement[];
+
+  constructor(qubits: number) {
+    this.cells = Array.from({ length: qubits }, () => new EmptyWire());
+  }
+
+  emptyWireAt(qubit: number): boolean {
+    return this.fetch(qubit) instanceof EmptyWire;
+  }
+
+  fetch(qubit: number): DrawElement {
+    const cell = this.cells[qubit];
+
+    if (!cell) {
+      throw new Error(`qubit index out of bounds: ${qubit}`);
+    }
+
+    return cell;
+  }
+
+  normalizeWidth(): TextLayer {
+    const longest = Math.max(...this.cells.map((cell) => cell.length()));
+
+    for (const cell of this.cells) {
+      cell.expandToLayer(longest);
+    }
+
+    return this;
+  }
+
+  place(qubit: number, cell: DrawElement): void {
+    this.cells[qubit] = cell;
+  }
+
+  placeSwapEndpoints(topQubit: number, bottomQubit: number): void {
+    this.place(topQubit, new Ex({ botConnect: '│' }));
+    this.place(bottomQubit, new Ex({ topConnect: '│' }));
+  }
+
+  toArray(): DrawElement[] {
+    return this.cells;
+  }
+}
+
+class ControlSpan {
+  private readonly maxQubit: number;
+  private readonly minQubit: number;
+  private readonly targetQubit: number;
+
+  constructor(controlQubits: number[], targetQubit: number) {
+    this.targetQubit = targetQubit;
+    this.minQubit = Math.min(...controlQubits, targetQubit);
+    this.maxQubit = Math.max(...controlQubits, targetQubit);
+  }
+
+  bridgeQubits(): number[] {
+    return range(this.minQubit + 1, this.maxQubit);
+  }
+
+  bulletFor(qubit: number): Bullet {
+    return new Bullet({
+      botConnect: qubit < this.maxQubit ? '│' : ' ',
+      topConnect: qubit > this.minQubit ? '│' : ' '
+    });
+  }
+
+  targetConnectors(): { botConnect: string; topConnect: string } {
+    return {
+      botConnect: this.targetQubit < this.maxQubit ? '┬' : '─',
+      topConnect: this.targetQubit > this.minQubit ? '┴' : '─'
+    };
+  }
+}
+
+class ControlledLayerPlacement {
+  private readonly layer: TextLayer;
+  private readonly span: ControlSpan;
+  private readonly step: TextStep;
+  private readonly target: GatePlacement;
+
+  constructor(layer: TextLayer, step: TextStep, target: GatePlacement) {
+    this.layer = layer;
+    this.step = step;
+    this.target = target;
+    this.span = new ControlSpan(step.controlQubits(), target.qubit);
+  }
+
+  apply(): void {
+    this.placeControlBullets();
+    this.target.placeOn(this.layer, this.span.targetConnectors());
+    this.placeControlBridges();
+  }
+
+  private placeControlBridges(): void {
+    for (const qubit of this.span.bridgeQubits()) {
+      if (this.step.emptySlot(qubit)) {
+        this.layer.place(qubit, new VerticalBridge());
+      }
+    }
+  }
+
+  private placeControlBullets(): void {
+    for (const qubit of this.step.controlQubits()) {
+      this.layer.place(qubit, this.span.bulletFor(qubit));
+    }
+  }
+}
+
+class TextStepLayerBuilder {
+  private readonly qubits: number;
+  private readonly step: TextStep;
+
+  constructor(rawStep: unknown[], qubits: number) {
+    this.step = new TextStep(rawStep);
+    this.qubits = qubits;
+  }
+
+  build(): DrawElement[] {
+    return this.populatedLayer().normalizeWidth().toArray();
+  }
+
+  private placeControlledGate(layer: TextLayer): void {
+    const target = this.step.controlledTarget();
+
+    if (target) {
+      new ControlledLayerPlacement(layer, this.step, target).apply();
+    }
+  }
+
+  private placeSingleGates(layer: TextLayer): void {
+    this.step.placeSingleGatesOn(layer);
+  }
+
+  private placeSwap(layer: TextLayer): void {
+    const swapPair = this.step.swapPair();
+
+    if (!swapPair) {
+      return;
+    }
+
+    const [topQubit, bottomQubit] = swapPair;
+    layer.placeSwapEndpoints(topQubit, bottomQubit);
+    this.placeSwapBridges(layer, topQubit, bottomQubit);
+  }
+
+  private placeSwapBridges(layer: TextLayer, topQubit: number, bottomQubit: number): void {
+    for (const qubit of range(topQubit + 1, bottomQubit)) {
+      if (this.step.emptySlot(qubit)) {
+        layer.place(qubit, new VerticalBridge());
+      }
+    }
+  }
+
+  private populatedLayer(): TextLayer {
+    const layer = new TextLayer(this.qubits);
+
+    this.placeSwap(layer);
+    this.placeControlledGate(layer);
+    this.placeSingleGates(layer);
+
+    return layer;
+  }
+}
+
+class TextLineMerger {
+  private static readonly INTERSECTION_MERGES = new Map<string, string>([
+    [mergeKey('┬', '═'), '╪'],
+    [mergeKey('│', '═'), '╪'],
+    [mergeKey('┬', '─'), '┼'],
+    [mergeKey('│', '─'), '┼'],
+    [mergeKey('║', '═'), '╬'],
+    [mergeKey('╥', '═'), '╬'],
+    [mergeKey('║', '─'), '╫'],
+    [mergeKey('╥', '─'), '╫']
+  ]);
+  private static readonly TOP_CORNER_MERGES = new Map<string, string>([
+    [mergeKey('└', '┌'), '├'],
+    [mergeKey('┘', '┐'), '┤']
+  ]);
+  private readonly blankBottomDoubleVerticalChars = new Set(['║', '╫', '╬']);
+  private readonly blankBottomVerticalChars = new Set(['│', '┼', '╪']);
+
+  mergeBottom(topLine: string, bottomLine: string): string {
+    return this.merge(topLine, bottomLine, (topChar, bottomChar) => {
+      if (bottomChar === ' ') {
+        return this.mergeBlankBottomWithBottomPriority(topChar);
+      }
+
+      return undefined;
+    });
+  }
+
+  mergeTop(topLine: string, bottomLine: string): string {
+    return this.merge(topLine, bottomLine, (topChar, bottomChar) => {
+      if (bottomChar === ' ') {
+        return this.mergeBlankBottomWithTopPriority(topChar);
+      }
+
+      return this.mergeTopPriority(topChar, bottomChar);
+    });
+  }
+
+  private merge(
+    topLine: string,
+    bottomLine: string,
+    customMerge: (topChar: string, bottomChar: string) => string | undefined
+  ): string {
+    const topChars = chars(topLine);
+    const bottomChars = chars(bottomLine);
+
+    return topChars.map((topChar, index) => {
+      const bottomChar = bottomChars[index] ?? ' ';
+
+      if (topChar === bottomChar) {
+        return topChar;
+      }
+
+      if (topChar === ' ') {
+        return bottomChar;
+      }
+
+      return (
+        customMerge(topChar, bottomChar) ??
+        TextLineMerger.INTERSECTION_MERGES.get(mergeKey(topChar, bottomChar)) ??
+        bottomChar
+      );
+    }).join('');
+  }
+
+  private mergeBlankBottomCommon(topChar: string): string | undefined {
+    if (this.blankBottomVerticalChars.has(topChar)) {
+      return '│';
+    }
+
+    if (this.blankBottomDoubleVerticalChars.has(topChar)) {
+      return '║';
+    }
+
+    return undefined;
+  }
+
+  private mergeBlankBottomWithBottomPriority(topChar: string): string {
+    if (new Set(['│', '┼', '╪', '┬']).has(topChar)) {
+      return '│';
+    }
+
+    if (topChar === '╥') {
+      return '║';
+    }
+
+    return this.mergeBlankBottomCommon(topChar) ?? ' ';
+  }
+
+  private mergeBlankBottomWithTopPriority(topChar: string): string {
+    return this.mergeBlankBottomCommon(topChar) ?? topChar;
+  }
+
+  private mergeTopPriority(topChar: string, bottomChar: string): string | undefined {
+    if (new Set(['┬', '╥']).has(topChar) && new Set(['║', '│']).has(bottomChar)) {
+      return topChar;
+    }
+
+    const cornerMerge = TextLineMerger.TOP_CORNER_MERGES.get(mergeKey(topChar, bottomChar));
+
+    if (cornerMerge) {
+      return cornerMerge;
+    }
+
+    if (new Set(['┐', '┌']).has(bottomChar)) {
+      return '┬';
+    }
+
+    if (new Set(['┘', '└']).has(topChar) && bottomChar === '─') {
+      return '┴';
+    }
+
+    return undefined;
+  }
+}
+
+class TextWireLines {
+  private readonly layers: DrawElement[][];
+  private readonly qubit: number;
+  private readonly wireFrame: { label: string; labelWidth: number; prefix: string };
+
+  constructor(
+    layers: DrawElement[][],
+    qubit: number,
+    options: { wireLabel: string; wireLabelWidth: number; wirePrefix: string }
+  ) {
+    this.layers = layers;
+    this.qubit = qubit;
+    this.wireFrame = {
+      label: options.wireLabel,
+      labelWidth: options.wireLabelWidth,
+      prefix: options.wirePrefix
+    };
+  }
+
+  toArray(): string[] {
+    return [
+      this.framedLine('annotation'),
+      this.framedLine('top'),
+      this.labeledMidLine(),
+      this.framedLine('bot')
+    ];
+  }
+
+  private cells(): DrawElement[] {
+    return this.layers.map((layer) => layer[this.qubit]);
+  }
+
+  private framedLine(part: 'annotation' | 'bot' | 'top'): string {
+    return this.wireFrame.prefix + this.renderedRow(part);
+  }
+
+  private labeledMidLine(): string {
+    return rjust(this.wireFrame.label, this.wireFrame.labelWidth) + this.renderedRow('mid');
+  }
+
+  private renderedRow(part: 'annotation' | 'bot' | 'mid' | 'top'): string {
+    return this.cells().map((cell) => cell[part]()).join('');
+  }
+}
+
+class TextWireCanvas {
+  private readonly lineMerger: TextLineMerger;
+  private readonly lines: string[] = [];
+  private previousBottom: string | undefined;
+
+  constructor(lineMerger: TextLineMerger) {
+    this.lineMerger = lineMerger;
+  }
+
+  append(wireLines: string[]): void {
+    const [annotationLine, topLine, midLine, bottomLine] = wireLines;
+    const mergedTop = this.mergedTopLine(topLine);
+
+    this.appendAnnotationLine(annotationLine);
+    this.appendBodyLines(mergedTop, midLine, bottomLine);
+    this.previousBottom = bottomLine;
+  }
+
+  toArray(): string[] {
+    return trimmedLines(this.lines);
+  }
+
+  private appendAnnotationLine(annotationLine: string): void {
+    if (annotationLine.trim() !== '') {
+      this.lines.push(annotationLine);
+    }
+  }
+
+  private appendBodyLines(mergedTopLine: string, midLine: string, bottomLine: string): void {
+    this.lines.push(mergedTopLine);
+    this.appendMergedLine(midLine);
+    this.appendMergedLine(bottomLine);
+  }
+
+  private appendMergedLine(nextLine: string): void {
+    const currentLine = this.lines[this.lines.length - 1];
+    this.lines.push(this.lineMerger.mergeBottom(currentLine, nextLine));
+  }
+
+  private mergedTopLine(topLine: string): string {
+    if (!this.previousBottom) {
+      return topLine;
+    }
+
+    const previousLine = this.lines.pop();
+
+    if (previousLine === undefined) {
+      return topLine;
+    }
+
+    return this.lineMerger.mergeTop(previousLine, topLine);
+  }
+}
+
+export type TextRendererStyle = 'colorized' | 'plain';
+
+export class TextRenderer {
+  private readonly circuit: CircuitData;
+  private readonly style: TextRendererStyle;
+
+  constructor(circuit: CircuitData, options: { style?: TextRendererStyle } = {}) {
+    this.circuit = circuit;
+    this.style = options.style ?? 'plain';
+  }
+
+  render(): string {
+    const output = this.drawWires(this.stepLayers()).join('\n');
+
+    if (this.style !== 'colorized') {
+      return output;
+    }
+
+    return colorizeCompactSuffixes(output);
+  }
+
+  private drawWires(layers: DrawElement[][]): string[] {
+    const canvas = new TextWireCanvas(new TextLineMerger());
+
+    for (let qubit = 0; qubit < this.circuit.qubits; qubit += 1) {
+      canvas.append(this.wireLines(layers, qubit));
+    }
+
+    return canvas.toArray();
+  }
+
+  private stepLayers(): DrawElement[][] {
+    return this.circuit.cols.map((rawStep) => new TextStepLayerBuilder(rawStep, this.circuit.qubits).build());
+  }
+
+  private wireLabel(qubit: number): string {
+    return `q${qubit}: `;
+  }
+
+  private wireLabelWidth(): number {
+    return charLength(this.wireLabel(this.circuit.qubits - 1));
+  }
+
+  private wireLines(layers: DrawElement[][], qubit: number): string[] {
+    return new TextWireLines(layers, qubit, {
+      wireLabel: this.wireLabel(qubit),
+      wireLabelWidth: this.wireLabelWidth(),
+      wirePrefix: ' '.repeat(this.wireLabelWidth())
+    }).toArray();
+  }
+}
+
+export function colorizeCompactSuffixes(output: string): string {
+  return output.replace(DIM_SUFFIX_PATTERN, (_match, base: string, suffix: string) => {
+    return `┤ ${base}${DIM_WHITE}${suffix}${RESET_FORMATTING}├`;
+  });
+}
+
+function center(value: string, width: number, pad = ' '): string {
+  const valueLength = charLength(value);
+
+  if (width <= valueLength) {
+    return value;
+  }
+
+  const totalPadding = width - valueLength;
+  const leftPadding = Math.floor(totalPadding / 2);
+  const rightPadding = totalPadding - leftPadding;
+
+  return pad.repeat(leftPadding) + value + pad.repeat(rightPadding);
+}
+
+function charLength(value: string): number {
+  return chars(value).length;
+}
+
+function chars(value: string): string[] {
+  return [...value];
+}
+
+function format(template: string, value: string): string {
+  return template.replace('%s', value);
+}
+
+function ljust(value: string, width: number, pad = ' '): string {
+  const valueLength = charLength(value);
+
+  if (width <= valueLength) {
+    return value;
+  }
+
+  return value + pad.repeat(width - valueLength);
+}
+
+function mergeKey(topChar: string, bottomChar: string): string {
+  return `${topChar}\0${bottomChar}`;
+}
+
+function range(start: number, endExclusive: number): number[] {
+  return Array.from({ length: Math.max(0, endExclusive - start) }, (_value, index) => start + index);
+}
+
+function rjust(value: string, width: number, pad = ' '): string {
+  const valueLength = charLength(value);
+
+  if (width <= valueLength) {
+    return value;
+  }
+
+  return pad.repeat(width - valueLength) + value;
+}
+
+function trimmedLines(lines: string[]): string[] {
+  return trimTrailingBlankLines(trimLeadingBlankLines(lines));
+}
+
+function trimLeadingBlankLines(lines: string[]): string[] {
+  const firstNonBlank = lines.findIndex((line) => line.trim() !== '');
+
+  return firstNonBlank === -1 ? [] : lines.slice(firstNonBlank);
+}
+
+function trimTrailingBlankLines(lines: string[]): string[] {
+  let end = lines.length;
+
+  while (end > 0 && lines[end - 1].trim() === '') {
+    end -= 1;
+  }
+
+  return lines.slice(0, end);
+}

--- a/src/view/text_renderer.ts
+++ b/src/view/text_renderer.ts
@@ -1,4 +1,4 @@
-import type { CircuitData } from '../circuit_file';
+import { CircuitFileError, type CircuitData } from '../circuit_file';
 
 const CONTROL_SYMBOL = '•';
 const DIM_SUFFIX_PATTERN = /┤ ([A-Z])([xyz†])├/gu;
@@ -378,7 +378,7 @@ class TextLayer {
     const cell = this.cells[qubit];
 
     if (!cell) {
-      throw new Error(`qubit index out of bounds: ${qubit}`);
+      throw new CircuitFileError(`qubit index out of bounds: ${qubit} (qubits: ${this.cells.length})`);
     }
 
     return cell;

--- a/test/typescript/process_compatibility.test.ts
+++ b/test/typescript/process_compatibility.test.ts
@@ -9,6 +9,7 @@ import {
   chooseCommandImplementation,
   commandLineArgs,
   createRubyFallbackInvocation,
+  rubyFallbackSyncStdio,
   runRubyFallback,
   runRubyFallbackSync,
   runSubprocess
@@ -38,6 +39,36 @@ async function withTempDir<T>(callback: (dir: string) => Promise<T>): Promise<T>
     return await callback(dir);
   } finally {
     await rm(dir, { force: true, recursive: true });
+  }
+}
+
+function withProcessTty<T>(isTTY: boolean, callback: () => T): T {
+  const stdoutDescriptor = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+  const stderrDescriptor = Object.getOwnPropertyDescriptor(process.stderr, 'isTTY');
+
+  Object.defineProperty(process.stdout, 'isTTY', {
+    configurable: true,
+    value: isTTY
+  });
+  Object.defineProperty(process.stderr, 'isTTY', {
+    configurable: true,
+    value: isTTY
+  });
+
+  try {
+    return callback();
+  } finally {
+    if (stdoutDescriptor) {
+      Object.defineProperty(process.stdout, 'isTTY', stdoutDescriptor);
+    } else {
+      Reflect.deleteProperty(process.stdout, 'isTTY');
+    }
+
+    if (stderrDescriptor) {
+      Object.defineProperty(process.stderr, 'isTTY', stderrDescriptor);
+    } else {
+      Reflect.deleteProperty(process.stderr, 'isTTY');
+    }
   }
 }
 
@@ -164,6 +195,20 @@ describe('Ruby fallback process compatibility', () => {
     assert.equal(result.signal, null);
     assert.match(stdout.text(), /^Usage:\n  qni clear\n/u);
     assert.equal(stderr.text(), '');
+  });
+
+  it('inherits TTY streams for synchronous Ruby fallback when no custom stream is supplied', () => {
+    withProcessTty(true, () => {
+      assert.deepEqual(rubyFallbackSyncStdio({}), ['ignore', 'inherit', 'inherit']);
+      assert.deepEqual(rubyFallbackSyncStdio({ stdout: new StringSink() }), ['ignore', 'pipe', 'inherit']);
+      assert.deepEqual(rubyFallbackSyncStdio({ stderr: new StringSink() }), ['ignore', 'inherit', 'pipe']);
+    });
+  });
+
+  it('pipes synchronous Ruby fallback streams for non-TTY parents', () => {
+    withProcessTty(false, () => {
+      assert.deepEqual(rubyFallbackSyncStdio({}), ['ignore', 'pipe', 'pipe']);
+    });
   });
 });
 

--- a/test/typescript/view_command.test.ts
+++ b/test/typescript/view_command.test.ts
@@ -81,21 +81,32 @@ async function writeCircuit(dir: string, circuit: unknown): Promise<void> {
   await writeFile(path.join(dir, 'circuit.json'), `${JSON.stringify(circuit, null, 2)}\n`);
 }
 
-function withStdoutTty<T>(isTTY: boolean, callback: () => T): T {
-  const descriptor = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+function withStreamTty<T>(options: { stderr: boolean; stdout: boolean }, callback: () => T): T {
+  const stdoutDescriptor = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+  const stderrDescriptor = Object.getOwnPropertyDescriptor(process.stderr, 'isTTY');
 
   Object.defineProperty(process.stdout, 'isTTY', {
     configurable: true,
-    value: isTTY
+    value: options.stdout
+  });
+  Object.defineProperty(process.stderr, 'isTTY', {
+    configurable: true,
+    value: options.stderr
   });
 
   try {
     return callback();
   } finally {
-    if (descriptor) {
-      Object.defineProperty(process.stdout, 'isTTY', descriptor);
+    if (stdoutDescriptor) {
+      Object.defineProperty(process.stdout, 'isTTY', stdoutDescriptor);
     } else {
       Reflect.deleteProperty(process.stdout, 'isTTY');
+    }
+
+    if (stderrDescriptor) {
+      Object.defineProperty(process.stderr, 'isTTY', stderrDescriptor);
+    } else {
+      Reflect.deleteProperty(process.stderr, 'isTTY');
     }
   }
 }
@@ -156,7 +167,7 @@ describe('view command TypeScript route', () => {
         cols: [['T†'], ['Ry(π/2)']]
       });
 
-      const result = withStdoutTty(true, () => captureDispatcherRun(dir, ['view']));
+      const result = withStreamTty({ stderr: false, stdout: true }, () => captureDispatcherRun(dir, ['view']));
 
       assert.equal(result.exitStatus, 0);
       assert.equal(result.stderr, '');
@@ -204,7 +215,9 @@ Examples:
         cols: [['T†']]
       });
 
-      const result = captureDispatcherRun(dir, ['view'], { ...process.env, QNI_USE_RUBY: '1' });
+      const result = withStreamTty({ stderr: false, stdout: false }, () =>
+        captureDispatcherRun(dir, ['view'], { ...process.env, QNI_USE_RUBY: '1' })
+      );
 
       assert.equal(result.exitStatus, 0);
       assert.equal(result.stderr, '');
@@ -235,6 +248,31 @@ describe('ASCII circuit parser TypeScript port', () => {
       {
         qubits: 2,
         cols: [['•', 'X']]
+      }
+    );
+  });
+
+  it('parses right-justified qubit labels from larger circuits', () => {
+    assert.deepEqual(
+      parseAsciiCircuit(
+        [
+          '     q0: ─────',
+          '     q1: ─────',
+          '     q2: ─────',
+          '     q3: ─────',
+          '     q4: ─────',
+          '     q5: ─────',
+          '     q6: ─────',
+          '     q7: ─────',
+          '     q8: ─────',
+          '     q9: ─────',
+          '    q10: ─────',
+          '    q11: ─────'
+        ].join('\n')
+      ),
+      {
+        qubits: 12,
+        cols: [[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]]
       }
     );
   });

--- a/test/typescript/view_command.test.ts
+++ b/test/typescript/view_command.test.ts
@@ -47,13 +47,13 @@ function captureDispatcherRun(cwd: string, argv: string[], env: NodeJS.ProcessEn
   process.stderr.write = ((
     chunk: string | Uint8Array,
     encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
-    callback?: BufferEncoding | ((error?: Error | null) => void)
+    callback?: (error?: Error | null) => void
   ): boolean => {
     stderr += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk.toString();
     if (typeof encodingOrCallback === 'function') {
       encodingOrCallback();
     }
-    if (typeof callback === 'function') {
+    if (callback) {
       callback();
     }
     return true;

--- a/test/typescript/view_command.test.ts
+++ b/test/typescript/view_command.test.ts
@@ -1,0 +1,273 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import { createDispatcher } from '../../src/dispatcher';
+import { parseAsciiCircuit } from '../../src/view/ascii_circuit_parser';
+
+interface CapturedRun {
+  readonly exitStatus: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}
+
+async function withTempDir<T>(callback: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'qni-cli-view-'));
+
+  try {
+    return await callback(dir);
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+}
+
+function captureDispatcherRun(cwd: string, argv: string[], env: NodeJS.ProcessEnv = { PATH: '' }): CapturedRun {
+  let stdout = '';
+  let stderr = '';
+  const originalStdoutWrite = process.stdout.write;
+  const originalStderrWrite = process.stderr.write;
+
+  process.stdout.write = ((
+    chunk: string | Uint8Array,
+    encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+    callback?: (error?: Error | null) => void
+  ): boolean => {
+    stdout += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk.toString();
+    if (typeof encodingOrCallback === 'function') {
+      encodingOrCallback();
+    }
+    if (callback) {
+      callback();
+    }
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = ((
+    chunk: string | Uint8Array,
+    encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+    callback?: BufferEncoding | ((error?: Error | null) => void)
+  ): boolean => {
+    stderr += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk.toString();
+    if (typeof encodingOrCallback === 'function') {
+      encodingOrCallback();
+    }
+    if (typeof callback === 'function') {
+      callback();
+    }
+    return true;
+  }) as typeof process.stderr.write;
+
+  try {
+    const dispatcher = createDispatcher({
+      cwd,
+      env,
+      projectRoot: process.cwd()
+    });
+
+    return {
+      exitStatus: dispatcher.run(argv),
+      stderr,
+      stdout
+    };
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+}
+
+async function writeCircuit(dir: string, circuit: unknown): Promise<void> {
+  await writeFile(path.join(dir, 'circuit.json'), `${JSON.stringify(circuit, null, 2)}\n`);
+}
+
+function withStdoutTty<T>(isTTY: boolean, callback: () => T): T {
+  const descriptor = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+
+  Object.defineProperty(process.stdout, 'isTTY', {
+    configurable: true,
+    value: isTTY
+  });
+
+  try {
+    return callback();
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(process.stdout, 'isTTY', descriptor);
+    } else {
+      Reflect.deleteProperty(process.stdout, 'isTTY');
+    }
+  }
+}
+
+describe('view command TypeScript route', () => {
+  it('renders a single-qubit gate without invoking Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      await writeCircuit(dir, {
+        qubits: 1,
+        cols: [['H']]
+      });
+
+      const result = captureDispatcherRun(dir, ['view']);
+
+      assert.equal(result.exitStatus, 0);
+      assert.equal(result.stderr, '');
+      assert.equal(
+        result.stdout,
+        [
+          '    ┌───┐',
+          'q0: ┤ H ├',
+          '    └───┘',
+          ''
+        ].join('\n')
+      );
+    });
+  });
+
+  it('renders controlled and angled gates like the Ruby oracle', async () => {
+    await withTempDir(async (dir) => {
+      await writeCircuit(dir, {
+        qubits: 2,
+        cols: [['•', 'Rz(π/2)']]
+      });
+
+      const result = captureDispatcherRun(dir, ['view']);
+
+      assert.equal(result.exitStatus, 0);
+      assert.equal(result.stderr, '');
+      assert.equal(
+        result.stdout,
+        [
+          'q0: ──■──',
+          '      π/2',
+          '    ┌─┴─┐',
+          'q1: ┤ Rz├',
+          '    └───┘',
+          ''
+        ].join('\n')
+      );
+    });
+  });
+
+  it('uses dim suffix color for compact TTY labels', async () => {
+    await withTempDir(async (dir) => {
+      await writeCircuit(dir, {
+        qubits: 1,
+        cols: [['T†'], ['Ry(π/2)']]
+      });
+
+      const result = withStdoutTty(true, () => captureDispatcherRun(dir, ['view']));
+
+      assert.equal(result.exitStatus, 0);
+      assert.equal(result.stderr, '');
+      assert.match(result.stdout, /T\u001B\[37;2m†\u001B\[0m/u);
+      assert.match(result.stdout, /R\u001B\[37;2my\u001B\[0m/u);
+    });
+  });
+
+  it('reports a missing circuit without invoking Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, ['view']);
+
+      assert.equal(result.exitStatus, 1);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, 'circuit.json does not exist\n');
+    });
+  });
+
+  it('prints view help without invoking Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, ['view', '--help']);
+
+      assert.equal(result.exitStatus, 0);
+      assert.equal(result.stderr, '');
+      assert.equal(
+        result.stdout,
+        `Usage:
+  qni view
+
+Overview:
+  Render ./circuit.json as an ASCII circuit diagram.
+  Output uses plain box-drawing text in non-TTY contexts.
+
+Examples:
+  qni view
+`
+      );
+    });
+  });
+
+  it('honors QNI_USE_RUBY for view', async () => {
+    await withTempDir(async (dir) => {
+      await writeCircuit(dir, {
+        qubits: 1,
+        cols: [['T†']]
+      });
+
+      const result = captureDispatcherRun(dir, ['view'], { ...process.env, QNI_USE_RUBY: '1' });
+
+      assert.equal(result.exitStatus, 0);
+      assert.equal(result.stderr, '');
+      assert.equal(
+        result.stdout,
+        [
+          '    ┌───┐',
+          'q0: ┤ T†├',
+          '    └───┘',
+          ''
+        ].join('\n')
+      );
+    });
+  });
+});
+
+describe('ASCII circuit parser TypeScript port', () => {
+  it('parses a controlled gate from qni view ASCII', () => {
+    assert.deepEqual(
+      parseAsciiCircuit(
+        [
+          'q0: ──■──',
+          '    ┌─┴─┐',
+          'q1: ┤ X ├',
+          '    └───┘'
+        ].join('\n')
+      ),
+      {
+        qubits: 2,
+        cols: [['•', 'X']]
+      }
+    );
+  });
+
+  it('parses angled gate annotations', () => {
+    assert.deepEqual(
+      parseAsciiCircuit(
+        [
+          '     π/2',
+          '    ┌───┐',
+          'q0: ┤ Ry├',
+          '    └───┘'
+        ].join('\n')
+      ),
+      {
+        qubits: 1,
+        cols: [['Ry(π/2)']]
+      }
+    );
+
+    assert.deepEqual(
+      parseAsciiCircuit(
+        [
+          '     2θ',
+          '    ┌───┐',
+          'q0: ┤ Ry├',
+          '    └───┘'
+        ].join('\n')
+      ),
+      {
+        qubits: 1,
+        cols: [['Ry(2*theta)']]
+      }
+    );
+  });
+});


### PR DESCRIPTION
## 概要

- `qni view` を TypeScript dispatcher route に追加し、ASCII renderer を TypeScript 実装へ移行しました。
- `qni view` の ASCII parser を TypeScript に移植し、既存 Markdown feature の parser / TTY helper が TypeScript path を通るようにしました。
- `QNI_USE_RUBY=1` の Ruby fallback は維持し、TTY で Ruby child が TTY 判定できるよう同期 fallback の stdio を調整しました。

## Linear

- YAS-226

## 検証

- `bundle exec rake check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 量子回路を視覚的に表示する新しいビューコマンドを追加
  * ASCII形式の回路図をテキストベースでレンダリング可能に
  * プレーンスタイルとカラー表示スタイルの2つの表示オプションをサポート

* **テスト**
  * ビューコマンドとASCII回路パーサーの包括的なテストスイートを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->