### PR TITLE
BasicGates Task 1.5 計画書の文体とパスを整える

### DIFF
--- a/docs/superpowers/plans/2026-03-20-basic-gates-task-1-5.md
+++ b/docs/superpowers/plans/2026-03-20-basic-gates-task-1-5.md
@@ -4,7 +4,7 @@
 
 **目的:** `BasicGates Task 1.5 PhaseFlip` を `features/katas/basic_gates/phase_flip.feature` に追加し、Quantum Katas の `DumpDiffOnOneQubit` と制御付き等価性検証の意図を `qni-cli` 側で再現する。
 
-**方針:** 先に `phase_flip.feature` を追加して、既存の `S`、`S†`、制御付き指定、`qni run`、`qni run --symbolic`、`qni expect` だけでタスクを表現できるかを確認する。`Task 1.5` は自己随伴ではないため、制御付き検証では候補の制御付き `S` と逆操作の制御付き `S†` を組にして、制御量子ビットが `|0⟩` に戻ることを見る。不足が出た場合のみ、機能仕様を先に定義する方針で新しい仕様書 / 計画書に戻る。
+**方針:** 先に `phase_flip.feature` を追加して、既存の `S`、`Sdg`（S†）、制御付き指定、`qni run`、`qni run --symbolic`、`qni expect` だけでタスクを表現できるかを確認する。`Task 1.5` は自己随伴ではないため、制御付き検証では候補の制御付き `S` と逆操作の制御付き `Sdg`（S†）を組にして、制御量子ビットが `|0⟩` に戻ることを見る。不足が出た場合のみ、機能仕様を先に定義する方針で新しい仕様書 / 計画書に戻る。
 
 **技術構成:** Ruby, Cucumber, Bundler, `qni-cli`
 
@@ -17,7 +17,7 @@
 - 確認: `features/add_s_gate.feature`
   - `qni add S` の既存挙動が回帰していないことを確認する。
 - 確認: `features/add_s_dagger_gate.feature`
-  - 制御付き検証で使う `S†` の既存挙動が回帰していないことを確認する。
+  - 制御付き検証で使う `Sdg`（S†）の既存挙動が回帰していないことを確認する。
 - 確認: `features/qni_run.feature`
   - 数値実行と記号表示の実行が回帰していないことを確認する。
 - 確認: `features/qni_expect.feature`

--- a/docs/superpowers/plans/2026-03-20-basic-gates-task-1-5.md
+++ b/docs/superpowers/plans/2026-03-20-basic-gates-task-1-5.md
@@ -91,7 +91,7 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/sha
 
 期待結果:
 
-- 既存機能で足りるならそのまま PASS
+- 既存機能で足りるならそのまま成功する
 - 失敗した場合は、何が不足かを `S` / `Sdg` / 制御付き指定 / 記号表示のどこかに切り分けられる
 
 - [ ] **手順 3: 失敗でも成功でも、機能仕様を先に追加する変更をコミットする**
@@ -157,7 +157,7 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/sha
 
 期待結果:
 
-- `Task 1.5` の 3 シナリオが PASS
+- `Task 1.5` の 3 シナリオが成功する
 
 - [ ] **手順 5: 必要な修正をコミットする**
 
@@ -200,7 +200,7 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/sha
 
 期待結果:
 
-- すべて PASS
+- すべて成功する
 
 - [ ] **手順 2: 近接回帰の成功をコミットする**
 
@@ -223,7 +223,7 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/sha
 
 期待結果:
 
-- 全シナリオが PASS
+- 全シナリオが成功する
 
 - [ ] **手順 2: Ruby 品質チェックを実行する**
 
@@ -238,7 +238,7 @@ rake flay
 
 期待結果:
 
-- すべて PASS
+- すべて成功する
 
 - [ ] **手順 3: 統合前の状態を確認する**
 

