### PR TITLE
記号実行計画の文体を整える

### DIFF
--- a/docs/superpowers/plans/2026-03-19-qni-run-symbolic.md
+++ b/docs/superpowers/plans/2026-03-19-qni-run-symbolic.md
@@ -1,37 +1,37 @@
-# qni run --symbolic Implementation Plan
+# qni run --symbolic 実装計画
 
-> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **エージェント作業者向け:** 必須: この計画を実装するときは、利用可能なら superpowers:subagent-driven-development、そうでなければ superpowers:executing-plans を使う。手順は進捗管理のためチェックボックス (`- [ ]`) 構文を使う。
 
-**Goal:** `qni run --symbolic` を追加し、1 qubit 回路について `α|0> + β|1>` 形式の状態表示と未束縛角度変数の記号表示を提供する。
+**目標:** `qni run --symbolic` を追加し、1 qubit 回路について `α|0> + β|1>` 形式の状態表示と未束縛角度変数の記号表示を提供する。
 
-**Architecture:** 既存の数値 `qni run` はそのまま維持し、`--symbolic` 指定時だけ Ruby から Python/SymPy helper を subprocess で呼び出す。Ruby 側は CLI オプション、入力 JSON の受け渡し、スコープ外エラーの整形を担当し、Python 側は 1 qubit の symbolic state evolution と `α|0> + β|1>` 形式の文字列表現生成を担当する。
+**構成:** 既存の数値 `qni run` はそのまま維持し、`--symbolic` 指定時だけ Ruby から Python/SymPy ヘルパーをサブプロセスで呼び出す。Ruby 側は CLI オプション、入力 JSON の受け渡し、対象外エラーの整形を担当し、Python 側は 1 qubit の記号的な状態遷移と `α|0> + β|1>` 形式の文字列表現生成を担当する。
 
-**Tech Stack:** Ruby, Thor, Cucumber, Python 3, SymPy, Open3, Bundler
+**技術構成:** Ruby, Thor, Cucumber, Python 3, SymPy, Open3, Bundler
 
 ---
 
-## File Structure
+## ファイル構成
 
-- Modify: `features/qni_run.feature`
+- 変更: `features/qni_run.feature`
   - `qni run --symbolic` の振る舞いを先に固定する。
-- Modify: `lib/qni/cli.rb`
-  - `run` に `--symbolic` オプションを追加し、symbolic rendering 経路へ分岐する。
-- Modify: `lib/qni/simulator.rb`
-  - 数値 rendering と symbolic rendering を分離し、`render_symbolic_state_vector` を追加する。
-- Create: `lib/qni/symbolic_state_renderer.rb`
-  - Python helper 呼び出し、JSON 入出力、1 qubit 制約、helper エラー整形を担当する。
-- Create: `libexec/qni_symbolic_run.py`
+- 変更: `lib/qni/cli.rb`
+  - `run` に `--symbolic` オプションを追加し、記号表示の経路へ分岐する。
+- 変更: `lib/qni/simulator.rb`
+  - 数値表示と記号表示を分離し、`render_symbolic_state_vector` を追加する。
+- 作成: `lib/qni/symbolic_state_renderer.rb`
+  - Python ヘルパー呼び出し、JSON 入出力、1 qubit 制約、ヘルパーエラー整形を担当する。
+- 作成: `libexec/qni_symbolic_run.py`
   - SymPy で 1 qubit 状態ベクトルを記号的に計算し、`α|0> + β|1>` 形式へ整形する。
-- Verify: `features/qni_cli.feature`
-  - `run` オプション追加が他コマンドの help 表示に影響していないことを確認する。
+- 確認: `features/qni_cli.feature`
+  - `run` オプション追加が他コマンドのヘルプ表示に影響していないことを確認する。
 
-## Task 1: Add failing symbolic run scenarios first
+## タスク 1: 先に失敗する `--symbolic` 実行シナリオを追加する
 
-**Files:**
-- Modify: `features/qni_run.feature`
-- Test: `features/qni_run.feature`
+**対象ファイル:**
+- 変更: `features/qni_run.feature`
+- テスト: `features/qni_run.feature`
 
