### PR TITLE
BasicGates Task 1.7 計画書の文体を整える

### DIFF
--- a/docs/superpowers/plans/2026-03-20-basic-gates-task-1-7.md
+++ b/docs/superpowers/plans/2026-03-20-basic-gates-task-1-7.md
@@ -44,7 +44,7 @@ Feature: Quantum Katas BasicGates Task 1.7 GlobalPhaseChange
   単独の量子ビットではグローバル位相は観測できないため、制御付き版で確認する
 
   Scenario: Task 1.7 の制御付き検証回路は制御量子ビットを |0> に戻す
-    Given 空の 2 量子ビット回路がある
+    Given 空の 2 qubit 回路がある
     And "qni add H --qubit 0 --step 0" を実行
     And "qni add Ry --angle 1.8545904360032246 --qubit 1 --step 1" を実行
     And "qni add Rz --angle 2π --control 0 --qubit 1 --step 2" を実行

--- a/docs/superpowers/plans/2026-03-20-basic-gates-task-1-7.md
+++ b/docs/superpowers/plans/2026-03-20-basic-gates-task-1-7.md
@@ -1,35 +1,35 @@
-# BasicGates Task 1.7 Implementation Plan
+# BasicGates Task 1.7 実装計画
 
-> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **エージェント作業者向け:** 必須: この計画を実装するときは、利用できる場合は `superpowers:subagent-driven-development`、利用できない場合は `superpowers:executing-plans` を使う。手順は進捗管理のためチェックボックス（`- [ ]`）構文を使う。
 
-**Goal:** `BasicGates Task 1.7 GlobalPhaseChange` を `features/katas/basic_gates/global_phase_change.feature` に追加し、Quantum Katas の controlled 等価性検証を `qni-cli` 側で再現する。
+**目的:** `BasicGates Task 1.7 GlobalPhaseChange` を `features/katas/basic_gates/global_phase_change.feature` に追加し、Quantum Katas の制御付き等価性検証を `qni-cli` 側で再現する。
 
-**Architecture:** 先に `global_phase_change.feature` を追加し、既存の `Rz`、angle expression、`qni run --symbolic`、`qni expect`、controlled 指定だけで task を表現できるかを確認する。`Task 1.7` は単独の 1 qubit では観測できないグローバル位相を扱うため、feature の中心は controlled 検証とし、symbolic は補助説明として追加する。必要なら実際の symbolic 出力を見てから expected を固定する。
+**設計:** 先に `global_phase_change.feature` を追加し、既存の `Rz`、角度式、`qni run --symbolic`、`qni expect`、`--control` 指定だけで `Task 1.7` を表現できるかを確認する。`Task 1.7` は単独の 1 量子ビットでは観測できないグローバル位相を扱うため、機能ファイルの中心は制御付き検証とし、記号計算出力は補助説明として追加する。必要なら実際の `qni run --symbolic` 出力を見てから期待値を固定する。
 
-**Tech Stack:** Ruby, Cucumber, Bundler, `qni-cli`
+**技術構成:** Ruby, Cucumber, Bundler, `qni-cli`
 
 ---
 
-## File Structure
+## ファイル構成
 
-- Create: `features/katas/basic_gates/global_phase_change.feature`
-  - `Task 1.7` の問題文、controlled 検証シナリオ、symbolic 補助シナリオを追加する。
-- Optionally modify: `features/qni_run.feature`
-  - `Rz(2π)` の symbolic 出力が未保証なら最小回帰を追加する。
-- Optionally modify: `features/qni_expect.feature`
-  - controlled `Rz(2π)` / `Rz(-2π)` を含む回路で `ZI` が 1 に戻ることが未保証なら最小回帰を追加する。
-- Optionally modify: `lib/qni/...`
-  - `Rz(2π)` の表現や symbolic 出力に本当の不足がある場合だけ最小実装を入れる。
-- Verify: `features/katas/basic_gates/phase_change.feature`
+- 作成: `features/katas/basic_gates/global_phase_change.feature`
+  - `Task 1.7` の問題文、制御付き検証シナリオ、記号計算の補助シナリオを追加する。
+- 必要なら変更: `features/qni_run.feature`
+  - `Rz(2π)` の記号計算出力が未保証なら最小回帰を追加する。
+- 必要なら変更: `features/qni_expect.feature`
+  - 制御付き `Rz(2π)` / `Rz(-2π)` を含む回路で `ZI` が 1 に戻ることが未保証なら最小回帰を追加する。
+- 必要なら変更: `lib/qni/...`
+  - `Rz(2π)` の表現や記号計算出力に本当の不足がある場合だけ最小実装を入れる。
+- 確認: `features/katas/basic_gates/phase_change.feature`
   - `Task 1.6` が回帰していないことを確認する。
 