--- a/docs/superpowers/plans/2026-03-20-basic-gates-task-1-5.md
+++ b/docs/superpowers/plans/2026-03-20-basic-gates-task-1-5.md
@@ -1,43 +1,43 @@
-# BasicGates Task 1.5 Implementation Plan
+# BasicGates Task 1.5 実装計画
 
-> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **自律実装エージェント向け:** 必須: この計画を実装するときは、利用可能なら superpowers:subagent-driven-development、なければ superpowers:executing-plans を使う。進捗管理にはチェックボックス (`- [ ]`) 記法を使う。
 
-**Goal:** `BasicGates Task 1.5 PhaseFlip` を `features/katas/basic_gates/phase_flip.feature` に追加し、Quantum Katas の `DumpDiffOnOneQubit` と controlled 等価性検証の意図を `qni-cli` 側で再現する。
+**目的:** `BasicGates Task 1.5 PhaseFlip` を `features/katas/basic_gates/phase_flip.feature` に追加し、Quantum Katas の `DumpDiffOnOneQubit` と制御付き等価性検証の意図を `qni-cli` 側で再現する。
 
-**Architecture:** 先に `phase_flip.feature` を追加して、既存の `S`、`S†`、controlled 指定、`qni run`、`qni run --symbolic`、`qni expect` だけで task を表現できるかを確認する。`Task 1.5` は self-adjoint ではないため、controlled 検証では candidate の controlled-`S` と inverse の controlled-`S†` を組にして control qubit が `|0⟩` に戻ることを見る。不足が出た場合のみ、feature-first で新しい spec / plan に戻る。
+**方針:** 先に `phase_flip.feature` を追加して、既存の `S`、`S†`、制御付き指定、`qni run`、`qni run --symbolic`、`qni expect` だけでタスクを表現できるかを確認する。`Task 1.5` は自己随伴ではないため、制御付き検証では候補の制御付き `S` と逆操作の制御付き `S†` を組にして、制御量子ビットが `|0⟩` に戻ることを見る。不足が出た場合のみ、機能仕様を先に定義する方針で新しい仕様書 / 計画書に戻る。
 
-**Tech Stack:** Ruby, Cucumber, Bundler, `qni-cli`
+**技術構成:** Ruby, Cucumber, Bundler, `qni-cli`
 
 ---
 
-## File Structure
+## ファイル構成
 
-- Create: `features/katas/basic_gates/phase_flip.feature`
-  - `Task 1.5` の問題文、`DumpDiffOnOneQubit` 相当の数値シナリオ、controlled 等価性検証、symbolic 補助シナリオを追加する。
-- Verify: `features/add_s_gate.feature`
+- 作成: `features/katas/basic_gates/phase_flip.feature`
+  - `Task 1.5` の問題文、`DumpDiffOnOneQubit` 相当の数値シナリオ、制御付き等価性検証、記号表示の補助シナリオを追加する。
+- 確認: `features/add_s_gate.feature`
   - `qni add S` の既存挙動が回帰していないことを確認する。
-- Verify: `features/add_s_dagger_gate.feature`
-  - controlled 検証で使う `S†` の既存挙動が回帰していないことを確認する。
-- Verify: `features/qni_run.feature`
-  - 数値 run と symbolic run が回帰していないことを確認する。
-- Verify: `features/qni_expect.feature`
-  - `qni expect` の出力が controlled 検証で回帰していないことを確認する。
-- Verify: `features/katas/basic_gates/state_flip.feature`
+- 確認: `features/add_s_dagger_gate.feature`
+  - 制御付き検証で使う `S†` の既存挙動が回帰していないことを確認する。
+- 確認: `features/qni_run.feature`
+  - 数値実行と記号表示の実行が回帰していないことを確認する。
+- 確認: `features/qni_expect.feature`
+  - `qni expect` の出力が制御付き検証で回帰していないことを確認する。
+- 確認: `features/katas/basic_gates/state_flip.feature`
   - `Task 1.1` が回帰していないことを確認する。
