### PR TITLE
BasicGates Task 1.2 計画書の文体を整える

### DIFF
--- a/docs/superpowers/plans/2026-03-19-basic-gates-task-1-2.md
+++ b/docs/superpowers/plans/2026-03-19-basic-gates-task-1-2.md
@@ -1,33 +1,33 @@
-# BasicGates Task 1.2 Implementation Plan
+# BasicGates Task 1.2 実装計画
 
-> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **エージェント作業者向け:** 必須: この計画の実装には superpowers:subagent-driven-development（サブエージェントが利用できる場合）または superpowers:executing-plans を使う。進捗管理にはチェックボックス（`- [ ]`）形式の手順を使う。
 
-**Goal:** `BasicGates Task 1.2 BasisChange` を `features/katas/basic_gates.feature` に追加し、`H` による基底変換を数値、controlled 検証、symbolic 表示の 3 つの観点で回帰テスト化する。
+**目的:** `BasicGates Task 1.2 BasisChange` を `features/katas/basic_gates.feature` に追加し、`H` による基底変換を数値、制御付き検証、記号表示の 3 つの観点で回帰テスト化する。
 
-**Architecture:** `Task 1.1` と同じ粒度を維持するため、`features/katas/basic_gates.feature` に `Task 1.2` の 5 シナリオを順に追加する。既存の `qni run`、`qni run --symbolic`、`qni expect`、初期状態 step だけで表現できる前提で進め、product code は触らない。
+**構成方針:** `Task 1.1` と同じ粒度を維持するため、`features/katas/basic_gates.feature` に `Task 1.2` の 5 シナリオを順に追加する。既存の `qni run`、`qni run --symbolic`、`qni expect`、初期状態のステップだけで表現できる前提で進め、製品コードは触らない。
 
-**Tech Stack:** Ruby, Cucumber, Bundler, `qni-cli`
+**技術構成:** Ruby, Cucumber, Bundler, `qni-cli`
 
 ---
 
-## File Structure
+## ファイル構成
 
-- Modify: `features/katas/basic_gates.feature`
-  - `Task 1.2` の数値 2 シナリオ、controlled 検証 1 シナリオ、symbolic 説明 1 シナリオ、問題文ヘッダを追加する。
-- Verify: `features/qni_run.feature`
+- 変更: `features/katas/basic_gates.feature`
+  - `Task 1.2` の数値 2 シナリオ、制御付き検証 1 シナリオ、記号表示の説明 1 シナリオ、問題文ヘッダーを追加する。
+- 確認: `features/qni_run.feature`
   - `H` と `qni run --symbolic` の既存振る舞いが回帰していないことを確認する。
-- Verify: `features/qni_expect.feature`
-  - controlled-`H` を含む `qni expect` の経路が問題なく動くことを確認する。
-- Verify: `features/katas/basic_gates.feature`
-  - `Task 1.1` と `Task 1.2` が同じ feature 内で共存して green であることを確認する。
+- 確認: `features/qni_expect.feature`
+  - 制御付き `H` を含む `qni expect` の経路が問題なく動くことを確認する。
+- 確認: `features/katas/basic_gates.feature`
+  - `Task 1.1` と `Task 1.2` が同じフィーチャーファイル内で共存して成功することを確認する。
 
-## Task 1: Add the failing Task 1.2 scenarios first
+## タスク 1: 失敗する Task 1.2 シナリオを先に追加する
 
-**Files:**
-- Modify: `features/katas/basic_gates.feature`
-- Test: `features/katas/basic_gates.feature`
+**対象ファイル:**
+- 変更: `features/katas/basic_gates.feature`
+- テスト: `features/katas/basic_gates.feature`
 
-- [ ] **Step 1: Write the new Task 1.2 section and scenarios**
+- [ ] **手順 1: 新しい Task 1.2 セクションとシナリオを書く**
 
 `features/katas/basic_gates.feature` に `Task 1.2 BasisChange` の説明行と次の 4 シナリオを追加する。
 
