### PR TITLE
TypeScript command error taxonomy を整理する

### DIFF
--- a/features/cli/typescript_command_error_taxonomy.feature.md
+++ b/features/cli/typescript_command_error_taxonomy.feature.md
@@ -1,0 +1,53 @@
+# Feature: TypeScript command error taxonomy
+
+qni-cli のメンテナとして
+TypeScript command route の CLI validation error と circuit file domain error を分けるために
+ユーザー向けエラー互換性を保ったまま責務境界を明確にしたい
+
+## Scenario: CLI validation error class が存在する
+
+- Then リポジトリファイル "src/commands/command_error.ts" は "export class CommandError extends Error" を含む
+
+## Scenario: gate command validation error は失敗する
+
+- Given 空の 1 qubit 回路がある
+- When "qni gate --qubit 1.0 --step 0" を実行
+- Then コマンドは失敗
+
+## Scenario: gate command validation error は stderr 互換性を保つ
+
+- Given 空の 1 qubit 回路がある
+- When "qni gate --qubit 1.0 --step 0" を実行
+- Then 標準エラー:
+
+  ```text
+  qubit must be an integer
+  ```
+
+## Scenario: state command validation error は失敗する
+
+- When "qni state set \"\"" を実行
+- Then コマンドは失敗
+
+## Scenario: state command validation error は stderr 互換性を保つ
+
+- When "qni state set \"\"" を実行
+- Then 標準エラー:
+
+  ```text
+  initial state expression is required
+  ```
+
+## Scenario: variable command validation error は失敗する
+
+- When "qni variable set theta" を実行
+- Then コマンドは失敗
+
+## Scenario: variable command validation error は stderr 互換性を保つ
+
+- When "qni variable set theta" を実行
+- Then 標準エラー:
+
+  ```text
+  wrong number of arguments
+  ```

--- a/src/commands/command_error.ts
+++ b/src/commands/command_error.ts
@@ -1,0 +1,6 @@
+export class CommandError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CommandError';
+  }
+}

--- a/src/commands/gate_command.ts
+++ b/src/commands/gate_command.ts
@@ -1,5 +1,6 @@
-import { CircuitFileError, currentCircuitFile } from '../circuit_file';
+import { currentCircuitFile } from '../circuit_file';
 import type { CommandHandlerContext } from '../dispatcher';
+import { CommandError } from './command_error';
 
 const HELP_TEXT = `Usage:
   qni gate --qubit=N --step=N
@@ -45,7 +46,7 @@ function parseGateOptions(args: string[]): GateOptions {
     const match = /^--(?<name>qubit|step)(?:=(?<value>.*))?$/u.exec(arg);
 
     if (!match?.groups) {
-      throw new CircuitFileError(`unknown option: ${arg}`);
+      throw new CommandError(`unknown option: ${arg}`);
     }
 
     const value = match.groups.value ?? args[index + 1];
@@ -65,17 +66,17 @@ function parseGateOptions(args: string[]): GateOptions {
 
 function requiredNonNegativeInteger(value: string | undefined, name: string): number {
   if (!value) {
-    throw new CircuitFileError(`${name} is required`);
+    throw new CommandError(`${name} is required`);
   }
 
   if (!/^[+-]?\d+$/u.test(value)) {
-    throw new CircuitFileError(`${name} must be an integer`);
+    throw new CommandError(`${name} must be an integer`);
   }
 
   const parsedValue = Number.parseInt(value, 10);
 
   if (parsedValue < 0) {
-    throw new CircuitFileError(`${name} must be >= 0`);
+    throw new CommandError(`${name} must be >= 0`);
   }
 
   return parsedValue;

--- a/src/commands/state_command.ts
+++ b/src/commands/state_command.ts
@@ -1,5 +1,6 @@
-import { CircuitFileError, currentCircuitFile } from '../circuit_file';
+import { currentCircuitFile } from '../circuit_file';
 import type { CommandHandlerContext } from '../dispatcher';
+import { CommandError } from './command_error';
 
 const HELP_TEXT = `Usage:
   qni state set "alpha|0> + beta|1>"
