### PR TITLE
symbolic helper 境界を TypeScript に追加する

### DIFF
--- a/features/cli/typescript_process_compatibility.feature.md
+++ b/features/cli/typescript_process_compatibility.feature.md
@@ -15,3 +15,11 @@ process compatibility helper の契約を明確にしたい
 ## Scenario: full check は TypeScript tests を実行する
 
 - Then リポジトリファイル "Rakefile" は "npm run test:ts" を含む
+
+## Scenario: TypeScript symbolic helper boundary が存在する
+
+- Then リポジトリファイル "src/symbolic_state_renderer.ts" は存在する
+
+## Scenario: TypeScript run command は symbolic helper boundary を使う
+
+- Then リポジトリファイル "src/commands/run_command.ts" は "renderSymbolicStateVector" を含む

--- a/src/commands/run_command.ts
+++ b/src/commands/run_command.ts
@@ -2,9 +2,17 @@ import { currentCircuitFile } from '../circuit_file';
 import type { CommandHandlerContext } from '../dispatcher';
 import { runRubyFallbackSync } from '../process/process_compatibility';
 import { Simulator } from '../simulator';
+import { renderSymbolicStateVector } from '../symbolic_state_renderer';
+
+interface RunOptions {
+  readonly basis?: string;
+  readonly symbolic: boolean;
+}
 
 export function runRunCommand(argv: string[], context: CommandHandlerContext): number {
-  if (!typeScriptRun(argv)) {
+  const options = parseRunOptions(argv);
+
+  if (!options) {
     return runRubyFallbackSync({
       argv,
       cwd: context.cwd,
@@ -14,7 +22,21 @@ export function runRunCommand(argv: string[], context: CommandHandlerContext): n
   }
 
   try {
-    process.stdout.write(`${new Simulator(currentCircuitFile(context.cwd).load()).renderStateVector()}\n`);
+    const circuit = currentCircuitFile(context.cwd).load();
+    if (options.basis !== undefined && !options.symbolic) {
+      throw new Error('--basis requires --symbolic');
+    }
+
+    const output = options.symbolic
+      ? renderSymbolicStateVector({
+          basis: options.basis,
+          circuit,
+          env: context.env,
+          projectRoot: context.projectRoot
+        })
+      : new Simulator(circuit).renderStateVector();
+
+    process.stdout.write(`${output}\n`);
     return 0;
   } catch (error) {
     process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
@@ -22,6 +44,42 @@ export function runRunCommand(argv: string[], context: CommandHandlerContext): n
   }
 }
 
-function typeScriptRun(argv: readonly string[]): boolean {
-  return argv.length === 1 && argv[0] === 'run';
+function parseRunOptions(argv: readonly string[]): RunOptions | undefined {
+  if (argv[0] !== 'run') {
+    return undefined;
+  }
+
+  const options: { basis?: string; symbolic: boolean } = { symbolic: false };
+  let index = 1;
+
+  while (index < argv.length) {
+    const argument = argv[index];
+
+    if (argument === '--symbolic') {
+      options.symbolic = true;
+      index += 1;
+      continue;
+    }
+
+    if (argument === '--basis') {
+      const basis = argv[index + 1];
+      if (basis === undefined) {
+        return undefined;
+      }
+
+      options.basis = basis;
+      index += 2;
+      continue;
+    }
+
+    if (argument.startsWith('--basis=')) {
+      options.basis = argument.slice('--basis='.length);
+      index += 1;
+      continue;
+    }
+
+    return undefined;
+  }
+
+  return options;
 }

--- a/src/symbolic_state_renderer.ts
+++ b/src/symbolic_state_renderer.ts
@@ -1,0 +1,129 @@
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import type { CircuitData } from './circuit_file';
+
+export class SymbolicStateRendererError extends Error {}
+
+export type SymbolicOutputFormat = 'latex' | 'text';
+
+export interface SymbolicStateRenderOptions {
+  readonly basis?: string;
+  readonly circuit: CircuitData;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly format?: SymbolicOutputFormat;
+  readonly projectRoot: string;
+}
+
+interface HelperCommand {
+  readonly args: readonly string[];
+  readonly command: string;
+}
+
+interface ResolvedSymbolicStateRenderOptions extends SymbolicStateRenderOptions {
+  readonly format: SymbolicOutputFormat;
+}
+
+const SETUP_MESSAGE = 'symbolic run requires SymPy runtime; run scripts/setup_symbolic_python.sh';
+
+export function renderSymbolicStateVector(options: SymbolicStateRenderOptions): string {
+  validateSymbolicBasis({ basis: options.basis, qubits: options.circuit.qubits });
+
+  return renderWithHelpers({
+    ...options,
+    format: options.format ?? 'text'
+  });
+}
+
+function validateSymbolicBasis(options: { basis?: string; qubits: number }): void {
+  if ((options.basis === 'x' || options.basis === 'y') && options.qubits !== 1) {
+    throw new SymbolicStateRendererError(
+      `symbolic ${options.basis}-basis run currently supports only 1-qubit circuits`
+    );
+  }
+
+  if (options.basis === 'bell' && options.qubits !== 2) {
+    throw new SymbolicStateRendererError('symbolic bell-basis run currently supports only 2-qubit circuits');
+  }
+}
+
+function renderWithHelpers(options: ResolvedSymbolicStateRenderOptions): string {
+  for (const command of helperCommands(options)) {
+    const output = renderWithHelper(command, options);
+
+    if (output !== undefined) {
+      return output;
+    }
+  }
+
+  throw new SymbolicStateRendererError(SETUP_MESSAGE);
+}
+
+function helperCommands(options: ResolvedSymbolicStateRenderOptions): HelperCommand[] {
+  const helperPath = path.join(options.projectRoot, 'libexec', 'qni_symbolic_run.py');
+  const args = [helperPath, '--format', options.format];
+
+  if (options.basis !== undefined) {
+    args.push('--basis', options.basis);
+  }
+
+  return [
+    {
+      args,
+      command: path.join(options.projectRoot, '.python-symbolic', 'bin', 'python')
+    },
+    {
+      args,
+      command: 'python3'
+    },
+    {
+      args: ['run', '--quiet', '--with', 'sympy', 'python3', ...args],
+      command: 'uv'
+    }
+  ];
+}
+
+function renderWithHelper(command: HelperCommand, options: ResolvedSymbolicStateRenderOptions): string | undefined {
+  const result = spawnSync(command.command, [...command.args], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ...options.env,
+      UV_CACHE_DIR: path.join(tmpdir(), 'qni-cli-uv-cache')
+    },
+    input: JSON.stringify(options.circuit),
+    stdio: ['pipe', 'pipe', 'pipe']
+  });
+
+  if (result.error) {
+    const error = result.error as NodeJS.ErrnoException;
+    if (error.code === 'ENOENT') {
+      return undefined;
+    }
+
+    throw new SymbolicStateRendererError(error.message);
+  }
+
+  if (result.status === 0) {
+    return result.stdout.trim();
+  }
+
+  if (retryableWithNextCommand(command.command, result.stderr)) {
+    return undefined;
+  }
+
+  throw new SymbolicStateRendererError(renderErrorMessage(result.stderr, result.status));
+}
+
+function retryableWithNextCommand(command: string, stderr: string): boolean {
+  return (
+    (command === 'uv' && stderr.includes('Failed to fetch:')) ||
+    (command === 'python3' && stderr.includes("No module named 'sympy'"))
+  );
+}
+
+function renderErrorMessage(stderr: string, status: number | null): string {
+  const message = stderr.trim();
+  return message === '' ? `symbolic renderer failed with exit status ${status ?? ''}` : message;
+}

--- a/test/typescript/symbolic_state_renderer.test.ts
+++ b/test/typescript/symbolic_state_renderer.test.ts
@@ -1,0 +1,260 @@
+import assert from 'node:assert/strict';
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import { createDispatcher } from '../../src/dispatcher';
+import {
+  renderSymbolicStateVector,
+  SymbolicStateRendererError
+} from '../../src/symbolic_state_renderer';
+
+interface CapturedRun {
+  readonly exitStatus: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}
+
+async function withTempDir<T>(callback: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'qni-cli-symbolic-'));
+
+  try {
+    return await callback(dir);
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+}
+
+async function writeCircuit(dir: string, circuit: unknown): Promise<void> {
+  await writeFile(path.join(dir, 'circuit.json'), `${JSON.stringify(circuit, null, 2)}\n`);
+}
+
+async function writeExecutable(filePath: string, body: string): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, body);
+  await chmod(filePath, 0o755);
+}
+
+async function writeSymbolicHelperPlaceholder(projectRoot: string): Promise<void> {
+  await mkdir(path.join(projectRoot, 'libexec'), { recursive: true });
+  await writeFile(path.join(projectRoot, 'libexec', 'qni_symbolic_run.py'), '');
+}
+
+function captureDispatcherRun(cwd: string, argv: string[], env: NodeJS.ProcessEnv = { PATH: '' }): CapturedRun {
+  let stdout = '';
+  let stderr = '';
+  const originalStdoutWrite = process.stdout.write;
+  const originalStderrWrite = process.stderr.write;
+
+  process.stdout.write = ((
+    chunk: string | Uint8Array,
+    encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+    callback?: (error?: Error | null) => void
+  ): boolean => {
+    stdout += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk.toString();
+    if (typeof encodingOrCallback === 'function') {
+      encodingOrCallback();
+    }
+    if (callback) {
+      callback();
+    }
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = ((
+    chunk: string | Uint8Array,
+    encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+    callback?: BufferEncoding | ((error?: Error | null) => void)
+  ): boolean => {
+    stderr += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk.toString();
+    if (typeof encodingOrCallback === 'function') {
+      encodingOrCallback();
+    }
+    if (typeof callback === 'function') {
+      callback();
+    }
+    return true;
+  }) as typeof process.stderr.write;
+
+  try {
+    const dispatcher = createDispatcher({
+      cwd,
+      env,
+      projectRoot: process.cwd()
+    });
+
+    return {
+      exitStatus: dispatcher.run(argv),
+      stderr,
+      stdout
+    };
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+}
+
+describe('TypeScript symbolic state renderer boundary', () => {
+  it('renders text and LaTeX through the retained Python helper', () => {
+    const circuit = {
+      cols: [['H']],
+      qubits: 1
+    };
+
+    assert.equal(
+      renderSymbolicStateVector({
+        circuit,
+        env: { PATH: '' },
+        projectRoot: process.cwd()
+      }),
+      'sqrt(2)/2|0> + sqrt(2)/2|1>'
+    );
+    assert.equal(
+      renderSymbolicStateVector({
+        circuit,
+        env: { PATH: '' },
+        format: 'latex',
+        projectRoot: process.cwd()
+      }),
+      '\\frac{\\sqrt{2}}{2} \\lvert 0 \\rangle + \\frac{\\sqrt{2}}{2} \\lvert 1 \\rangle'
+    );
+  });
+
+  it('passes named basis options to the helper', () => {
+    assert.equal(
+      renderSymbolicStateVector({
+        basis: 'x',
+        circuit: {
+          cols: [['H']],
+          qubits: 1
+        },
+        env: { PATH: '' },
+        projectRoot: process.cwd()
+      }),
+      '|+>'
+    );
+  });
+
+  it('validates named-basis qubit counts before invoking helpers', () => {
+    assert.throws(
+      () =>
+        renderSymbolicStateVector({
+          basis: 'x',
+          circuit: {
+            cols: [[1, 1]],
+            qubits: 2
+          },
+          env: { PATH: '' },
+          projectRoot: process.cwd()
+        }),
+      (error: unknown) =>
+        error instanceof SymbolicStateRendererError &&
+        error.message === 'symbolic x-basis run currently supports only 1-qubit circuits'
+    );
+  });
+
+  it('falls back from missing repository runtime to uv when system python lacks SymPy', async () => {
+    await withTempDir(async (projectRoot) => {
+      const bin = path.join(projectRoot, 'bin');
+      await writeSymbolicHelperPlaceholder(projectRoot);
+      await writeExecutable(
+        path.join(bin, 'python3'),
+        `#!/bin/sh
+echo "ModuleNotFoundError: No module named 'sympy'" >&2
+exit 1
+`
+      );
+      await writeExecutable(path.join(bin, 'uv'), '#!/bin/sh\necho uv-success\n');
+
+      assert.equal(
+        renderSymbolicStateVector({
+          circuit: {
+            cols: [[1]],
+            qubits: 1
+          },
+          env: { PATH: bin },
+          projectRoot
+        }),
+        'uv-success'
+      );
+    });
+  });
+
+  it('does not mask a non-zero repository runtime helper failure', async () => {
+    await withTempDir(async (projectRoot) => {
+      const bin = path.join(projectRoot, 'bin');
+      await writeSymbolicHelperPlaceholder(projectRoot);
+      await writeExecutable(
+        path.join(projectRoot, '.python-symbolic', 'bin', 'python'),
+        '#!/bin/sh\necho "repo runtime failed" >&2\nexit 9\n'
+      );
+      await writeExecutable(path.join(bin, 'python3'), '#!/bin/sh\necho should-not-run\n');
+
+      assert.throws(
+        () =>
+          renderSymbolicStateVector({
+            circuit: {
+              cols: [[1]],
+              qubits: 1
+            },
+            env: { PATH: bin },
+            projectRoot
+          }),
+        (error: unknown) =>
+          error instanceof SymbolicStateRendererError && error.message === 'repo runtime failed'
+      );
+    });
+  });
+});
+
+describe('run command symbolic TypeScript route', () => {
+  it('runs --symbolic without invoking Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      const bin = path.join(dir, 'bin');
+      await writeCircuit(dir, {
+        cols: [['H']],
+        qubits: 1
+      });
+      await writeExecutable(path.join(bin, 'bundle'), '#!/bin/sh\necho RUBY_FALLBACK_INVOKED >&2\nexit 42\n');
+
+      const result = captureDispatcherRun(dir, ['run', '--symbolic'], { PATH: bin });
+
+      assert.equal(result.exitStatus, 0);
+      assert.equal(result.stderr, '');
+      assert.equal(result.stdout, 'sqrt(2)/2|0> + sqrt(2)/2|1>\n');
+    });
+  });
+
+  it('rejects --basis without --symbolic before helper execution', async () => {
+    await withTempDir(async (dir) => {
+      const bin = path.join(dir, 'bin');
+      await writeCircuit(dir, {
+        cols: [[1]],
+        qubits: 1
+      });
+      await writeExecutable(path.join(bin, 'bundle'), '#!/bin/sh\necho RUBY_FALLBACK_INVOKED >&2\nexit 42\n');
+
+      const result = captureDispatcherRun(dir, ['run', '--basis', 'x'], { PATH: bin });
+
+      assert.equal(result.exitStatus, 1);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, '--basis requires --symbolic\n');
+    });
+  });
+
+  it('passes an empty symbolic basis value to the helper like Ruby', async () => {
+    await withTempDir(async (dir) => {
+      await writeCircuit(dir, {
+        cols: [[1]],
+        qubits: 1
+      });
+
+      const result = captureDispatcherRun(dir, ['run', '--symbolic', '--basis=']);
+
+      assert.equal(result.exitStatus, 1);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, 'unsupported symbolic basis:\n');
+    });
+  });
+});


### PR DESCRIPTION
## 概要

- YAS-251
- TypeScript から `libexec/qni_symbolic_run.py` を呼び出す `src/symbolic_state_renderer.ts` を追加しました。
- `run --symbolic` と `--basis` 指定を TypeScript の `run` command path から helper 境界へ接続しました。
- `--format text|latex`、JSON stdin、`--basis`、repository runtime / `python3` / `uv` fallback、stderr / exit status の扱いを Ruby 境界に合わせました。

## 検証

- `npm run test:ts`
- `npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress features/cli/run/symbolic.feature.md features/cli/run/errors.feature.md features/cli/typescript_process_compatibility.feature.md features/cli/export/state_vector_png.feature.md`
- `bundle exec rake check`
