### PR TITLE
export LaTeX source を TypeScript route に移行する

### DIFF
--- a/src/commands/export_command.ts
+++ b/src/commands/export_command.ts
@@ -182,7 +182,7 @@ function parseExportOptions(args: string[]): ExportOptions | undefined {
     if (valueSetter) {
       const value = inlineValue ?? args[index + 1];
 
-      if (value === undefined || (inlineValue === undefined && value.startsWith('-'))) {
+      if (value === undefined || (inlineValue === undefined && optionLikeValue(name, value))) {
         return undefined;
       }
 
@@ -249,6 +249,10 @@ function validateOptions(options: ExportOptions): void {
 
 function captionPresent(options: ExportOptions): boolean {
   return (options.caption ?? '').length > 0;
+}
+
+function optionLikeValue(optionName: string, value: string): boolean {
+  return value.startsWith('-') && (optionName !== '--caption-size' || parseCaptionSize(value) === undefined);
 }
 
 function parseCaptionSize(value: string): number | undefined {

--- a/src/commands/export_command.ts
+++ b/src/commands/export_command.ts
@@ -174,7 +174,7 @@ function parseExportOptions(args: string[]): ExportOptions | undefined {
     if (valueSetter) {
       const value = inlineValue ?? args[index + 1];
 
-      if (value === undefined) {
+      if (value === undefined || (inlineValue === undefined && value.startsWith('-'))) {
         return undefined;
       }
 

--- a/src/commands/export_command.ts
+++ b/src/commands/export_command.ts
@@ -1,0 +1,269 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { CircuitFileError, currentCircuitFile } from '../circuit_file';
+import type { CommandHandlerContext } from '../dispatcher';
+import { QCircuitLatex, validateCaptionOptions, type ExportTheme } from '../export/qcircuit_latex';
+import { runRubyFallbackSync } from '../process/process_compatibility';
+
+const HELP_TEXT = `Usage:
+  qni export --latex-source [--output=PATH]
+  qni export --png [--caption=TEXT] [--caption-tex] [--caption-position=top|bottom] [--caption-size=N] --output=PATH
+  qni export --state-vector --png --output=PATH
+  qni export --circle-notation --png --output=PATH
+
+Overview:
+  Export ./circuit.json as qcircuit LaTeX or PNG.
+  --latex-source writes qcircuit LaTeX to standard output by default.
+  With --output=PATH, --latex-source writes the LaTeX file instead.
+  --png renders the qcircuit LaTeX with pdflatex and converts the PDF to PNG with pdftocairo.
+  --caption adds explanatory text above or below regular circuit export.
+  --caption-tex treats --caption as raw LaTeX instead of escaping it.
+  --no-transparent writes an opaque PNG background, useful for light circuit lines on dark note themes.
+  --state-vector renders the symbolic state vector as LaTeX and converts it to PNG.
+  --circle-notation renders the final computational-basis state as a circle-notation PNG.
+  qni export follows qni's step constraints, so one step can contain simple 1-qubit gates, one controlled gate, or one 2-qubit SWAP.
+
+Options:
+  --latex-source  # write qcircuit LaTeX
+  --png           # write PNG rendered from qcircuit LaTeX
+  --state-vector  # write the symbolic state vector as PNG
+  --circle-notation # write the computational-basis circle notation as PNG
+  --dark          # draw white circuit lines for dark backgrounds (default)
+  --light         # draw black circuit lines for light backgrounds
+  [--[no-]transparent] # write PNG with transparent background (default: true)
+  [--caption=TEXT] # add a caption to regular circuit export
+  [--caption-tex] # treat --caption as raw LaTeX
+  [--caption-position=top|bottom] # caption position (default: bottom)
+  [--caption-size=N] # caption font size in pt (default: 12)
+  [--output=PATH] # output file path; required for --png
+
+Examples:
+  qni export --latex-source
+  qni export --latex-source --output circuit.tex
+  qni export --latex-source --light
+  qni export --png --output circuit.png
+  qni export --png --dark --output circuit.png
+  qni export --png --caption "CNOT before cut" --output circuit.png
+  qni export --png --caption '$\\mathrm{CNOT}$' --caption-tex --output circuit.png
+  qni export --png --light --no-transparent --output circuit.png
+  qni export --state-vector --png --output state.png
+  qni export --circle-notation --png --output circles.png
+`;
+
+interface ExportOptions {
+  readonly caption?: string;
+  readonly captionFormat: 'tex' | 'text';
+  readonly captionPosition: string;
+  readonly captionSize: number;
+  readonly circleNotation: boolean;
+  readonly dark: boolean;
+  readonly latexSource: boolean;
+  readonly light: boolean;
+  readonly output?: string;
+  readonly png: boolean;
+  readonly stateVector: boolean;
+}
+
+const BOOLEAN_OPTIONS = new Map<string, (options: MutableExportOptions) => void>([
+  ['--caption-tex', (options) => {
+    options.captionFormat = 'tex';
+  }],
+  ['--circle-notation', (options) => {
+    options.circleNotation = true;
+  }],
+  ['--dark', (options) => {
+    options.dark = true;
+  }],
+  ['--latex-source', (options) => {
+    options.latexSource = true;
+  }],
+  ['--light', (options) => {
+    options.light = true;
+  }],
+  ['--no-transparent', () => undefined],
+  ['--png', (options) => {
+    options.png = true;
+  }],
+  ['--state-vector', (options) => {
+    options.stateVector = true;
+  }],
+  ['--transparent', () => undefined]
+]);
+
+const VALUE_OPTIONS = new Map<string, (options: MutableExportOptions, value: string) => void>([
+  ['--caption', (options, value) => {
+    options.caption = value;
+  }],
+  ['--caption-position', (options, value) => {
+    options.captionPosition = value;
+  }],
+  ['--caption-size', (options, value) => {
+    options.captionSize = Number.parseInt(value, 10);
+  }],
+  ['--output', (options, value) => {
+    options.output = value;
+  }]
+]);
+
+type MutableExportOptions = {
+  -readonly [Property in keyof ExportOptions]: ExportOptions[Property];
+};
+
+export function runExportCommand(argv: string[], context: CommandHandlerContext): number {
+  if (helpRequest(argv)) {
+    process.stdout.write(HELP_TEXT);
+    return 0;
+  }
+
+  const options = parseExportOptions(argv.slice(1));
+
+  if (!options) {
+    return rubyFallback(argv, context);
+  }
+
+  try {
+    validateOptions(options);
+
+    if (!typeScriptLatexSource(options)) {
+      return rubyFallback(argv, context);
+    }
+
+    const latexSource = new QCircuitLatex(currentCircuitFile(context.cwd).load(), {
+      caption: options.caption,
+      captionFormat: options.captionFormat,
+      captionPosition: options.captionPosition,
+      captionSize: options.captionSize,
+      theme: theme(options)
+    }).render();
+
+    writeLatexSource(latexSource, options, context.cwd);
+    return 0;
+  } catch (error) {
+    if (error instanceof CircuitFileError || error instanceof Error) {
+      process.stderr.write(`${error.message}\n`);
+      return 1;
+    }
+
+    throw error;
+  }
+}
+
+function helpRequest(argv: string[]): boolean {
+  return argv.length === 1 || (argv.length === 2 && (argv[1] === '--help' || argv[1] === '-h'));
+}
+
+function parseExportOptions(args: string[]): ExportOptions | undefined {
+  const options: MutableExportOptions = {
+    captionFormat: 'text',
+    captionPosition: 'bottom',
+    captionSize: 12,
+    circleNotation: false,
+    dark: false,
+    latexSource: false,
+    light: false,
+    png: false,
+    stateVector: false
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    const [name, inlineValue] = arg.split(/=(.*)/su, 2);
+    const valueSetter = VALUE_OPTIONS.get(name);
+
+    if (valueSetter) {
+      const value = inlineValue ?? args[index + 1];
+
+      if (value === undefined) {
+        return undefined;
+      }
+
+      if (inlineValue === undefined) {
+        index += 1;
+      }
+
+      valueSetter(options, value ?? '');
+      continue;
+    }
+
+    const booleanSetter = BOOLEAN_OPTIONS.get(arg);
+
+    if (!booleanSetter) {
+      return undefined;
+    }
+
+    booleanSetter(options);
+  }
+
+  return options;
+}
+
+function validateOptions(options: ExportOptions): void {
+  if (!options.png && options.stateVector) {
+    throw new Error('--state-vector currently supports only --png');
+  }
+
+  if (!options.png && options.circleNotation) {
+    throw new Error('--circle-notation currently supports only --png');
+  }
+
+  if (options.latexSource === options.png) {
+    throw new Error('choose exactly one of --latex-source or --png');
+  }
+
+  if (options.dark && options.light) {
+    throw new Error('choose at most one of --dark or --light');
+  }
+
+  if (options.stateVector && options.circleNotation) {
+    throw new Error('choose at most one of --state-vector or --circle-notation');
+  }
+
+  if (captionPresent(options) && (options.stateVector || options.circleNotation)) {
+    throw new Error('--caption is supported only for regular circuit export');
+  }
+
+  validateCaptionOptions({
+    caption: options.caption,
+    captionFormat: options.captionFormat,
+    captionPosition: options.captionPosition,
+    captionSize: options.captionSize
+  });
+
+  if (options.png && !options.output) {
+    throw new Error('--output=PATH is required for --png');
+  }
+}
+
+function captionPresent(options: ExportOptions): boolean {
+  return (options.caption ?? '').length > 0;
+}
+
+function rubyFallback(argv: string[], context: CommandHandlerContext): number {
+  return runRubyFallbackSync({
+    argv,
+    cwd: context.cwd,
+    env: context.env,
+    projectRoot: context.projectRoot
+  }).exitStatus ?? 1;
+}
+
+function theme(options: ExportOptions): ExportTheme {
+  return options.light ? 'light' : 'dark';
+}
+
+function typeScriptLatexSource(options: ExportOptions): boolean {
+  return options.latexSource && !options.png && !options.stateVector && !options.circleNotation;
+}
+
+function writeLatexSource(latexSource: string, options: ExportOptions, cwd: string): void {
+  if (!options.output) {
+    process.stdout.write(`${latexSource}\n`);
+    return;
+  }
+
+  const outputPath = path.resolve(cwd, options.output);
+
+  mkdirSync(path.dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, `${latexSource}\n`);
+}

--- a/src/commands/export_command.ts
+++ b/src/commands/export_command.ts
@@ -54,6 +54,7 @@ Examples:
 interface ExportOptions {
   readonly caption?: string;
   readonly captionFormat: 'tex' | 'text';
+  readonly captionSizeError?: string;
   readonly captionPosition: string;
   readonly captionSize: number;
   readonly circleNotation: boolean;
@@ -99,7 +100,14 @@ const VALUE_OPTIONS = new Map<string, (options: MutableExportOptions, value: str
     options.captionPosition = value;
   }],
   ['--caption-size', (options, value) => {
-    options.captionSize = Number.parseInt(value, 10);
+    const captionSize = parseCaptionSize(value);
+
+    if (captionSize === undefined) {
+      options.captionSizeError = `Expected numeric value for '--caption-size'; got "${value}"`;
+      return;
+    }
+
+    options.captionSize = captionSize;
   }],
   ['--output', (options, value) => {
     options.output = value;
@@ -199,6 +207,10 @@ function parseExportOptions(args: string[]): ExportOptions | undefined {
 }
 
 function validateOptions(options: ExportOptions): void {
+  if (options.captionSizeError) {
+    throw new Error(options.captionSizeError);
+  }
+
   if (!options.png && options.stateVector) {
     throw new Error('--state-vector currently supports only --png');
   }
@@ -237,6 +249,14 @@ function validateOptions(options: ExportOptions): void {
 
 function captionPresent(options: ExportOptions): boolean {
   return (options.caption ?? '').length > 0;
+}
+
+function parseCaptionSize(value: string): number | undefined {
+  if (!/^[+-]?(?:\d+(?:\.\d+)?|\.\d+)$/u.test(value)) {
+    return undefined;
+  }
+
+  return Math.trunc(Number(value));
 }
 
 function rubyFallback(argv: string[], context: CommandHandlerContext): number {

--- a/src/commands/export_command.ts
+++ b/src/commands/export_command.ts
@@ -1,0 +1,269 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { CircuitFileError, currentCircuitFile } from '../circuit_file';
+import type { CommandHandlerContext } from '../dispatcher';
+import { QCircuitLatex, validateCaptionOptions, type ExportTheme } from '../export/qcircuit_latex';
+import { runRubyFallbackSync } from '../process/process_compatibility';
+
+const HELP_TEXT = `Usage:
+  qni export --latex-source [--output=PATH]
+  qni export --png [--caption=TEXT] [--caption-tex] [--caption-position=top|bottom] [--caption-size=N] --output=PATH
+  qni export --state-vector --png --output=PATH
+  qni export --circle-notation --png --output=PATH
+
+Overview:
+  Export ./circuit.json as qcircuit LaTeX or PNG.
+  --latex-source writes qcircuit LaTeX to standard output by default.
+  With --output=PATH, --latex-source writes the LaTeX file instead.
+  --png renders the qcircuit LaTeX with pdflatex and converts the PDF to PNG with pdftocairo.
+  --caption adds explanatory text above or below regular circuit export.
+  --caption-tex treats --caption as raw LaTeX instead of escaping it.
+  --no-transparent writes an opaque PNG background, useful for light circuit lines on dark note themes.
+  --state-vector renders the symbolic state vector as LaTeX and converts it to PNG.
+  --circle-notation renders the final computational-basis state as a circle-notation PNG.
+  qni export follows qni's step constraints, so one step can contain simple 1-qubit gates, one controlled gate, or one 2-qubit SWAP.
+
+Options:
+  --latex-source  # write qcircuit LaTeX
+  --png           # write PNG rendered from qcircuit LaTeX
+  --state-vector  # write the symbolic state vector as PNG
+  --circle-notation # write the computational-basis circle notation as PNG
+  --dark          # draw white circuit lines for dark backgrounds (default)
+  --light         # draw black circuit lines for light backgrounds
+  [--[no-]transparent] # write PNG with transparent background (default: true)
+  [--caption=TEXT] # add a caption to regular circuit export
+  [--caption-tex] # treat --caption as raw LaTeX
+  [--caption-position=top|bottom] # caption position (default: bottom)
+  [--caption-size=N] # caption font size in pt (default: 12)
+  [--output=PATH] # output file path; required for --png
+
+Examples:
+  qni export --latex-source
+  qni export --latex-source --output circuit.tex
+  qni export --latex-source --light
+  qni export --png --output circuit.png
+  qni export --png --dark --output circuit.png
+  qni export --png --caption "CNOT before cut" --output circuit.png
+  qni export --png --caption '$\\mathrm{CNOT}$' --caption-tex --output circuit.png
+  qni export --png --light --no-transparent --output circuit.png
+  qni export --state-vector --png --output state.png
+  qni export --circle-notation --png --output circles.png
+`;
+
+interface ExportOptions {
+  readonly caption?: string;
+  readonly captionFormat: 'tex' | 'text';
+  readonly captionPosition: string;
+  readonly captionSize: number;
+  readonly circleNotation: boolean;
+  readonly dark: boolean;
+  readonly latexSource: boolean;
+  readonly light: boolean;
+  readonly output?: string;
+  readonly png: boolean;
+  readonly stateVector: boolean;
+}
+
+const BOOLEAN_OPTIONS = new Map<string, (options: MutableExportOptions) => void>([
+  ['--caption-tex', (options) => {
+    options.captionFormat = 'tex';
+  }],
+  ['--circle-notation', (options) => {
+    options.circleNotation = true;
+  }],
+  ['--dark', (options) => {
+    options.dark = true;
+  }],
+  ['--latex-source', (options) => {
+    options.latexSource = true;
+  }],
+  ['--light', (options) => {
+    options.light = true;
+  }],
+  ['--no-transparent', () => undefined],
+  ['--png', (options) => {
+    options.png = true;
+  }],
+  ['--state-vector', (options) => {
+    options.stateVector = true;
+  }],
+  ['--transparent', () => undefined]
+]);
+
+const VALUE_OPTIONS = new Map<string, (options: MutableExportOptions, value: string) => void>([
+  ['--caption', (options, value) => {
+    options.caption = value;
+  }],
+  ['--caption-position', (options, value) => {
+    options.captionPosition = value;
+  }],
+  ['--caption-size', (options, value) => {
+    options.captionSize = Number.parseInt(value, 10);
+  }],
+  ['--output', (options, value) => {
+    options.output = value;
+  }]
+]);
+
+type MutableExportOptions = {
+  -readonly [Property in keyof ExportOptions]: ExportOptions[Property];
+};
+
+export function runExportCommand(argv: string[], context: CommandHandlerContext): number {
+  if (helpRequest(argv)) {
+    process.stdout.write(HELP_TEXT);
+    return 0;
+  }
+
+  const options = parseExportOptions(argv.slice(1));
+
+  if (!options) {
+    return rubyFallback(argv, context);
+  }
+
+  try {
+    if (!typeScriptLatexSource(options)) {
+      return rubyFallback(argv, context);
+    }
+
+    validateOptions(options);
+
+    const latexSource = new QCircuitLatex(currentCircuitFile(context.cwd).load(), {
+      caption: options.caption,
+      captionFormat: options.captionFormat,
+      captionPosition: options.captionPosition,
+      captionSize: options.captionSize,
+      theme: theme(options)
+    }).render();
+
+    writeLatexSource(latexSource, options, context.cwd);
+    return 0;
+  } catch (error) {
+    if (error instanceof CircuitFileError || error instanceof Error) {
+      process.stderr.write(`${error.message}\n`);
+      return 1;
+    }
+
+    throw error;
+  }
+}
+
+function helpRequest(argv: string[]): boolean {
+  return argv.length === 1 || (argv.length === 2 && (argv[1] === '--help' || argv[1] === '-h'));
+}
+
+function parseExportOptions(args: string[]): ExportOptions | undefined {
+  const options: MutableExportOptions = {
+    captionFormat: 'text',
+    captionPosition: 'bottom',
+    captionSize: 12,
+    circleNotation: false,
+    dark: false,
+    latexSource: false,
+    light: false,
+    png: false,
+    stateVector: false
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    const [name, inlineValue] = arg.split(/=(.*)/su, 2);
+    const valueSetter = VALUE_OPTIONS.get(name);
+
+    if (valueSetter) {
+      const value = inlineValue ?? args[index + 1];
+
+      if (value === undefined) {
+        return undefined;
+      }
+
+      if (inlineValue === undefined) {
+        index += 1;
+      }
+
+      valueSetter(options, value ?? '');
+      continue;
+    }
+
+    const booleanSetter = BOOLEAN_OPTIONS.get(arg);
+
+    if (!booleanSetter) {
+      return undefined;
+    }
+
+    booleanSetter(options);
+  }
+
+  return options;
+}
+
+function validateOptions(options: ExportOptions): void {
+  if (!options.png && options.stateVector) {
+    throw new Error('--state-vector currently supports only --png');
+  }
+
+  if (!options.png && options.circleNotation) {
+    throw new Error('--circle-notation currently supports only --png');
+  }
+
+  if (options.latexSource === options.png) {
+    throw new Error('choose exactly one of --latex-source or --png');
+  }
+
+  if (options.dark && options.light) {
+    throw new Error('choose at most one of --dark or --light');
+  }
+
+  if (options.stateVector && options.circleNotation) {
+    throw new Error('choose at most one of --state-vector or --circle-notation');
+  }
+
+  if (captionPresent(options) && (options.stateVector || options.circleNotation)) {
+    throw new Error('--caption is supported only for regular circuit export');
+  }
+
+  validateCaptionOptions({
+    caption: options.caption,
+    captionFormat: options.captionFormat,
+    captionPosition: options.captionPosition,
+    captionSize: options.captionSize
+  });
+
+  if (options.png && !options.output) {
+    throw new Error('--output=PATH is required for --png');
+  }
+}
+
+function captionPresent(options: ExportOptions): boolean {
+  return (options.caption ?? '').length > 0;
+}
+
+function rubyFallback(argv: string[], context: CommandHandlerContext): number {
+  return runRubyFallbackSync({
+    argv,
+    cwd: context.cwd,
+    env: context.env,
+    projectRoot: context.projectRoot
+  }).exitStatus ?? 1;
+}
+
+function theme(options: ExportOptions): ExportTheme {
+  return options.light ? 'light' : 'dark';
+}
+
+function typeScriptLatexSource(options: ExportOptions): boolean {
+  return options.latexSource && !options.png && !options.stateVector && !options.circleNotation;
+}
+
+function writeLatexSource(latexSource: string, options: ExportOptions, cwd: string): void {
+  if (!options.output) {
+    process.stdout.write(`${latexSource}\n`);
+    return;
+  }
+
+  const outputPath = path.resolve(cwd, options.output);
+
+  mkdirSync(path.dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, `${latexSource}\n`);
+}

--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -3,6 +3,7 @@ import {
   runRubyFallbackSync
 } from './process/process_compatibility';
 import { runAddCommand } from './commands/add_command';
+import { runExportCommand } from './commands/export_command';
 import { runGateCommand } from './commands/gate_command';
 import { runExpectCommand } from './commands/expect_command';
 import { runRemoveCommand } from './commands/remove_command';
@@ -33,6 +34,7 @@ interface CommandRoute {
 
 const TYPESCRIPT_ROUTES = new Map<string, CommandHandler>([
   ['add', runAddCommand],
+  ['export', runExportCommand],
   ['expect', runExpectCommand],
   ['gate', runGateCommand],
   ['rm', runRemoveCommand],

--- a/src/export/qcircuit_latex.ts
+++ b/src/export/qcircuit_latex.ts
@@ -1,0 +1,358 @@
+import type { CircuitData } from '../circuit_file';
+
+const CONTROL_SYMBOL = '•';
+const EMPTY_SLOT = 1;
+const SWAP_SYMBOL = 'Swap';
+
+const DOCUMENT_HEADER_LINES = [
+  '\\documentclass[border=24px]{standalone}',
+  '',
+  '\\usepackage[braket, qm]{qcircuit}',
+  '\\usepackage{graphicx}',
+  '\\usepackage{textcomp}',
+  '\\usepackage{xcolor}',
+  '',
+  '\\begin{document}'
+];
+const DOCUMENT_FOOTER_LINES = ['\\end{document}'];
+const CIRCUIT_HEADER_LINES = ['\\scalebox{1.0}{'];
+const CIRCUIT_FOOTER_LINES = ['\\\\ }', '}'];
+const EMPTY_CIRCUIT_MIN_COLUMNS = 3;
+
+const DIRECT_SLOT_RENDERERS = new Map<unknown, string>([
+  [null, '\\qw'],
+  ['', '\\qw'],
+  [EMPTY_SLOT, '\\qw']
+]);
+
+const TARGET_SLOT_RENDERERS = new Map<unknown, string>([
+  ['X', '\\targ']
+]);
+
+const SPECIAL_GATE_LABELS = new Map<unknown, string>([
+  ['X^½', '\\sqrt{\\mathrm{X}}'],
+  ['S†', '\\mathrm{S^\\dagger}'],
+  ['T†', '\\mathrm{T^\\dagger}']
+]);
+
+const LATEX_ESCAPE_MAP = new Map<string, string>([
+  ['\\', '\\textbackslash{}'],
+  ['{', '\\{'],
+  ['}', '\\}'],
+  ['$', '\\$'],
+  ['&', '\\&'],
+  ['%', '\\%'],
+  ['#', '\\#'],
+  ['_', '\\_'],
+  ['^', '\\textasciicircum{}'],
+  ['~', '\\textasciitilde{}'],
+  ['·', '$\\cdot$'],
+  ['⊗', '$\\otimes$'],
+  ['π', '$\\pi$']
+]);
+
+export interface QCircuitCaptionOptions {
+  readonly caption?: string;
+  readonly captionFormat?: 'tex' | 'text';
+  readonly captionPosition?: string;
+  readonly captionSize?: number;
+}
+
+export type ExportTheme = 'dark' | 'light';
+
+export interface QCircuitLatexOptions extends QCircuitCaptionOptions {
+  readonly theme: ExportTheme;
+}
+
+class QCircuitCaption {
+  static readonly DEFAULT_POSITION = 'bottom';
+  static readonly DEFAULT_SIZE_PT = 12;
+
+  private readonly format: 'tex' | 'text';
+  private readonly position: string;
+  private readonly sizePt: number;
+  private readonly text: string;
+
+  constructor(options: QCircuitCaptionOptions) {
+    this.format = options.captionFormat ?? 'text';
+    this.position = options.captionPosition ?? QCircuitCaption.DEFAULT_POSITION;
+    this.sizePt = options.captionSize ?? QCircuitCaption.DEFAULT_SIZE_PT;
+    this.text = options.caption ?? '';
+  }
+
+  get lines(): string[] {
+    if (!this.present) {
+      return [];
+    }
+
+    return [`{\\fontsize{${this.sizePt}}{${this.lineHeightPt}}\\selectfont ${this.escapedText}}`];
+  }
+
+  get positionBottom(): boolean {
+    return this.position === 'bottom';
+  }
+
+  get positionTop(): boolean {
+    return this.position === 'top';
+  }
+
+  static validPosition(position: string): boolean {
+    return position === 'top' || position === 'bottom';
+  }
+
+  private get escapedText(): string {
+    if (this.format === 'tex') {
+      return this.text;
+    }
+
+    return [...this.text].map((char) => LATEX_ESCAPE_MAP.get(char) ?? char).join('');
+  }
+
+  private get lineHeightPt(): number {
+    return Math.ceil(this.sizePt * 1.25);
+  }
+
+  private get present(): boolean {
+    return this.text.length > 0;
+  }
+}
+
+export class QCircuitLatex {
+  private readonly caption: QCircuitCaption;
+  private readonly circuit: CircuitData;
+  private readonly theme: ExportTheme;
+
+  constructor(circuit: CircuitData, options: QCircuitLatexOptions) {
+    this.caption = new QCircuitCaption(options);
+    this.circuit = circuit;
+    this.theme = options.theme;
+  }
+
+  render(): string {
+    return this.documentLines.join('\n');
+  }
+
+  private get documentLines(): string[] {
+    return [
+      ...DOCUMENT_HEADER_LINES,
+      this.themeColorLine,
+      '\\begin{tabular}{c}',
+      ...this.topCaptionLines,
+      ...this.circuitLines,
+      ...this.bottomCaptionLines,
+      '\\end{tabular}',
+      ...DOCUMENT_FOOTER_LINES
+    ];
+  }
+
+  private get bottomCaptionLines(): string[] {
+    if (!this.caption.positionBottom) {
+      return [];
+    }
+
+    return ['\\\\[0.8em]', ...this.caption.lines];
+  }
+
+  private get circuitLines(): string[] {
+    return [
+      ...CIRCUIT_HEADER_LINES,
+      '\\Qcircuit @C=0.55em @R=2.2em @!R { \\\\',
+      this.renderedRows,
+      ...CIRCUIT_FOOTER_LINES
+    ];
+  }
+
+  private get renderedRows(): string {
+    return Array.from({ length: this.circuit.qubits }, (_unused, qubit) => {
+      const renderedCells = this.renderedColumns.map((column) => column.renderFor(qubit));
+
+      return `  ${this.wireLabel(qubit)} & ${[...renderedCells, '\\qw'].join(' & ')}\\\\`;
+    }).join('\n');
+  }
+
+  private get renderedColumns(): QCircuitColumn[] {
+    return this.columns.map((column) => new QCircuitColumn(column));
+  }
+
+  private get columns(): unknown[][] {
+    if (this.circuit.cols.length > 0) {
+      return this.circuit.cols;
+    }
+
+    return Array.from({ length: EMPTY_CIRCUIT_MIN_COLUMNS }, () =>
+      Array.from({ length: this.circuit.qubits }, () => EMPTY_SLOT)
+    );
+  }
+
+  private get themeColorLine(): string {
+    return `\\color{${this.themeColorName}}`;
+  }
+
+  private get themeColorName(): string {
+    return this.theme === 'light' ? 'black' : 'white';
+  }
+
+  private get topCaptionLines(): string[] {
+    if (!this.caption.positionTop) {
+      return [];
+    }
+
+    return [...this.caption.lines, '\\\\[0.8em]'];
+  }
+
+  private wireLabel(qubit: number): string {
+    return `\\push{q${qubit}: \\ket{0}}`;
+  }
+}
+
+class QCircuitColumn {
+  private readonly slots: unknown[];
+
+  constructor(slots: unknown[]) {
+    this.slots = slots;
+  }
+
+  renderFor(qubit: number): string {
+    return this.renderedCells.get(qubit) ?? '\\qw';
+  }
+
+  private get renderedCells(): Map<number, string> {
+    if (this.swapStep) {
+      return this.swapCells();
+    }
+
+    if (this.controlledStep) {
+      return this.controlledCells();
+    }
+
+    return this.simpleCells();
+  }
+
+  private get controlledStep(): boolean {
+    return this.slots.includes(CONTROL_SYMBOL);
+  }
+
+  private get swapStep(): boolean {
+    return this.slots.includes(SWAP_SYMBOL);
+  }
+
+  private controlledCells(): Map<number, string> {
+    const target = this.controlledTarget();
+    const cells = new Map<number, string>();
+
+    for (const controlQubit of this.controlQubits) {
+      cells.set(controlQubit, `\\ctrl{${target.qubit - controlQubit}}`);
+    }
+
+    cells.set(target.qubit, target.renderedCell);
+    return cells;
+  }
+
+  private controlledTarget(): ControlledTarget {
+    const targets = this.slots
+      .map((slot, qubit) => ({ qubit, slot }))
+      .filter(({ slot }) => !emptySlot(slot) && slot !== CONTROL_SYMBOL);
+
+    if (targets.length !== 1) {
+      throw new Error(`unsupported controlled step: ${JSON.stringify(this.slots)}`);
+    }
+
+    return new ControlledTarget(targets[0].slot, targets[0].qubit);
+  }
+
+  private get controlQubits(): number[] {
+    return this.slots
+      .map((slot, index) => ({ index, slot }))
+      .filter(({ slot }) => slot === CONTROL_SYMBOL)
+      .map(({ index }) => index);
+  }
+
+  private simpleCells(): Map<number, string> {
+    return new Map(this.slots.map((slot, qubit) => [qubit, renderedSlot(slot)]));
+  }
+
+  private swapCells(): Map<number, string> {
+    if (!this.validSwapStep) {
+      throw new Error(`unsupported swap step: ${JSON.stringify(this.slots)}`);
+    }
+
+    const [topQubit, bottomQubit] = this.swapQubits.sort((a, b) => a - b);
+
+    return new Map<number, string>([
+      [topQubit, '\\qswap'],
+      [bottomQubit, `\\qswap \\qwx[${topQubit - bottomQubit}]`]
+    ]);
+  }
+
+  private get validSwapStep(): boolean {
+    return this.swapQubits.length === 2 && this.slots.every((slot) => emptySlot(slot) || slot === SWAP_SYMBOL);
+  }
+
+  private get swapQubits(): number[] {
+    return this.slots
+      .map((slot, index) => ({ index, slot }))
+      .filter(({ slot }) => slot === SWAP_SYMBOL)
+      .map(({ index }) => index);
+  }
+}
+
+class ControlledTarget {
+  readonly qubit: number;
+
+  private readonly slot: unknown;
+
+  constructor(slot: unknown, qubit: number) {
+    this.slot = slot;
+    this.qubit = qubit;
+  }
+
+  get renderedCell(): string {
+    return TARGET_SLOT_RENDERERS.get(this.slot) ?? gateCell(this.slot);
+  }
+}
+
+function emptySlot(slot: unknown): boolean {
+  return DIRECT_SLOT_RENDERERS.has(slot);
+}
+
+function renderedSlot(slot: unknown): string {
+  return DIRECT_SLOT_RENDERERS.get(slot) ?? gateCell(slot);
+}
+
+function gateCell(slot: unknown): string {
+  return `\\gate{${gateLabel(slot)}}`;
+}
+
+function gateLabel(slot: unknown): string {
+  const specialLabel = SPECIAL_GATE_LABELS.get(slot);
+
+  if (specialLabel) {
+    return specialLabel;
+  }
+
+  const label = String(slot);
+  const match = /^(?<name>[A-Za-z]+)\((?<angle>.+)\)$/u.exec(label);
+
+  if (match?.groups) {
+    return `\\mathrm{${match.groups.name}}(${formattedAngle(match.groups.angle)})`;
+  }
+
+  return `\\mathrm{${label}}`;
+}
+
+function formattedAngle(angle: string): string {
+  return angle.replace(/π/gu, '\\pi').replace(/(?<![A-Za-z])pi(?![A-Za-z])/gu, '\\pi');
+}
+
+export function validateCaptionOptions(options: QCircuitCaptionOptions): void {
+  const position = options.captionPosition ?? QCircuitCaption.DEFAULT_POSITION;
+  const size = options.captionSize ?? QCircuitCaption.DEFAULT_SIZE_PT;
+
+  if (!QCircuitCaption.validPosition(position)) {
+    throw new Error('--caption-position must be top or bottom');
+  }
+
+  if (!Number.isFinite(size) || size <= 0) {
+    throw new Error('--caption-size must be positive');
+  }
+}

--- a/src/export/qcircuit_latex.ts
+++ b/src/export/qcircuit_latex.ts
@@ -256,7 +256,7 @@ class QCircuitColumn {
       .filter(({ slot }) => !emptySlot(slot) && slot !== CONTROL_SYMBOL);
 
     if (targets.length !== 1) {
-      throw new Error(`unsupported controlled step: ${JSON.stringify(this.slots)}`);
+      throw new Error(`unsupported controlled step: ${rubyInspect(this.slots)}`);
     }
 
     return new ControlledTarget(targets[0].slot, targets[0].qubit);
@@ -275,7 +275,7 @@ class QCircuitColumn {
 
   private swapCells(): Map<number, string> {
     if (!this.validSwapStep) {
-      throw new Error(`unsupported swap step: ${JSON.stringify(this.slots)}`);
+      throw new Error(`unsupported swap step: ${rubyInspect(this.slots)}`);
     }
 
     const [topQubit, bottomQubit] = this.swapQubits.sort((a, b) => a - b);
@@ -344,6 +344,22 @@ function gateLabel(slot: unknown): string {
 
 function formattedAngle(angle: string): string {
   return angle.replace(/π/gu, '\\pi').replace(/(?<![A-Za-z])pi(?![A-Za-z])/gu, '\\pi');
+}
+
+function rubyInspect(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => rubyInspect(item)).join(', ')}]`;
+  }
+
+  if (value === null || value === undefined) {
+    return 'nil';
+  }
+
+  if (typeof value === 'string') {
+    return JSON.stringify(value);
+  }
+
+  return String(value);
 }
 
 export function validateCaptionOptions(options: QCircuitCaptionOptions): void {

--- a/src/export/qcircuit_latex.ts
+++ b/src/export/qcircuit_latex.ts
@@ -1,0 +1,360 @@
+import type { CircuitData } from '../circuit_file';
+
+const CONTROL_SYMBOL = '•';
+const EMPTY_SLOT = 1;
+const SWAP_SYMBOL = 'Swap';
+
+const DOCUMENT_HEADER_LINES = [
+  '\\documentclass[border=24px]{standalone}',
+  '',
+  '\\usepackage[braket, qm]{qcircuit}',
+  '\\usepackage{graphicx}',
+  '\\usepackage{textcomp}',
+  '\\usepackage{xcolor}',
+  '',
+  '\\begin{document}'
+];
+const DOCUMENT_FOOTER_LINES = ['\\end{document}'];
+const CIRCUIT_HEADER_LINES = ['\\scalebox{1.0}{'];
+const CIRCUIT_FOOTER_LINES = ['\\\\ }', '}'];
+const EMPTY_CIRCUIT_MIN_COLUMNS = 3;
+
+const DIRECT_SLOT_RENDERERS = new Map<unknown, string>([
+  [null, '\\qw'],
+  ['', '\\qw'],
+  [EMPTY_SLOT, '\\qw']
+]);
+
+const TARGET_SLOT_RENDERERS = new Map<unknown, string>([
+  ['X', '\\targ']
+]);
+
+const SPECIAL_GATE_LABELS = new Map<unknown, string>([
+  ['X^½', '\\sqrt{\\mathrm{X}}'],
+  ['S†', '\\mathrm{S^\\dagger}'],
+  ['T†', '\\mathrm{T^\\dagger}']
+]);
+
+const LATEX_ESCAPE_MAP = new Map<string, string>([
+  ['\\', '\\textbackslash{}'],
+  ['{', '\\{'],
+  ['}', '\\}'],
+  ['$', '\\$'],
+  ['&', '\\&'],
+  ['%', '\\%'],
+  ['#', '\\#'],
+  ['_', '\\_'],
+  ['^', '\\textasciicircum{}'],
+  ['~', '\\textasciitilde{}'],
+  ['·', '$\\cdot$'],
+  ['⊗', '$\\otimes$'],
+  ['π', '$\\pi$']
+]);
+
+export interface QCircuitCaptionOptions {
+  readonly caption?: string;
+  readonly captionFormat?: 'tex' | 'text';
+  readonly captionPosition?: string;
+  readonly captionSize?: number;
+}
+
+export type ExportTheme = 'dark' | 'light';
+
+export interface QCircuitLatexOptions extends QCircuitCaptionOptions {
+  readonly theme: ExportTheme;
+}
+
+class QCircuitCaption {
+  static readonly DEFAULT_POSITION = 'bottom';
+  static readonly DEFAULT_SIZE_PT = 12;
+
+  private readonly format: 'tex' | 'text';
+  private readonly position: string;
+  private readonly sizePt: number;
+  private readonly text: string;
+
+  constructor(options: QCircuitCaptionOptions) {
+    this.format = options.captionFormat ?? 'text';
+    this.position = options.captionPosition ?? QCircuitCaption.DEFAULT_POSITION;
+    this.sizePt = options.captionSize ?? QCircuitCaption.DEFAULT_SIZE_PT;
+    this.text = options.caption ?? '';
+  }
+
+  get lines(): string[] {
+    if (!this.present) {
+      return [];
+    }
+
+    return [`{\\fontsize{${this.sizePt}}{${this.lineHeightPt}}\\selectfont ${this.escapedText}}`];
+  }
+
+  get positionBottom(): boolean {
+    return this.position === 'bottom';
+  }
+
+  get positionTop(): boolean {
+    return this.position === 'top';
+  }
+
+  static validPosition(position: string): boolean {
+    return position === 'top' || position === 'bottom';
+  }
+
+  private get escapedText(): string {
+    if (this.format === 'tex') {
+      return this.text;
+    }
+
+    return [...this.text].map((char) => LATEX_ESCAPE_MAP.get(char) ?? char).join('');
+  }
+
+  private get lineHeightPt(): number {
+    return Math.ceil(this.sizePt * 1.25);
+  }
+
+  private get present(): boolean {
+    return this.text.length > 0;
+  }
+}
+
+export class QCircuitLatex {
+  private readonly caption: QCircuitCaption;
+  private readonly circuit: CircuitData;
+  private readonly theme: ExportTheme;
+
+  constructor(circuit: CircuitData, options: QCircuitLatexOptions) {
+    this.caption = new QCircuitCaption(options);
+    this.circuit = circuit;
+    this.theme = options.theme;
+  }
+
+  render(): string {
+    return this.documentLines.join('\n');
+  }
+
+  private get documentLines(): string[] {
+    return [
+      ...DOCUMENT_HEADER_LINES,
+      this.themeColorLine,
+      '\\begin{tabular}{c}',
+      ...this.topCaptionLines,
+      ...this.circuitLines,
+      ...this.bottomCaptionLines,
+      '\\end{tabular}',
+      ...DOCUMENT_FOOTER_LINES
+    ];
+  }
+
+  private get bottomCaptionLines(): string[] {
+    if (!this.caption.positionBottom) {
+      return [];
+    }
+
+    return ['\\\\[0.8em]', ...this.caption.lines];
+  }
+
+  private get circuitLines(): string[] {
+    return [
+      ...CIRCUIT_HEADER_LINES,
+      '\\Qcircuit @C=0.55em @R=2.2em @!R { \\\\',
+      this.renderedRows,
+      ...CIRCUIT_FOOTER_LINES
+    ];
+  }
+
+  private get renderedRows(): string {
+    const renderedColumns = this.renderedColumns;
+
+    return Array.from({ length: this.circuit.qubits }, (_unused, qubit) => {
+      const renderedCells = renderedColumns.map((column) => column.renderFor(qubit));
+
+      return `  ${this.wireLabel(qubit)} & ${[...renderedCells, '\\qw'].join(' & ')}\\\\`;
+    }).join('\n');
+  }
+
+  private get renderedColumns(): QCircuitColumn[] {
+    return this.columns.map((column) => new QCircuitColumn(column));
+  }
+
+  private get columns(): unknown[][] {
+    if (this.circuit.cols.length > 0) {
+      return this.circuit.cols;
+    }
+
+    return Array.from({ length: EMPTY_CIRCUIT_MIN_COLUMNS }, () =>
+      Array.from({ length: this.circuit.qubits }, () => EMPTY_SLOT)
+    );
+  }
+
+  private get themeColorLine(): string {
+    return `\\color{${this.themeColorName}}`;
+  }
+
+  private get themeColorName(): string {
+    return this.theme === 'light' ? 'black' : 'white';
+  }
+
+  private get topCaptionLines(): string[] {
+    if (!this.caption.positionTop) {
+      return [];
+    }
+
+    return [...this.caption.lines, '\\\\[0.8em]'];
+  }
+
+  private wireLabel(qubit: number): string {
+    return `\\push{q${qubit}: \\ket{0}}`;
+  }
+}
+
+class QCircuitColumn {
+  private readonly slots: unknown[];
+
+  constructor(slots: unknown[]) {
+    this.slots = slots;
+  }
+
+  renderFor(qubit: number): string {
+    return this.renderedCells.get(qubit) ?? '\\qw';
+  }
+
+  private get renderedCells(): Map<number, string> {
+    if (this.swapStep) {
+      return this.swapCells();
+    }
+
+    if (this.controlledStep) {
+      return this.controlledCells();
+    }
+
+    return this.simpleCells();
+  }
+
+  private get controlledStep(): boolean {
+    return this.slots.includes(CONTROL_SYMBOL);
+  }
+
+  private get swapStep(): boolean {
+    return this.slots.includes(SWAP_SYMBOL);
+  }
+
+  private controlledCells(): Map<number, string> {
+    const target = this.controlledTarget();
+    const cells = new Map<number, string>();
+
+    for (const controlQubit of this.controlQubits) {
+      cells.set(controlQubit, `\\ctrl{${target.qubit - controlQubit}}`);
+    }
+
+    cells.set(target.qubit, target.renderedCell);
+    return cells;
+  }
+
+  private controlledTarget(): ControlledTarget {
+    const targets = this.slots
+      .map((slot, qubit) => ({ qubit, slot }))
+      .filter(({ slot }) => !emptySlot(slot) && slot !== CONTROL_SYMBOL);
+
+    if (targets.length !== 1) {
+      throw new Error(`unsupported controlled step: ${JSON.stringify(this.slots)}`);
+    }
+
+    return new ControlledTarget(targets[0].slot, targets[0].qubit);
+  }
+
+  private get controlQubits(): number[] {
+    return this.slots
+      .map((slot, index) => ({ index, slot }))
+      .filter(({ slot }) => slot === CONTROL_SYMBOL)
+      .map(({ index }) => index);
+  }
+
+  private simpleCells(): Map<number, string> {
+    return new Map(this.slots.map((slot, qubit) => [qubit, renderedSlot(slot)]));
+  }
+
+  private swapCells(): Map<number, string> {
+    if (!this.validSwapStep) {
+      throw new Error(`unsupported swap step: ${JSON.stringify(this.slots)}`);
+    }
+
+    const [topQubit, bottomQubit] = this.swapQubits.sort((a, b) => a - b);
+
+    return new Map<number, string>([
+      [topQubit, '\\qswap'],
+      [bottomQubit, `\\qswap \\qwx[${topQubit - bottomQubit}]`]
+    ]);
+  }
+
+  private get validSwapStep(): boolean {
+    return this.swapQubits.length === 2 && this.slots.every((slot) => emptySlot(slot) || slot === SWAP_SYMBOL);
+  }
+
+  private get swapQubits(): number[] {
+    return this.slots
+      .map((slot, index) => ({ index, slot }))
+      .filter(({ slot }) => slot === SWAP_SYMBOL)
+      .map(({ index }) => index);
+  }
+}
+
+class ControlledTarget {
+  readonly qubit: number;
+
+  private readonly slot: unknown;
+
+  constructor(slot: unknown, qubit: number) {
+    this.slot = slot;
+    this.qubit = qubit;
+  }
+
+  get renderedCell(): string {
+    return TARGET_SLOT_RENDERERS.get(this.slot) ?? gateCell(this.slot);
+  }
+}
+
+function emptySlot(slot: unknown): boolean {
+  return DIRECT_SLOT_RENDERERS.has(slot);
+}
+
+function renderedSlot(slot: unknown): string {
+  return DIRECT_SLOT_RENDERERS.get(slot) ?? gateCell(slot);
+}
+
+function gateCell(slot: unknown): string {
+  return `\\gate{${gateLabel(slot)}}`;
+}
+
+function gateLabel(slot: unknown): string {
+  const specialLabel = SPECIAL_GATE_LABELS.get(slot);
+
+  if (specialLabel) {
+    return specialLabel;
+  }
+
+  const label = String(slot);
+  const match = /^(?<name>[A-Za-z]+)\((?<angle>.+)\)$/u.exec(label);
+
+  if (match?.groups) {
+    return `\\mathrm{${match.groups.name}}(${formattedAngle(match.groups.angle)})`;
+  }
+
+  return `\\mathrm{${label}}`;
+}
+
+function formattedAngle(angle: string): string {
+  return angle.replace(/π/gu, '\\pi').replace(/(?<![A-Za-z])pi(?![A-Za-z])/gu, '\\pi');
+}
+
+export function validateCaptionOptions(options: QCircuitCaptionOptions): void {
+  const position = options.captionPosition ?? QCircuitCaption.DEFAULT_POSITION;
+  const size = options.captionSize ?? QCircuitCaption.DEFAULT_SIZE_PT;
+
+  if (!QCircuitCaption.validPosition(position)) {
+    throw new Error('--caption-position must be top or bottom');
+  }
+
+  if (!Number.isFinite(size) || size <= 0) {
+    throw new Error('--caption-size must be positive');
+  }
+}

--- a/test/typescript/export_command.test.ts
+++ b/test/typescript/export_command.test.ts
@@ -133,6 +133,50 @@ describe('export command TypeScript route', () => {
     });
   });
 
+  it('rejects malformed --caption-size values like the Ruby oracle without invoking Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      await writeCircuit(dir, {
+        qubits: 1,
+        cols: [['H']]
+      });
+
+      for (const value of ['1abc', 'abc', 'NaN', 'Infinity', '0x10', '5.']) {
+        const argv = ['export', '--latex-source', '--caption-size', value];
+        const result = captureDispatcherRun(dir, argv, { PATH: '' });
+        const oracle = await rubyOracle(dir, argv);
+
+        assert.equal(result.exitStatus, oracle.exitStatus, value);
+        assert.equal(result.stdout, oracle.stdout, value);
+        assert.equal(result.stderr, oracle.stderr, value);
+      }
+    });
+  });
+
+  it('reports malformed controlled and swap steps like the Ruby oracle', async () => {
+    await withTempDir(async (dir) => {
+      for (const circuit of [
+        {
+          qubits: 3,
+          cols: [['•', 'H', 'X']]
+        },
+        {
+          qubits: 3,
+          cols: [['Swap', 'Swap', 'H']]
+        }
+      ]) {
+        await writeCircuit(dir, circuit);
+
+        const argv = ['export', '--latex-source'];
+        const result = captureDispatcherRun(dir, argv, { PATH: '' });
+        const oracle = await rubyOracle(dir, argv);
+
+        assert.equal(result.exitStatus, oracle.exitStatus);
+        assert.equal(result.stdout, oracle.stdout);
+        assert.equal(result.stderr, oracle.stderr);
+      }
+    });
+  });
+
   it('writes LaTeX source to --output without stdout like Ruby', async () => {
     await withTempDir(async (dir) => {
       await writeCircuit(dir, {

--- a/test/typescript/export_command.test.ts
+++ b/test/typescript/export_command.test.ts
@@ -140,7 +140,7 @@ describe('export command TypeScript route', () => {
         cols: [['H']]
       });
 
-      for (const value of ['1abc', 'abc', 'NaN', 'Infinity', '0x10', '5.']) {
+      for (const value of ['1abc', 'abc', 'NaN', 'Infinity', '0x10', '5.', '-1', '-1.5', '.5']) {
         const argv = ['export', '--latex-source', '--caption-size', value];
         const result = captureDispatcherRun(dir, argv, { PATH: '' });
         const oracle = await rubyOracle(dir, argv);

--- a/test/typescript/export_command.test.ts
+++ b/test/typescript/export_command.test.ts
@@ -183,6 +183,21 @@ describe('export command TypeScript route', () => {
     });
   });
 
+  it('leaves value-like option ambiguity on Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      await writeCircuit(dir, {
+        qubits: 1,
+        cols: [['H']]
+      });
+
+      const result = captureDispatcherRun(dir, ['export', '--latex-source', '--output', '--light'], { PATH: '' });
+
+      assert.equal(result.exitStatus, 127);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, 'spawnSync bundle ENOENT\n');
+    });
+  });
+
   it('honors QNI_USE_RUBY for export', async () => {
     await withTempDir(async (dir) => {
       await writeCircuit(dir, {

--- a/test/typescript/export_command.test.ts
+++ b/test/typescript/export_command.test.ts
@@ -1,0 +1,200 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import { createDispatcher } from '../../src/dispatcher';
+
+interface CapturedRun {
+  readonly exitStatus: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}
+
+async function withTempDir<T>(callback: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'qni-cli-export-'));
+
+  try {
+    return await callback(dir);
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+}
+
+function captureDispatcherRun(
+  cwd: string,
+  argv: string[],
+  env: NodeJS.ProcessEnv = { ...process.env }
+): CapturedRun {
+  let stdout = '';
+  let stderr = '';
+  const originalStdoutWrite = process.stdout.write;
+  const originalStderrWrite = process.stderr.write;
+
+  process.stdout.write = ((
+    chunk: string | Uint8Array,
+    encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+    callback?: (error?: Error | null) => void
+  ): boolean => {
+    stdout += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk.toString();
+    if (typeof encodingOrCallback === 'function') {
+      encodingOrCallback();
+    }
+    if (callback) {
+      callback();
+    }
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = ((
+    chunk: string | Uint8Array,
+    encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+    callback?: BufferEncoding | ((error?: Error | null) => void)
+  ): boolean => {
+    stderr += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk.toString();
+    if (typeof encodingOrCallback === 'function') {
+      encodingOrCallback();
+    }
+    if (typeof callback === 'function') {
+      callback();
+    }
+    return true;
+  }) as typeof process.stderr.write;
+
+  try {
+    const dispatcher = createDispatcher({
+      cwd,
+      env,
+      projectRoot: process.cwd()
+    });
+
+    return {
+      exitStatus: dispatcher.run(argv),
+      stderr,
+      stdout
+    };
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+}
+
+async function writeCircuit(dir: string, circuit: unknown): Promise<void> {
+  await writeFile(path.join(dir, 'circuit.json'), `${JSON.stringify(circuit, null, 2)}\n`);
+}
+
+async function rubyOracle(dir: string, argv: string[]): Promise<CapturedRun> {
+  return captureDispatcherRun(dir, argv, { ...process.env, QNI_USE_RUBY: '1' });
+}
+
+describe('export command TypeScript route', () => {
+  it('renders qcircuit LaTeX source like the Ruby oracle without invoking Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      await writeCircuit(dir, {
+        qubits: 2,
+        cols: [
+          ['•', 'X'],
+          ['Swap', 'Swap']
+        ]
+      });
+
+      const result = captureDispatcherRun(dir, ['export', '--latex-source'], { PATH: '' });
+      const oracle = await rubyOracle(dir, ['export', '--latex-source']);
+
+      assert.equal(result.exitStatus, 0);
+      assert.equal(result.stderr, '');
+      assert.equal(result.stdout, oracle.stdout);
+    });
+  });
+
+  it('renders captioned light-theme LaTeX source like the Ruby oracle', async () => {
+    await withTempDir(async (dir) => {
+      await writeCircuit(dir, {
+        qubits: 1,
+        cols: [['H']]
+      });
+
+      const argv = [
+        'export',
+        '--latex-source',
+        '--caption',
+        'π & CNOT',
+        '--caption-position',
+        'top',
+        '--light'
+      ];
+      const result = captureDispatcherRun(dir, argv, { PATH: '' });
+      const oracle = await rubyOracle(dir, argv);
+
+      assert.equal(result.exitStatus, 0);
+      assert.equal(result.stderr, '');
+      assert.equal(result.stdout, oracle.stdout);
+    });
+  });
+
+  it('writes LaTeX source to --output without stdout like Ruby', async () => {
+    await withTempDir(async (dir) => {
+      await writeCircuit(dir, {
+        qubits: 1,
+        cols: [['T†']]
+      });
+
+      const result = captureDispatcherRun(dir, ['export', '--latex-source', '--output', 'nested/circuit.tex'], {
+        PATH: ''
+      });
+      const output = await readFile(path.join(dir, 'nested', 'circuit.tex'), 'utf8');
+      const oracle = await rubyOracle(dir, ['export', '--latex-source', '--output', 'nested/circuit.tex']);
+      const oracleOutput = await readFile(path.join(dir, 'nested', 'circuit.tex'), 'utf8');
+
+      assert.equal(result.exitStatus, 0);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, '');
+      assert.equal(output, oracleOutput);
+      assert.equal(oracle.exitStatus, 0);
+      assert.equal(oracle.stdout, '');
+      assert.equal(oracle.stderr, '');
+    });
+  });
+
+  it('prints export help without invoking Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, ['export', '--help'], { PATH: '' });
+
+      assert.equal(result.exitStatus, 0);
+      assert.equal(result.stderr, '');
+      assert.match(result.stdout, /qni export --latex-source \[--output=PATH\]/u);
+      assert.match(result.stdout, /qni export --circle-notation --png --output=PATH/u);
+    });
+  });
+
+  it('keeps regular PNG export on Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      await writeCircuit(dir, {
+        qubits: 1,
+        cols: [['H']]
+      });
+
+      const result = captureDispatcherRun(dir, ['export', '--png', '--output', 'circuit.png'], { PATH: '' });
+
+      assert.equal(result.exitStatus, 127);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, 'spawnSync bundle ENOENT\n');
+    });
+  });
+
+  it('honors QNI_USE_RUBY for export', async () => {
+    await withTempDir(async (dir) => {
+      await writeCircuit(dir, {
+        qubits: 1,
+        cols: [['H']]
+      });
+
+      const result = captureDispatcherRun(dir, ['export', '--latex-source'], { PATH: '', QNI_USE_RUBY: '1' });
+
+      assert.equal(result.exitStatus, 127);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, 'spawnSync bundle ENOENT\n');
+    });
+  });
+});


### PR DESCRIPTION
## 概要

- `qni export --latex-source` と `qni export --help` を TypeScript route に移行
- qcircuit LaTeX / caption rendering を TypeScript に追加
- `--caption-size` の不正値・非正値、malformed controlled / swap step の stderr を Ruby oracle と一致
- `export --png`、`--state-vector --png`、`--circle-notation --png`、`QNI_USE_RUBY=1` は Ruby fallback を維持
- YAS-227 の棚卸し結果として PNG / circle-notation / Bloch workflows は split issue 化済み

## Linear

- YAS-227: https://linear.app/yasuhito/issue/YAS-227/export-と-bloch-workflows-を-typescript-に移行する

## 検証

- `npm run test:ts`
- `npm run build && npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress features/cli/export/*.feature.md`
- `bundle exec rake check`

## 互換性メモ

- 移行対象の `export --latex-source` は Ruby oracle と stdout / stderr / exit status / output file 内容を比較済み
- `--caption-size` は `1abc` / `abc` / `NaN` / `Infinity` / `0x10` / `5.` / `-1` / `-1.5` / `.5` を Ruby oracle と比較済み
- malformed controlled / swap step は Ruby `Array#inspect` 相当の stderr 表記を比較済み
- fallback に残す PNG / APNG / inline は Node dispatcher と `QNI_USE_RUBY=1` で stable properties を比較済み


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * QCircuit回路をLaTeXまたはPNGでエクスポートするCLI機能を追加。キャプション位置・サイズ、テーマ、レンダリングモードなど細かなオプションを指定可能。高品質なLaTeXベースのレンダリングで回路図を出力できます。

* **Tests**
  * エクスポート機能の包括的なテストを追加。キャプション検証、テーマ処理、出力ファイル生成、外部レンダリングフォールバックなどの振る舞いを確認します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->