-- Verify: `features/katas/basic_gates/basis_change.feature`
+- 確認: `features/katas/basic_gates/basis_change.feature`
   - `Task 1.2` が回帰していないことを確認する。
-- Verify: `features/katas/basic_gates/sign_flip.feature`
+- 確認: `features/katas/basic_gates/sign_flip.feature`
   - `Task 1.3` が回帰していないことを確認する。
-- Verify: `features/katas/basic_gates/amplitude_change.feature`
+- 確認: `features/katas/basic_gates/amplitude_change.feature`
   - `Task 1.4` が回帰していないことを確認する。
 
-## Task 1: `Task 1.5` feature を先に追加して既存機能で足りるか確認する
+## タスク 1: `Task 1.5` の機能仕様を先に追加して既存機能で足りるか確認する
 
-**Files:**
-- Create: `features/katas/basic_gates/phase_flip.feature`
-- Test: `features/katas/basic_gates/phase_flip.feature`
+**対象ファイル:**
+- 作成: `features/katas/basic_gates/phase_flip.feature`
+- テスト: `features/katas/basic_gates/phase_flip.feature`
 
-- [ ] **Step 1: `Task 1.5` の問題文とシナリオを書く**
+- [ ] **手順 1: `Task 1.5` の問題文とシナリオを書く**
 
 `features/katas/basic_gates/phase_flip.feature` を新規作成し、少なくとも次を追加する。
 
@@ -58,7 +58,7 @@ Feature: Quantum Katas BasicGates Task 1.5 PhaseFlip
       0.6,0.8i
       """
 
-  Scenario: Task 1.5 の controlled 検証回路は control qubit を |0> に戻す
+  Scenario: Task 1.5 の制御付き検証回路は制御量子ビットを |0> に戻す
     Given 空の 2 qubit 回路がある
     And "qni add H --qubit 0 --step 0" を実行
     And "qni add Ry --angle 1.8545904360032246 --qubit 1 --step 1" を実行
@@ -71,7 +71,7 @@ Feature: Quantum Katas BasicGates Task 1.5 PhaseFlip
       ZI=1.0
       """
 
-  Scenario: Task 1.5 は symbolic 表示で位相 i を示す
+  Scenario: Task 1.5 は記号表示で位相 i を示す
     Given 1 qubit の初期状態が "0.6|0> + 0.8|1>" である
     And "qni add S --qubit 0 --step 1" を実行
     When "qni run --symbolic" を実行