@@ -50,7 +50,7 @@
       0.7071067811865475,-0.7071067811865475
       """
 
-  シナリオ: Task 1.2 の controlled 検証回路は control qubit を |0> に戻す
+  シナリオ: Task 1.2 の制御付き検証回路は制御量子ビットを |0> に戻す
     前提 空の 2 qubit 回路がある
     かつ "qni add H --qubit 0 --step 0" を実行
     かつ "qni add Ry --angle 1.8545904360032246 --qubit 1 --step 1" を実行
@@ -63,7 +63,7 @@
       ZI=1.0
       """
 
-  シナリオ: Task 1.2 は symbolic 表示で一般状態への基底変換を示す
+  シナリオ: Task 1.2 は記号表示で一般状態への基底変換を示す
     前提 "qni add Ry --angle theta --qubit 0 --step 0" を実行
     かつ "qni add H --qubit 0 --step 1" を実行
     もし "qni run --symbolic" を実行
@@ -73,113 +73,113 @@
       """
 ```
 
-`Task 1.2` の問題文要約も `Task 1.1` と同じ形式で feature 上に追加する。
+`Task 1.2` の問題文要約も `Task 1.1` と同じ形式でフィーチャーファイル上に追加する。
 
-- [ ] **Step 2: Run the focused kata feature and verify red**
+- [ ] **手順 2: 対象の kata フィーチャーファイルを実行し、失敗を確認する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber features/katas/basic_gates.feature
 ```
 
-Expected:
+期待結果:
 
 - 新規 `Task 1.2` シナリオのうち少なくとも 1 本が失敗する
-- failure は期待文字列か、controlled-`H` の CLI 表現差にある
-- `Task 1.1` シナリオ群は引き続き green
+- 失敗理由は期待文字列か、制御付き `H` の CLI 表現差にある
+- `Task 1.1` シナリオ群は引き続き成功する
 
-- [ ] **Step 3: Commit the failing feature**
+- [ ] **手順 3: 失敗するフィーチャーファイルをコミットする**
 
 ```bash
 git add features/katas/basic_gates.feature
 git commit -m "test: add Task 1.2 kata scenarios"
 ```
 
-## Task 2: Adjust only the feature expectations to match actual CLI output
+## タスク 2: 実際の CLI 出力に合わせてフィーチャーファイルの期待値だけを調整する
 
-**Files:**
-- Modify: `features/katas/basic_gates.feature`
-- Test: `features/katas/basic_gates.feature`
+**対象ファイル:**
+- 変更: `features/katas/basic_gates.feature`
+- テスト: `features/katas/basic_gates.feature`
 
-- [ ] **Step 1: Re-run one failing Task 1.2 scenario**
+- [ ] **手順 1: 失敗している Task 1.2 シナリオを 1 つ再実行する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber features/katas/basic_gates.feature:60
 ```
 
-Expected:
+期待結果:
 
-- actual の `qni run` / `qni run --symbolic` / `qni expect` 出力が 1 シナリオ単位で確認できる
+- 実際の `qni run` / `qni run --symbolic` / `qni expect` 出力を 1 シナリオ単位で確認できる
 
-- [ ] **Step 2: Make the smallest possible correction in the feature**
+- [ ] **手順 2: フィーチャーファイルに最小限の修正を入れる**
 
 変更は次に限定する。
 
-- 数値の丸め差があれば expected stdout を現実の CLI 出力に合わせる
-- symbolic の項順や係数表記が既存 `qni_run.feature` と整合しているなら、その表記に feature を合わせる
-- controlled-`H` が既存 CLI で書けない場合はここで止め、新しい spec / plan に戻る
+- 数値の丸め差があれば期待標準出力を実際の CLI 出力に合わせる
+- 記号表示の項順や係数表記が既存 `qni_run.feature` と整合しているなら、その表記にフィーチャーファイルを合わせる
+- 制御付き `H` が既存 CLI で書けない場合はここで止め、新しい仕様書 / 計画書に戻る
 
-このタスクでは product code を変更しない。
+このタスクでは製品コードを変更しない。
 
-- [ ] **Step 3: Re-run the kata feature and verify it turns green**
+- [ ] **手順 3: kata フィーチャーファイルを再実行し、成功に変わることを確認する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber features/katas/basic_gates.feature
 ```
 
-Expected:
+期待結果:
 
-- `Task 1.1` と `Task 1.2` を含む kata feature が green
+- `Task 1.1` と `Task 1.2` を含む kata フィーチャーファイルが成功する
 
-- [ ] **Step 4: Commit the corrected feature**
+- [ ] **手順 4: 修正したフィーチャーファイルをコミットする**
 
 ```bash
 git add features/katas/basic_gates.feature
 git commit -m "test: document Task 1.2 basis change"
 ```
 
-## Task 3: Verify nearby regressions
+## タスク 3: 近接する回帰を確認する
 
-**Files:**
-- Verify: `features/katas/basic_gates.feature`
-- Verify: `features/qni_run.feature`
-- Verify: `features/qni_expect.feature`
+**対象ファイル:**
+- 確認: `features/katas/basic_gates.feature`
+- 確認: `features/qni_run.feature`
+- 確認: `features/qni_expect.feature`
 
-- [ ] **Step 1: Run the targeted regression set**
+- [ ] **手順 1: 対象の回帰確認を実行する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber features/qni_run.feature features/qni_expect.feature features/katas/basic_gates.feature
 ```
 
-Expected:
+期待結果:
 
-- PASS
-- `Task 1.2` の数値・controlled・symbolic の 3 系統が green
+- 成功
+- `Task 1.2` の数値・制御付き・記号表示の 3 系統が成功する
 - `Task 1.1` の既存ケースが回帰していない
 
-- [ ] **Step 2: Inspect the final diff**
+- [ ] **手順 2: 最終差分を確認する**
 
-Check:
+確認:
 
 - 変更が `features/katas/basic_gates.feature` だけに収まっている
-- product code に変更がない
+- 製品コードに変更がない
 
-- [ ] **Step 3: Commit the verification checkpoint**
+- [ ] **手順 3: 検証の区切りをコミットする**
 
 ```bash
 git add features/katas/basic_gates.feature
 git commit -m "test: verify Task 1.2 kata coverage"
 ```
 
-## Notes
+## メモ
 
-- 今回は `Task 1.2` を `Task 1.1` と同じ深さに揃えることが目的であり、product code 追加は前提にしない。
-- symbolic シナリオの式は、説明の分かりやすさよりも既存 `qni run --symbolic` の実出力との一致を優先する。
-- controlled-`H` が `qni add H --control 0 --qubit 1` でそのまま書けることが前提であり、ここで不足が見つかった場合は新しい spec / plan に切り出す。
+- 今回は `Task 1.2` を `Task 1.1` と同じ深さに揃えることが目的であり、製品コード追加は前提にしない。
+- 記号表示シナリオの式は、説明の分かりやすさよりも既存 `qni run --symbolic` の実出力との一致を優先する。
+- 制御付き `H` が `qni add H --control 0 --qubit 1` でそのまま書けることが前提であり、ここで不足が見つかった場合は新しい仕様書 / 計画書に切り出す。


### PR DESCRIPTION
## 概要

- `docs/superpowers/plans/2026-03-19-basic-gates-task-1-2.md` の見出しと説明文を日本語の計画書として自然な文体へ修正しました。
- `qni run --symbolic`、ファイルパス、コマンド、Gherkin キーワードなど、原文維持すべき識別子は維持しました。

## 対応課題

- Linear: YAS-266

## 検証

- `git diff --check`
- `bundle exec rake check`