-## Task 1: `Task 1.7` feature を先に追加して既存機能で足りるか確認する
+## 作業 1: `Task 1.7` の機能ファイルを先に追加して既存機能で足りるか確認する
 
-**Files:**
-- Create: `features/katas/basic_gates/global_phase_change.feature`
-- Test: `features/katas/basic_gates/global_phase_change.feature`
+**対象ファイル:**
+- 作成: `features/katas/basic_gates/global_phase_change.feature`
+- テスト: `features/katas/basic_gates/global_phase_change.feature`
 
-- [ ] **Step 1: `Task 1.7` の問題文とシナリオを書く**
+- [ ] **手順 1: `Task 1.7` の問題文とシナリオを書く**
 
 `features/katas/basic_gates/global_phase_change.feature` を新規作成し、少なくとも次を追加する。
 
@@ -41,10 +41,10 @@ Feature: Quantum Katas BasicGates Task 1.7 GlobalPhaseChange
   目標:
   状態を -β|0⟩ - γ|1⟩ に変える
   注意:
-  単独の qubit ではグローバル位相は観測できないため、controlled 版で確認する
+  単独の量子ビットではグローバル位相は観測できないため、制御付き版で確認する
 
-  Scenario: Task 1.7 の controlled 検証回路は control qubit を |0> に戻す
-    Given 空の 2 qubit 回路がある
+  Scenario: Task 1.7 の制御付き検証回路は制御量子ビットを |0> に戻す
+    Given 空の 2 量子ビット回路がある
     And "qni add H --qubit 0 --step 0" を実行
     And "qni add Ry --angle 1.8545904360032246 --qubit 1 --step 1" を実行
     And "qni add Rz --angle 2π --control 0 --qubit 1 --step 2" を実行
@@ -54,85 +54,85 @@ Feature: Quantum Katas BasicGates Task 1.7 GlobalPhaseChange
     Then 期待値 "ZI" は 1.0 ± 1e-12
 ```
 
-symbolic 補助シナリオは、`qni run --symbolic` の実出力を確認してから expected を固定する。
+記号計算の補助シナリオは、`qni run --symbolic` の実出力を確認してから期待値を固定する。
 
-- [ ] **Step 2: focused 実行で red / green を確認する**
+- [ ] **手順 2: 絞り込み実行で失敗 / 成功を確認する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber features/katas/basic_gates/global_phase_change.feature
 ```
 
-Expected:
+期待結果:
 
-- 少なくとも controlled / symbolic のどこで不足があるかを 1 箇所に切り分けられる
-- 既存機能で足りるならそのまま PASS
+- 少なくとも制御付き検証 / 記号計算出力のどこで不足があるかを 1 箇所に切り分けられる
+- 既存機能で足りるならそのまま成功する
 
-- [ ] **Step 3: feature-first の追加をコミットする**
+- [ ] **手順 3: 機能ファイル先行の追加をコミットする**
 
 ```bash
 git add features/katas/basic_gates/global_phase_change.feature
 git commit -m "test: add Task 1.7 kata scenarios"
 ```
 
-## Task 2: 必要なら最小修正で green にする
+## 作業 2: 必要なら最小修正で成功させる
 
-**Files:**
-- Modify: `features/katas/basic_gates/global_phase_change.feature`
-- Optionally modify: `features/qni_run.feature`
-- Optionally modify: `features/qni_expect.feature`
-- Optionally modify: `lib/qni/...`
+**対象ファイル:**
+- 変更: `features/katas/basic_gates/global_phase_change.feature`
+- 必要なら変更: `features/qni_run.feature`
+- 必要なら変更: `features/qni_expect.feature`
+- 必要なら変更: `lib/qni/...`
 
-- [ ] **Step 1: 失敗原因を 1 箇所に絞る**
+- [ ] **手順 1: 失敗原因を 1 箇所に絞る**
 
 想定する失敗原因は次に限る。
 
 - `qni add Rz --angle 2π --control ...` が受理されない
 - `qni add Rz --angle -2π --control ...` が受理されない