@@ -81,109 +81,109 @@ Feature: Quantum Katas BasicGates Task 1.5 PhaseFlip
       """
 ```
 
-- [ ] **Step 2: focused 実行で red / green を確認する**
+- [ ] **手順 2: 対象を絞った実行で失敗 / 成功を確認する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber features/katas/basic_gates/phase_flip.feature
 ```
 
-Expected:
+期待結果:
 
 - 既存機能で足りるならそのまま PASS
-- 失敗した場合は、何が不足かを `S` / `Sdg` / controlled / symbolic のどこかに切り分けられる
+- 失敗した場合は、何が不足かを `S` / `Sdg` / 制御付き指定 / 記号表示のどこかに切り分けられる
 
-- [ ] **Step 3: failing でも green でも、feature-first の追加をコミットする**
+- [ ] **手順 3: 失敗でも成功でも、機能仕様を先に追加する変更をコミットする**
 
 ```bash
 git add features/katas/basic_gates/phase_flip.feature
 git commit -m "test: add Task 1.5 kata scenarios"
 ```
 
-## Task 2: 必要なら最小修正で green にする
+## タスク 2: 必要なら最小修正で成功させる
 
-**Files:**
-- Modify: `features/katas/basic_gates/phase_flip.feature`
-- Optionally modify: `features/add_s_gate.feature`
-- Optionally modify: `features/add_s_dagger_gate.feature`
-- Optionally modify: `features/qni_run.feature`
-- Optionally modify: `features/qni_expect.feature`
-- Optionally modify: `lib/qni/...`
+**対象ファイル:**
+- 変更: `features/katas/basic_gates/phase_flip.feature`
+- 必要なら変更: `features/add_s_gate.feature`
+- 必要なら変更: `features/add_s_dagger_gate.feature`
+- 必要なら変更: `features/qni_run.feature`
+- 必要なら変更: `features/qni_expect.feature`
+- 必要なら変更: `lib/qni/...`
 
-- [ ] **Step 1: 失敗原因を 1 箇所に絞る**
+- [ ] **手順 1: 失敗原因を 1 箇所に絞る**
 
 想定する失敗原因は次に限る。
 
 - `qni add S --control ...` が受理されない
 - `qni add Sdg --control ...` が受理されない
-- `qni run --symbolic` の複素係数表記が expected と違う
-- `qni expect ZI` の丸め差で exact 比較が落ちる
+- `qni run --symbolic` の複素係数表記が期待値と違う
+- `qni expect ZI` の丸め差で完全一致比較が落ちる
 
 ここで複数の原因が見えた場合でも、最初に 1 つだけ直す。
 
-- [ ] **Step 2: product code 不足がある場合は、既存 feature に最小回帰を追加する**
+- [ ] **手順 2: 実装コードの不足がある場合は、既存の機能仕様に最小回帰を追加する**
 
-不足が product code にある場合だけ、対応する既存 feature に最小シナリオを追加する。
+不足が実装コードにある場合だけ、対応する既存の機能仕様に最小シナリオを追加する。
 
 例:
 
 - `features/add_s_gate.feature`
-  - controlled `S` が回路に保存できること
+  - 制御付き `S` が回路に保存できること
 - `features/add_s_dagger_gate.feature`
-  - controlled `Sdg` が回路に保存できること
+  - 制御付き `Sdg` が回路に保存できること
 - `features/qni_run.feature`
-  - `S` 適用後に複素係数を数値 / symbolic の両方で表示できること
+  - `S` 適用後に複素係数を数値 / 記号表示の両方で表示できること
 - `features/qni_expect.feature`
-  - controlled `S` と `Sdg` を含む回路で `ZI` が 1 に戻ること
+  - 制御付き `S` と `Sdg` を含む回路で `ZI` が 1 に戻ること
 
-- [ ] **Step 3: 必要な最小実装だけを入れる**
+- [ ] **手順 3: 必要な最小実装だけを入れる**
 
 実装変更は、実際に失敗した箇所のみに限定する。
 
-- gate 登録の不足なら、その gate と controlled 指定の受理
-- symbolic 表示の不足なら、複素係数の表記整形
-- expect の丸め差だけなら、既存の近似比較 step を使う方向を優先する
+- ゲート登録の不足なら、そのゲートと制御付き指定の受理
+- 記号表示の不足なら、複素係数の表記整形
+- `qni expect` の丸め差だけなら、既存の近似比較ステップを使う方向を優先する
 
 新しい CLI コマンドや汎用検証機能は追加しない。
 
-- [ ] **Step 4: `Task 1.5` feature を再実行して green を確認する**
+- [ ] **手順 4: `Task 1.5` の機能仕様を再実行して成功を確認する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber features/katas/basic_gates/phase_flip.feature
 ```
 
-Expected:
+期待結果:
 
 - `Task 1.5` の 3 シナリオが PASS
 
-- [ ] **Step 5: 必要な修正をコミットする**
+- [ ] **手順 5: 必要な修正をコミットする**
 
 ```bash
 git add features/katas/basic_gates/phase_flip.feature features/add_s_gate.feature features/add_s_dagger_gate.feature features/qni_run.feature features/qni_expect.feature lib/qni
 git commit -m "feat: support Task 1.5 phase flip verification"
 ```
 
-`lib/qni` に変更がない場合は、実際に触った file だけ `git add` する。
+`lib/qni` に変更がない場合は、実際に触ったファイルだけ `git add` する。
 
-## Task 3: 近接回帰を確認する
+## タスク 3: 近接回帰を確認する
 
-**Files:**
-- Test: `features/add_s_gate.feature`
-- Test: `features/add_s_dagger_gate.feature`
-- Test: `features/qni_run.feature`
-- Test: `features/qni_expect.feature`
-- Test: `features/katas/basic_gates/state_flip.feature`
-- Test: `features/katas/basic_gates/basis_change.feature`
-- Test: `features/katas/basic_gates/sign_flip.feature`
-- Test: `features/katas/basic_gates/amplitude_change.feature`
-- Test: `features/katas/basic_gates/phase_flip.feature`
+**対象ファイル:**
+- テスト: `features/add_s_gate.feature`
+- テスト: `features/add_s_dagger_gate.feature`
+- テスト: `features/qni_run.feature`
+- テスト: `features/qni_expect.feature`
+- テスト: `features/katas/basic_gates/state_flip.feature`
+- テスト: `features/katas/basic_gates/basis_change.feature`
+- テスト: `features/katas/basic_gates/sign_flip.feature`
+- テスト: `features/katas/basic_gates/amplitude_change.feature`
+- テスト: `features/katas/basic_gates/phase_flip.feature`
 
-- [ ] **Step 1: 近接 feature をまとめて実行する**
+- [ ] **手順 1: 近接する機能仕様をまとめて実行する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber \
@@ -198,36 +198,36 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/sha
   features/katas/basic_gates/phase_flip.feature
 ```
 
-Expected:
+期待結果:
 
 - すべて PASS
 
-- [ ] **Step 2: 近接回帰の green をコミットする**
+- [ ] **手順 2: 近接回帰の成功をコミットする**
 
 ```bash
 git commit --allow-empty -m "test: verify Task 1.5 regressions"
 ```
 
-## Task 4: 全量確認して統合準備をする
+## タスク 4: 全量確認して統合準備をする
 
-**Files:**
-- Test: repository-wide checks
+**対象ファイル:**
+- テスト: リポジトリ全体の確認
 
-- [ ] **Step 1: full cucumber を実行する**
+- [ ] **手順 1: Cucumber 全体を実行する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber
 ```
 
-Expected:
+期待結果:
 
-- 全 scenario が PASS
+- 全シナリオが PASS
 
-- [ ] **Step 2: Ruby 品質チェックを実行する**
+- [ ] **手順 2: Ruby 品質チェックを実行する**
 
-Run:
+実行:
 
 ```bash
 rake rubocop
@@ -236,20 +236,20 @@ rake flog
 rake flay
 ```
 
-Expected:
+期待結果:
 
 - すべて PASS
 
-- [ ] **Step 3: 統合前の状態を確認する**
+- [ ] **手順 3: 統合前の状態を確認する**
 
-Run:
+実行:
 
 ```bash
 git status --short
 git log --oneline --decorate -5
 ```
 
-Expected:
+期待結果:
 
 - 作業ツリーがクリーン
 - `Task 1.5` 関連コミットが確認できる

--- a/docs/superpowers/plans/2026-03-20-basic-gates-task-1-5.md
+++ b/docs/superpowers/plans/2026-03-20-basic-gates-task-1-5.md
@@ -2,9 +2,9 @@
 
 > **自律実装エージェント向け:** 必須: この計画を実装するときは、利用可能なら superpowers:subagent-driven-development、なければ superpowers:executing-plans を使う。進捗管理にはチェックボックス (`- [ ]`) 記法を使う。
 
-**目的:** `BasicGates Task 1.5 PhaseFlip` を `features/katas/basic_gates/phase_flip.feature` に追加し、Quantum Katas の `DumpDiffOnOneQubit` と制御付き等価性検証の意図を `qni-cli` 側で再現する。
+**目的:** `BasicGates Task 1.5 PhaseFlip` を `features/katas/basic_gates/phase_flip.feature.md` に追加し、Quantum Katas の `DumpDiffOnOneQubit` と制御付き等価性検証の意図を `qni-cli` 側で再現する。
 
-**方針:** 先に `phase_flip.feature` を追加して、既存の `S`、`Sdg`（S†）、制御付き指定、`qni run`、`qni run --symbolic`、`qni expect` だけでタスクを表現できるかを確認する。`Task 1.5` は自己随伴ではないため、制御付き検証では候補の制御付き `S` と逆操作の制御付き `Sdg`（S†）を組にして、制御量子ビットが `|0⟩` に戻ることを見る。不足が出た場合のみ、機能仕様を先に定義する方針で新しい仕様書 / 計画書に戻る。
+**方針:** 先に `phase_flip.feature.md` を追加して、既存の `S`、`Sdg`（S†）、制御付き指定、`qni run`、`qni run --symbolic`、`qni expect` だけでタスクを表現できるかを確認する。`Task 1.5` は自己随伴ではないため、制御付き検証では候補の制御付き `S` と逆操作の制御付き `Sdg`（S†）を組にして、制御量子ビットが `|0⟩` に戻ることを見る。不足が出た場合のみ、機能仕様を先に定義する方針で新しい仕様書 / 計画書に戻る。
 
 **技術構成:** Ruby, Cucumber, Bundler, `qni-cli`
 
@@ -12,34 +12,36 @@
 
 ## ファイル構成
 
-- 作成: `features/katas/basic_gates/phase_flip.feature`
+- 変更: `features/katas/basic_gates/phase_flip.feature.md`
   - `Task 1.5` の問題文、`DumpDiffOnOneQubit` 相当の数値シナリオ、制御付き等価性検証、記号表示の補助シナリオを追加する。
-- 確認: `features/add_s_gate.feature`
+- 確認: `features/cli/add/add_s_gate.feature.md`
   - `qni add S` の既存挙動が回帰していないことを確認する。
-- 確認: `features/add_s_dagger_gate.feature`
+- 確認: `features/cli/add/add_s_dagger_gate.feature.md`
   - 制御付き検証で使う `Sdg`（S†）の既存挙動が回帰していないことを確認する。
-- 確認: `features/qni_run.feature`
-  - 数値実行と記号表示の実行が回帰していないことを確認する。
-- 確認: `features/qni_expect.feature`
+- 確認: `features/cli/run/basic_state_vectors.feature.md`
+  - 数値実行が回帰していないことを確認する。
+- 確認: `features/cli/run/symbolic.feature.md`
+  - 記号表示の実行が回帰していないことを確認する。
+- 確認: `features/cli/expect/command.feature.md`
   - `qni expect` の出力が制御付き検証で回帰していないことを確認する。
-- 確認: `features/katas/basic_gates/state_flip.feature`
+- 確認: `features/katas/basic_gates/state_flip.feature.md`
   - `Task 1.1` が回帰していないことを確認する。
-- 確認: `features/katas/basic_gates/basis_change.feature`
+- 確認: `features/katas/basic_gates/basis_change.feature.md`
   - `Task 1.2` が回帰していないことを確認する。
-- 確認: `features/katas/basic_gates/sign_flip.feature`
+- 確認: `features/katas/basic_gates/sign_flip.feature.md`
   - `Task 1.3` が回帰していないことを確認する。
-- 確認: `features/katas/basic_gates/amplitude_change.feature`
+- 確認: `features/katas/basic_gates/amplitude_change.feature.md`
   - `Task 1.4` が回帰していないことを確認する。
 
 ## タスク 1: `Task 1.5` の機能仕様を先に追加して既存機能で足りるか確認する
 
 **対象ファイル:**
-- 作成: `features/katas/basic_gates/phase_flip.feature`
-- テスト: `features/katas/basic_gates/phase_flip.feature`
+- 変更: `features/katas/basic_gates/phase_flip.feature.md`
+- テスト: `features/katas/basic_gates/phase_flip.feature.md`
 
 - [ ] **手順 1: `Task 1.5` の問題文とシナリオを書く**
 
-`features/katas/basic_gates/phase_flip.feature` を新規作成し、少なくとも次を追加する。
+`features/katas/basic_gates/phase_flip.feature.md` に少なくとも次を追加する。
 
 ```gherkin
 Feature: Quantum Katas BasicGates Task 1.5 PhaseFlip
@@ -86,7 +88,7 @@ Feature: Quantum Katas BasicGates Task 1.5 PhaseFlip
 実行:
 
 ```bash
-BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber features/katas/basic_gates/phase_flip.feature
+BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber features/katas/basic_gates/phase_flip.feature.md
 ```
 
 期待結果:
@@ -97,18 +99,19 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/sha
 - [ ] **手順 3: 失敗でも成功でも、機能仕様を先に追加する変更をコミットする**
 
 ```bash
-git add features/katas/basic_gates/phase_flip.feature
+git add features/katas/basic_gates/phase_flip.feature.md
 git commit -m "test: add Task 1.5 kata scenarios"
 ```
 
 ## タスク 2: 必要なら最小修正で成功させる
 
 **対象ファイル:**
-- 変更: `features/katas/basic_gates/phase_flip.feature`
-- 必要なら変更: `features/add_s_gate.feature`
-- 必要なら変更: `features/add_s_dagger_gate.feature`
-- 必要なら変更: `features/qni_run.feature`
-- 必要なら変更: `features/qni_expect.feature`
+- 変更: `features/katas/basic_gates/phase_flip.feature.md`
+- 必要なら変更: `features/cli/add/add_s_gate.feature.md`
+- 必要なら変更: `features/cli/add/add_s_dagger_gate.feature.md`
+- 必要なら変更: `features/cli/run/basic_state_vectors.feature.md`
+- 必要なら変更: `features/cli/run/symbolic.feature.md`
+- 必要なら変更: `features/cli/expect/command.feature.md`
 - 必要なら変更: `lib/qni/...`
 
 - [ ] **手順 1: 失敗原因を 1 箇所に絞る**
@@ -128,13 +131,13 @@ git commit -m "test: add Task 1.5 kata scenarios"
 
 例:
 
-- `features/add_s_gate.feature`
+- `features/cli/add/add_s_gate.feature.md`
   - 制御付き `S` が回路に保存できること
-- `features/add_s_dagger_gate.feature`
+- `features/cli/add/add_s_dagger_gate.feature.md`
   - 制御付き `Sdg` が回路に保存できること
-- `features/qni_run.feature`
+- `features/cli/run/basic_state_vectors.feature.md` / `features/cli/run/symbolic.feature.md`
   - `S` 適用後に複素係数を数値 / 記号表示の両方で表示できること
-- `features/qni_expect.feature`
+- `features/cli/expect/command.feature.md`
   - 制御付き `S` と `Sdg` を含む回路で `ZI` が 1 に戻ること
 
 - [ ] **手順 3: 必要な最小実装だけを入れる**
@@ -152,7 +155,7 @@ git commit -m "test: add Task 1.5 kata scenarios"
 実行:
 
 ```bash
-BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber features/katas/basic_gates/phase_flip.feature
+BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber features/katas/basic_gates/phase_flip.feature.md
 ```
 
 期待結果:
@@ -162,7 +165,7 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/sha
 - [ ] **手順 5: 必要な修正をコミットする**
 
 ```bash
-git add features/katas/basic_gates/phase_flip.feature features/add_s_gate.feature features/add_s_dagger_gate.feature features/qni_run.feature features/qni_expect.feature lib/qni
+git add features/katas/basic_gates/phase_flip.feature.md features/cli/add/add_s_gate.feature.md features/cli/add/add_s_dagger_gate.feature.md features/cli/run/basic_state_vectors.feature.md features/cli/run/symbolic.feature.md features/cli/expect/command.feature.md lib/qni
 git commit -m "feat: support Task 1.5 phase flip verification"
 ```
 
@@ -171,15 +174,16 @@ git commit -m "feat: support Task 1.5 phase flip verification"
 ## タスク 3: 近接回帰を確認する
 
 **対象ファイル:**
-- テスト: `features/add_s_gate.feature`
-- テスト: `features/add_s_dagger_gate.feature`
-- テスト: `features/qni_run.feature`
-- テスト: `features/qni_expect.feature`
-- テスト: `features/katas/basic_gates/state_flip.feature`
-- テスト: `features/katas/basic_gates/basis_change.feature`
-- テスト: `features/katas/basic_gates/sign_flip.feature`
-- テスト: `features/katas/basic_gates/amplitude_change.feature`
-- テスト: `features/katas/basic_gates/phase_flip.feature`
+- テスト: `features/cli/add/add_s_gate.feature.md`
+- テスト: `features/cli/add/add_s_dagger_gate.feature.md`
+- テスト: `features/cli/run/basic_state_vectors.feature.md`
+- テスト: `features/cli/run/symbolic.feature.md`
+- テスト: `features/cli/expect/command.feature.md`
+- テスト: `features/katas/basic_gates/state_flip.feature.md`
+- テスト: `features/katas/basic_gates/basis_change.feature.md`
+- テスト: `features/katas/basic_gates/sign_flip.feature.md`
+- テスト: `features/katas/basic_gates/amplitude_change.feature.md`
+- テスト: `features/katas/basic_gates/phase_flip.feature.md`
 
 - [ ] **手順 1: 近接する機能仕様をまとめて実行する**
 
@@ -187,15 +191,16 @@ git commit -m "feat: support Task 1.5 phase flip verification"
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber \
-  features/add_s_gate.feature \
-  features/add_s_dagger_gate.feature \
-  features/qni_run.feature \
-  features/qni_expect.feature \
-  features/katas/basic_gates/state_flip.feature \
-  features/katas/basic_gates/basis_change.feature \
-  features/katas/basic_gates/sign_flip.feature \
-  features/katas/basic_gates/amplitude_change.feature \
-  features/katas/basic_gates/phase_flip.feature
+  features/cli/add/add_s_gate.feature.md \
+  features/cli/add/add_s_dagger_gate.feature.md \
+  features/cli/run/basic_state_vectors.feature.md \
+  features/cli/run/symbolic.feature.md \
+  features/cli/expect/command.feature.md \
+  features/katas/basic_gates/state_flip.feature.md \
+  features/katas/basic_gates/basis_change.feature.md \
+  features/katas/basic_gates/sign_flip.feature.md \
+  features/katas/basic_gates/amplitude_change.feature.md \
+  features/katas/basic_gates/phase_flip.feature.md
 ```
 
 期待結果:


### PR DESCRIPTION
## 概要

- YAS-272
- `docs/superpowers/plans/2026-03-20-basic-gates-task-1-5.md` の英語見出しと説明文を自然な日本語に修正しました。
- `Sdg`（S†）の表記を追跡しやすい形に揃えました。
- 期待結果欄に本文として残っていた `PASS` を `成功する` / `すべて成功する` などの自然な日本語に修正しました。
- 計画書内の作成対象、確認対象、実行例、`git add` 例を、現行リポジトリに実在する `.feature.md` と `features/cli/...` 配下のパスに揃えました。
- コマンド、Gherkin キーワード、期待出力など、原文維持すべき技術表記は残しました。

## 検証

- `git diff --check`
- `bundle exec rake check`