-- [ ] **Step 1: Write the failing symbolic scenarios**
+- [ ] **手順 1: 失敗する `--symbolic` シナリオを書く**
 
 `features/qni_run.feature` に次の 4 シナリオを追加する。
 
@@ -70,50 +70,50 @@
       """
 ```
 
-- [ ] **Step 2: Run the focused feature and verify it fails for the right reason**
+- [ ] **手順 2: 対象を絞った機能仕様を実行し、想定どおりの理由で失敗することを確認する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber features/qni_run.feature
 ```
 
-Expected:
+期待結果:
 
 - 新規 4 シナリオが失敗する
 - 失敗理由は `--symbolic` が未対応であることを示す
-- 既存の `qni run` シナリオは引き続き green
+- 既存の `qni run` シナリオは引き続き成功する
 
-- [ ] **Step 3: Commit the failing feature**
+- [ ] **手順 3: 失敗する機能仕様を commit する**
 
 ```bash
 git add features/qni_run.feature
 git commit -m "test: add symbolic run scenarios"
 ```
 
-## Task 2: Add Ruby CLI plumbing and subprocess boundary
+## タスク 2: Ruby CLI の接続処理とサブプロセス境界を追加する
 
-**Files:**
-- Modify: `lib/qni/cli.rb`
-- Modify: `lib/qni/simulator.rb`
-- Create: `lib/qni/symbolic_state_renderer.rb`
-- Test: `features/qni_run.feature`
+**対象ファイル:**
+- 変更: `lib/qni/cli.rb`
+- 変更: `lib/qni/simulator.rb`
+- 作成: `lib/qni/symbolic_state_renderer.rb`
+- テスト: `features/qni_run.feature`
 
-- [ ] **Step 1: Re-run one focused failing scenario**
+- [ ] **手順 1: 対象を絞った失敗シナリオを 1 つ再実行する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber features/qni_run.feature:330
 ```
 
-Expected:
+期待結果:
 
 - `qni run --symbolic` が未対応で落ちることを再確認する
 
-- [ ] **Step 2: Add the minimal CLI option and routing**
+- [ ] **手順 2: 最小限の CLI オプションと分岐を追加する**
 
-`lib/qni/cli.rb` で `run` に boolean の `--symbolic` オプションを追加し、`Simulator.new(circuit)` を次のように分岐させる。
+`lib/qni/cli.rb` で `run` に boolean 型の `--symbolic` オプションを追加し、`Simulator.new(circuit)` を次のように分岐させる。
 
 ```ruby
 method_option :symbolic, type: :boolean, default: false, desc: 'Show a 1-qubit symbolic state expression'
@@ -125,7 +125,7 @@ def simulate
 end
 ```
 
-- [ ] **Step 3: Create a dedicated Ruby renderer wrapper**
+- [ ] **手順 3: 専用の Ruby 表示ラッパーを作成する**
 
 `lib/qni/symbolic_state_renderer.rb` に、責務を次だけに絞ったクラスを作る。
 
@@ -152,9 +152,9 @@ module Qni
 end
 ```
 
-ここでは helper 不在、`python3` 不在、`sympy` import failure も `Simulator::Error` に変換する。
+ここではヘルパー不在、`python3` 不在、`sympy` の import 失敗も `Simulator::Error` に変換する。
 
-- [ ] **Step 4: Hook the wrapper into `Simulator`**
+- [ ] **手順 4: ラッパーを `Simulator` につなぐ**
 
 `lib/qni/simulator.rb` に次を追加する。
 
@@ -164,57 +164,57 @@ def render_symbolic_state_vector
 end
 ```
 
-- [ ] **Step 5: Run the focused feature again**
+- [ ] **手順 5: 対象を絞った機能仕様を再実行する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber features/qni_run.feature
 ```
 
-Expected:
+期待結果:
 
-- 2 qubit の scope エラーは通る
-- 1 qubit の symbolic シナリオは helper 未実装のためまだ失敗する
+- 2 qubit の対象外エラーは通る
+- 1 qubit の `--symbolic` シナリオはヘルパー未実装のためまだ失敗する
 
-- [ ] **Step 6: Commit the Ruby-side boundary**
+- [ ] **手順 6: Ruby 側の境界を commit する**
 
 ```bash
 git add lib/qni/cli.rb lib/qni/simulator.rb lib/qni/symbolic_state_renderer.rb features/qni_run.feature
 git commit -m "feat: add symbolic run plumbing"
 ```
 
-## Task 3: Implement the SymPy helper minimally
+## タスク 3: SymPy ヘルパーを最小限実装する
 
-**Files:**
-- Create: `libexec/qni_symbolic_run.py`
-- Test: `features/qni_run.feature`
+**対象ファイル:**
+- 作成: `libexec/qni_symbolic_run.py`
+- テスト: `features/qni_run.feature`
 
-- [ ] **Step 1: Re-run one failing symbolic scenario**
+- [ ] **手順 1: 失敗する `--symbolic` シナリオを 1 つ再実行する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber features/qni_run.feature:330
 ```
 
-Expected:
+期待結果:
 
-- helper 未実装か import failure で失敗する
+- ヘルパー未実装か import 失敗で失敗する
 
-- [ ] **Step 2: Implement the minimal 1-qubit symbolic simulator**
+- [ ] **手順 2: 最小限の 1 qubit 記号シミュレーターを実装する**
 
 `libexec/qni_symbolic_run.py` に次の責務を実装する。
 
-- stdin から circuit JSON を読む
+- 標準入力から circuit JSON を読む
 - `qubits != 1` なら標準エラーへ `symbolic run currently supports only 1-qubit circuits` を出して `exit(1)`
 - 初期状態を `Matrix([1, 0])` にする
 - 各 col の唯一の要素を順に適用する
 - 離散ゲートは 2x2 SymPy `Matrix` で持つ
-- 角度付きゲートは gate 文字列から角度を取り出し、variables にあれば値へ置換し、なければ `Symbol` として扱う
-- 最終振幅を `simplify` し、0 でない項だけを `coeff|basis>` へ整形して stdout に出す
+- 角度付きゲートはゲート文字列から角度を取り出し、variables にあれば値へ置換し、なければ `Symbol` として扱う
+- 最終振幅を `simplify` し、0 でない項だけを `coeff|basis>` へ整形して標準出力に出す
 
-最低限必要な gate table は次のとおり。
+最低限必要なゲート表は次のとおり。
 
 ```python
 H = Matrix([[sqrt(2)/2, sqrt(2)/2], [sqrt(2)/2, -sqrt(2)/2]])
@@ -232,78 +232,78 @@ Ry(phi) = Matrix([[cos(phi/2), -sin(phi/2)], [sin(phi/2), cos(phi/2)]])
 Rz(phi) = Matrix([[exp(-I*phi/2), 0], [0, exp(I*phi/2)]])
 ```
 
-- [ ] **Step 3: Run the focused feature and verify it turns green**
+- [ ] **手順 3: 対象を絞った機能仕様を実行し、成功することを確認する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber features/qni_run.feature
 ```
 
-Expected:
+期待結果:
 
-- 新規 4 シナリオが green
-- 既存の `qni run` 数値シナリオも green
+- 新規 4 シナリオが成功する
+- 既存の `qni run` 数値シナリオも成功する
 
-- [ ] **Step 4: Commit the helper**
+- [ ] **手順 4: ヘルパーを commit する**
 
 ```bash
 git add libexec/qni_symbolic_run.py features/qni_run.feature lib/qni/cli.rb lib/qni/simulator.rb lib/qni/symbolic_state_renderer.rb
 git commit -m "feat: add symbolic state rendering"
 ```
 
-## Task 4: Verify regressions and nearby CLI behavior
+## タスク 4: 回帰と近接する CLI の振る舞いを確認する
 
-**Files:**
-- Verify: `features/qni_run.feature`
-- Verify: `features/qni_cli.feature`
-- Verify: `features/katas/basic_gates.feature`
+**対象ファイル:**
+- 確認: `features/qni_run.feature`
+- 確認: `features/qni_cli.feature`
+- 確認: `features/katas/basic_gates.feature`
 
-- [ ] **Step 1: Run the targeted regression set**
+- [ ] **手順 1: 対象を絞った回帰確認を実行する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber features/qni_run.feature features/qni_cli.feature features/katas/basic_gates.feature
 ```
 
-Expected:
+期待結果:
 
-- PASS
-- `Task 1.1` の既存 kata feature が回帰していない
+- 成功
+- `タスク 1.1` の既存 kata 機能仕様が回帰していない
 - `qni run` の既定 CSV 出力が回帰していない
 
-- [ ] **Step 2: Run the full suite**
+- [ ] **手順 2: 全体テストを実行する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber
 ```
 
-Expected:
+期待結果:
 
-- PASS
-- feature 全体が green
+- 成功
+- 機能仕様全体が成功する
 
-- [ ] **Step 3: Inspect final diff**
+- [ ] **手順 3: 最終差分を確認する**
 
-Check:
+確認:
 
-- 新しい product file が `lib/qni/symbolic_state_renderer.rb` と `libexec/qni_symbolic_run.py` に限定されている
-- 既存の数値 simulator の振る舞いを壊していない
+- 新しい実装ファイルが `lib/qni/symbolic_state_renderer.rb` と `libexec/qni_symbolic_run.py` に限定されている
+- 既存の数値シミュレーターの振る舞いを壊していない
 - `run --symbolic` の 1 qubit 限定が明確に表現されている
 
-- [ ] **Step 4: Commit the verification checkpoint**
+- [ ] **手順 4: 検証の区切りを commit する**
 
 ```bash
 git add features/qni_run.feature features/qni_cli.feature features/katas/basic_gates.feature lib/qni/cli.rb lib/qni/simulator.rb lib/qni/symbolic_state_renderer.rb libexec/qni_symbolic_run.py
 git commit -m "test: verify symbolic run behavior"
 ```
 
-## Notes
+## メモ
 
-- 今回のスコープは 1 qubit の `qni run --symbolic` に限定する。2 qubit 以上の symbolic display は次段に切る。
+- 今回の対象範囲は 1 qubit の `qni run --symbolic` に限定する。2 qubit 以上の記号表示は次段に切る。
 - 数値 `qni run` は未束縛変数で従来どおり失敗させる。`qni run --symbolic` だけが未束縛変数を許容する。
-- `qni run --symbolic` は new command ではなく既存 `run` の opt-in 表示モードとして実装する。
-- Python helper の依存解決で詰まった場合は、helper 呼び出し経路だけを一旦失敗メッセージ付きで通し、新しい spec / plan で依存導入を切り出す。
+- `qni run --symbolic` は新しいコマンドではなく既存 `run` の任意指定の表示モードとして実装する。
+- Python ヘルパーの依存解決で詰まった場合は、ヘルパー呼び出し経路だけを一旦失敗メッセージ付きで通し、新しい仕様書 / 計画書で依存導入を切り出す。

--- a/docs/superpowers/plans/2026-03-19-qni-run-symbolic.md
+++ b/docs/superpowers/plans/2026-03-19-qni-run-symbolic.md
@@ -84,7 +84,7 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/sha
 - 失敗理由は `--symbolic` が未対応であることを示す
 - 既存の `qni run` シナリオは引き続き成功する
 
-- [ ] **手順 3: 失敗する機能仕様を commit する**
+- [ ] **手順 3: 失敗する機能仕様をコミットする**
 
 ```bash
 git add features/qni_run.feature
@@ -152,7 +152,7 @@ module Qni
 end
 ```
 
-ここではヘルパー不在、`python3` 不在、`sympy` の import 失敗も `Simulator::Error` に変換する。
+ここではヘルパー不在、`python3` 不在、`sympy` のインポート失敗も `Simulator::Error` に変換する。
 
 - [ ] **手順 4: ラッパーを `Simulator` につなぐ**
 
@@ -177,7 +177,7 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/sha
 - 2 qubit の対象外エラーは通る
 - 1 qubit の `--symbolic` シナリオはヘルパー未実装のためまだ失敗する
 
-- [ ] **手順 6: Ruby 側の境界を commit する**
+- [ ] **手順 6: Ruby 側の境界をコミットする**
 
 ```bash
 git add lib/qni/cli.rb lib/qni/simulator.rb lib/qni/symbolic_state_renderer.rb features/qni_run.feature
@@ -200,7 +200,7 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/sha
 
 期待結果:
 
-- ヘルパー未実装か import 失敗で失敗する
+- ヘルパー未実装かインポート失敗で失敗する
 
 - [ ] **手順 2: 最小限の 1 qubit 記号シミュレーターを実装する**
 
@@ -245,7 +245,7 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/sha
 - 新規 4 シナリオが成功する
 - 既存の `qni run` 数値シナリオも成功する
 
-- [ ] **手順 4: ヘルパーを commit する**
+- [ ] **手順 4: ヘルパーをコミットする**
 
 ```bash
 git add libexec/qni_symbolic_run.py features/qni_run.feature lib/qni/cli.rb lib/qni/simulator.rb lib/qni/symbolic_state_renderer.rb
@@ -294,7 +294,7 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/sha
 - 既存の数値シミュレーターの振る舞いを壊していない
 - `run --symbolic` の 1 qubit 限定が明確に表現されている
 
-- [ ] **手順 4: 検証の区切りを commit する**
+- [ ] **手順 4: 検証の区切りをコミットする**
 
 ```bash
 git add features/qni_run.feature features/qni_cli.feature features/katas/basic_gates.feature lib/qni/cli.rb lib/qni/simulator.rb lib/qni/symbolic_state_renderer.rb libexec/qni_symbolic_run.py

--- a/test/typescript/symbolic_state_renderer.test.ts
+++ b/test/typescript/symbolic_state_renderer.test.ts
@@ -161,11 +161,12 @@ describe('TypeScript symbolic state renderer boundary', () => {
       await writeExecutable(
         path.join(bin, 'python3'),
         `#!/bin/sh
+while IFS= read -r _; do :; done
 echo "ModuleNotFoundError: No module named 'sympy'" >&2
 exit 1
 `
       );
-      await writeExecutable(path.join(bin, 'uv'), '#!/bin/sh\necho uv-success\n');
+      await writeExecutable(path.join(bin, 'uv'), '#!/bin/sh\nwhile IFS= read -r _; do :; done\necho uv-success\n');
 
       assert.equal(
         renderSymbolicStateVector({
@@ -187,7 +188,7 @@ exit 1
       await writeSymbolicHelperPlaceholder(projectRoot);
       await writeExecutable(
         path.join(projectRoot, '.python-symbolic', 'bin', 'python'),
-        '#!/bin/sh\necho "repo runtime failed" >&2\nexit 9\n'
+        '#!/bin/sh\nwhile IFS= read -r _; do :; done\necho "repo runtime failed" >&2\nexit 9\n'
       );
       await writeExecutable(path.join(bin, 'python3'), '#!/bin/sh\necho should-not-run\n');
 


### PR DESCRIPTION
## 概要

YAS-269

`docs/superpowers/plans/2026-03-19-qni-run-symbolic.md` の本文を見直し、不自然な英日混在になっていた普通名詞を自然な日本語へ置き換えました。

## 変更内容

- 見出し、手順名、期待結果のラベルを日本語化しました。
- `symbolic rendering`, `subprocess`, `new command`, `opt-in` など、本文中の普通名詞を自然な日本語表現へ直しました。
- コマンド例、ファイルパス、CLI 引数、エラーメッセージ、コード識別子、コミットメッセージ例は原文を維持しました。
- GitHub Actions で既存の TypeScript テスト fixture が `spawnSync ... EPIPE` になったため、偽ヘルパースクリプトが標準入力を読み捨ててから期待する終了状態を返すようにしました。

## 検証

- `npx tsc -p tsconfig.test.json && node --test tmp/typescript-tests/test/typescript/symbolic_state_renderer.test.js`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- `bundle exec rake check`