-- `qni run --symbolic` の `Rz(2π)` 表示が expected と違う
-- `qni expect ZI` の丸め差で exact 比較が落ちる
+- `qni run --symbolic` の `Rz(2π)` 表示が期待値と違う
+- `qni expect ZI` の丸め差で厳密比較が落ちる
 
-- [ ] **Step 2: product code 不足がある場合だけ既存 feature に最小回帰を追加する**
+- [ ] **手順 2: 製品コードに不足がある場合だけ既存の機能ファイルに最小回帰を追加する**
 
-不足が product code にある場合のみ、対応する既存 feature に最小シナリオを追加する。
+不足が製品コードにある場合のみ、対応する既存の機能ファイルに最小シナリオを追加する。
 
-- [ ] **Step 3: 必要な最小実装だけを入れる**
+- [ ] **手順 3: 必要な最小実装だけを入れる**
 
 実装変更は、実際に失敗した箇所のみに限定する。
 
-- [ ] **Step 4: `Task 1.7` feature を再実行して green を確認する**
+- [ ] **手順 4: `Task 1.7` の機能ファイルを再実行して成功を確認する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber features/katas/basic_gates/global_phase_change.feature
 ```
 
-Expected:
+期待結果:
 
-- `Task 1.7` の feature が PASS
+- `Task 1.7` の機能ファイルが成功する
 
-- [ ] **Step 5: 必要な修正をコミットする**
+- [ ] **手順 5: 必要な修正をコミットする**
 
 ```bash
 git add features/katas/basic_gates/global_phase_change.feature features/qni_run.feature features/qni_expect.feature lib/qni
 git commit -m "feat: support Task 1.7 global phase verification"
 ```
 
-`lib/qni` に変更がない場合は、実際に触った file だけ `git add` する。
+`lib/qni` に変更がない場合は、実際に触ったファイルだけ `git add` する。
 
-## Task 3: 近接回帰を確認する
+## 作業 3: 近接回帰を確認する
 
-**Files:**
-- Test: `features/qni_run.feature`
-- Test: `features/qni_expect.feature`
-- Test: `features/katas/basic_gates/phase_change.feature`
-- Test: `features/katas/basic_gates/global_phase_change.feature`
+**対象ファイル:**
+- テスト: `features/qni_run.feature`
+- テスト: `features/qni_expect.feature`
+- テスト: `features/katas/basic_gates/phase_change.feature`
+- テスト: `features/katas/basic_gates/global_phase_change.feature`
 
-- [ ] **Step 1: 近接 feature をまとめて実行する**
+- [ ] **手順 1: 近接する機能ファイルをまとめて実行する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber \
@@ -142,36 +142,36 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/sha
   features/katas/basic_gates/global_phase_change.feature
 ```
 
-Expected:
+期待結果:
 
-- すべて PASS
+- すべて成功する
 
-- [ ] **Step 2: 近接回帰の green をコミットする**
+- [ ] **手順 2: 近接回帰の成功をコミットする**
 
 ```bash
 git commit --allow-empty -m "test: verify Task 1.7 regressions"
 ```
 
-## Task 4: 全量確認して統合準備をする
+## 作業 4: 全量確認して統合準備をする
 
-**Files:**
-- Test: repository-wide checks
+**対象ファイル:**
+- テスト: リポジトリ全体の確認
 
-- [ ] **Step 1: full cucumber を実行する**
+- [ ] **手順 1: 全 Cucumber を実行する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber
 ```
 
-Expected:
+期待結果:
 
-- 全 scenario が PASS
+- 全シナリオが成功する
 
-- [ ] **Step 2: Ruby 品質チェックを実行する**
+- [ ] **手順 2: Ruby 品質チェックを実行する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec rake rubocop
@@ -180,6 +180,6 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/sha
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec rake flay
 ```
 
-Expected:
+期待結果:
 
-- すべて PASS
+- すべて成功する


### PR DESCRIPTION
## 概要

- `docs/superpowers/plans/2026-03-20-basic-gates-task-1-7.md` の見出しと本文を自然な日本語に修正しました。
- コマンド例、ファイルパス、Gherkin キーワード、CLI 引数、識別子は原文を保ちました。
- 意味、仕様、期待値、コマンド例は変えていません。

## 検証

- `git diff --check`
- `bundle exec rake check`

## Linear

- YAS-274