@@ -32,7 +33,7 @@ export function runStateCommand(argv: string[], context: CommandHandlerContext):
 
   try {
     if (!isTypeScriptStateSubcommand(subcommand)) {
-      throw new CircuitFileError(`unsupported state subcommand: ${subcommand}`);
+      throw new CommandError(`unsupported state subcommand: ${subcommand}`);
     }
 
     const output = executeSubcommand(subcommand, argv.slice(2), context);
@@ -75,12 +76,12 @@ function isTypeScriptStateSubcommand(value: string): value is TypeScriptStateSub
 
 function requireArgumentCount(args: string[], expected: number): void {
   if (args.length !== expected) {
-    throw new CircuitFileError('wrong number of arguments');
+    throw new CommandError('wrong number of arguments');
   }
 }
 
 function requireStateExpression(value: string): void {
   if (value.length === 0) {
-    throw new CircuitFileError('initial state expression is required');
+    throw new CommandError('initial state expression is required');
   }
 }

--- a/src/commands/variable_command.ts
+++ b/src/commands/variable_command.ts
@@ -1,5 +1,6 @@
-import { CircuitFileError, currentCircuitFile } from '../circuit_file';
+import { currentCircuitFile } from '../circuit_file';
 import type { CommandHandlerContext } from '../dispatcher';
+import { CommandError } from './command_error';
 
 const HELP_TEXT = `Usage:
   qni variable set NAME ANGLE
@@ -35,7 +36,7 @@ export function runVariableCommand(argv: string[], context: CommandHandlerContex
     }
 
     if (!isVariableSubcommand(subcommand)) {
-      throw new CircuitFileError(`unsupported variable subcommand: ${subcommand}`);
+      throw new CommandError(`unsupported variable subcommand: ${subcommand}`);
     }
 
     const output = executeSubcommand(subcommand, argv.slice(2), context);
@@ -101,7 +102,7 @@ function isVariableSubcommand(value: string): value is VariableSubcommand {
 
 function requiredArgument(value: string | undefined, message: string): string {
   if (value === undefined) {
-    throw new CircuitFileError(message);
+    throw new CommandError(message);
   }
 
   return value;
@@ -109,6 +110,6 @@ function requiredArgument(value: string | undefined, message: string): string {
 
 function requireArgumentCount(args: string[], expected: number): void {
   if (args.length !== expected) {
-    throw new CircuitFileError('wrong number of arguments');
+    throw new CommandError('wrong number of arguments');
   }
 }

--- a/test/typescript/gate_command.test.ts
+++ b/test/typescript/gate_command.test.ts
@@ -161,6 +161,16 @@ describe('gate command TypeScript route', () => {
     });
   });
 
+  it('rejects unknown CLI options before reading circuit.json', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, ['gate', '--wat']);
+
+      assert.equal(result.exitStatus, 1);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, 'unknown option: --wat\n');
+    });
+  });
+
   it('honors QNI_USE_RUBY for gate', async () => {
     await withTempDir(async (dir) => {
       const result = captureDispatcherRun(dir, ['gate', '--qubit', '0', '--step', '0'], {

--- a/test/typescript/state_command.test.ts
+++ b/test/typescript/state_command.test.ts
@@ -163,6 +163,16 @@ describe('state command TypeScript route', () => {
     });
   });
 
+  it('rejects unsupported subcommands before reading circuit.json', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, ['state', 'wat']);
+
+      assert.equal(result.exitStatus, 1);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, 'unsupported state subcommand: wat\n');
+    });
+  });
+
   it('validates the existing initial state before replacing it', async () => {
     await withTempDir(async (dir) => {
       const circuitPath = path.join(dir, 'circuit.json');

--- a/test/typescript/variable_command.test.ts
+++ b/test/typescript/variable_command.test.ts
@@ -153,6 +153,16 @@ describe('variable command TypeScript route', () => {
     });
   });
 
+  it('rejects unsupported subcommands before reading circuit.json', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, ['variable', 'wat']);
+
+      assert.equal(result.exitStatus, 1);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, 'unsupported variable subcommand: wat\n');
+    });
+  });
+
   it('rejects malformed cols before mutating circuit.json', async () => {
     await withTempDir(async (dir) => {
       const circuitPath = path.join(dir, 'circuit.json');


### PR DESCRIPTION
## 概要

- TypeScript command route の CLI 引数検証用に `CommandError` を追加しました。
- `gate_command.ts` / `state_command.ts` / `variable_command.ts` の引数・サブコマンド検証は `CommandError` に移し、`currentCircuitFile` 以降の `circuit.json` 読み書きやドメイン検証は既存の `CircuitFileError` に残しました。
- stderr 文字列と exit status の互換性を保つ回帰テストを、feature と TypeScript tests に追加しました。

## 確認

- `npm run build && npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress features/cli/typescript_command_error_taxonomy.feature.md`
- `npx tsc -p tsconfig.test.json && node --test tmp/typescript-tests/test/typescript/gate_command.test.js tmp/typescript-tests/test/typescript/state_command.test.js tmp/typescript-tests/test/typescript/variable_command.test.js`
- `bundle exec rake check`

## Linear

- YAS-230
