### PR TITLE
BasicGates Task 1.8 計画書の文体を修正

### DIFF
--- a/docs/superpowers/plans/2026-03-20-basic-gates-task-1-8.md
+++ b/docs/superpowers/plans/2026-03-20-basic-gates-task-1-8.md
@@ -1,37 +1,37 @@
-# BasicGates Task 1.8 Implementation Plan
+# BasicGates Task 1.8 実装計画
 
-> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **エージェント作業者向け:** 必須: この計画を実装するときは、利用できる場合は superpowers:subagent-driven-development を、そうでない場合は superpowers:executing-plans を使う。手順は追跡用にチェックボックス (`- [ ]`) 構文を使う。
 
-**Goal:** `BasicGates Task 1.8 BellStateChange1` を `features/katas/basic_gates/bell_state_change_1.feature` に追加し、Quantum Katas の `DumpDiff` と controlled Bell state 検証を `qni-cli` 側で再現する。同時に `qni run --symbolic` を 2 qubit 回路まで拡張する。
+**目的:** `BasicGates Task 1.8 BellStateChange1` を `features/katas/basic_gates/bell_state_change_1.feature` に追加し、Quantum Katas の `DumpDiff` と制御付き Bell 状態検証を `qni-cli` 側で再現する。同時に `qni run --symbolic` を 2 量子ビット回路まで拡張する。
 
-**Architecture:** 先に `bell_state_change_1.feature` を追加し、2 qubit の数値シナリオ、2 qubit の symbolic シナリオ、3 qubit の controlled 検証シナリオを書いて red / green を確認する。`Task 1.8` の説明力に必要な 2 qubit symbolic は Python/SymPy helper に実装し、Ruby 側は既存の subprocess 境界とエラー整形を再利用する。まずは Bell 系に必要な gate だけを対象にし、不足が出た場合だけ既存 feature へ最小回帰を追加して実装を足す。
+**構成方針:** 先に `bell_state_change_1.feature` を追加し、2 量子ビットの数値シナリオ、2 量子ビットの記号表示シナリオ、3 量子ビットの制御付き検証シナリオを書いて失敗 / 成功を確認する。`Task 1.8` の説明力に必要な 2 量子ビットの記号表示は Python/SymPy 補助スクリプトに実装し、Ruby 側は既存の子プロセス境界とエラー整形を再利用する。まずは Bell 系に必要なゲートだけを対象にし、不足が出た場合だけ既存の機能仕様へ最小限の回帰シナリオを追加して実装を足す。
 
-**Tech Stack:** Ruby, Python, SymPy, Cucumber, Bundler, `qni-cli`
+**技術構成:** Ruby, Python, SymPy, Cucumber, Bundler, `qni-cli`
 
 ---
 
-## File Structure
+## ファイル構成
 
-- Create: `features/katas/basic_gates/bell_state_change_1.feature`
-  - `Task 1.8` の問題文、2 qubit の数値シナリオ、2 qubit の symbolic シナリオ、3 qubit の controlled 検証シナリオを追加する。
-- Modify: `features/qni_run.feature`
-  - `qni run --symbolic` の 2 qubit 表示に関する最小回帰を追加する。
-- Optionally modify: `features/qni_expect.feature`
-  - 3 qubit controlled Bell 検証に必要な期待値確認が未保証なら最小回帰を追加する。
-- Modify: `lib/qni/symbolic_state_renderer.rb`
-  - 2 qubit symbolic を許可する Ruby 側の分岐と helper 呼び出しを調整する。
-- Modify: `libexec/qni_symbolic_run.py`
-  - 2 qubit symbolic 計算と controlled gate の適用を実装する。
-- Verify: `features/katas/basic_gates/global_phase_change.feature`
+- 作成: `features/katas/basic_gates/bell_state_change_1.feature`
+  - `Task 1.8` の問題文、2 量子ビットの数値シナリオ、2 量子ビットの記号表示シナリオ、3 量子ビットの制御付き検証シナリオを追加する。
+- 変更: `features/qni_run.feature`
+  - `qni run --symbolic` の 2 量子ビット表示に関する最小限の回帰シナリオを追加する。
+- 必要なら変更: `features/qni_expect.feature`
+  - 3 量子ビットの制御付き Bell 検証に必要な期待値確認が未保証なら、最小限の回帰シナリオを追加する。
+- 変更: `lib/qni/symbolic_state_renderer.rb`
+  - 2 量子ビットの記号表示を許可する Ruby 側の分岐と補助スクリプト呼び出しを調整する。
+- 変更: `libexec/qni_symbolic_run.py`
+  - 2 量子ビットの記号計算と制御付きゲートの適用を実装する。
+- 確認: `features/katas/basic_gates/global_phase_change.feature`
   - `Task 1.7` が回帰していないことを確認する。
 
-## Task 1: `Task 1.8` feature を先に追加して不足を切り分ける
+## タスク 1: `Task 1.8` の機能仕様を先に追加して不足を切り分ける
 
-**Files:**
-- Create: `features/katas/basic_gates/bell_state_change_1.feature`
-- Test: `features/katas/basic_gates/bell_state_change_1.feature`
+**ファイル:**
+- 作成: `features/katas/basic_gates/bell_state_change_1.feature`
+- テスト: `features/katas/basic_gates/bell_state_change_1.feature`
 
-- [ ] **Step 1: `Task 1.8` の問題文とシナリオを書く**
+- [ ] **手順 1: `Task 1.8` の問題文とシナリオを書く**
 
 `features/katas/basic_gates/bell_state_change_1.feature` を新規作成し、少なくとも次を追加する。
 
@@ -54,7 +54,7 @@ Feature: Quantum Katas BasicGates Task 1.8 BellStateChange1
       0.7071067811865475,0.0,0.0,-0.7071067811865475
       """
 
-  Scenario: Task 1.8 は symbolic 表示で |Φ⁻⟩ を示す
+  Scenario: Task 1.8 は記号表示で |Φ⁻⟩ を示す
     Given 空の 2 qubit 回路がある
     And "qni add H --qubit 0 --step 0" を実行
     And "qni add X --control 0 --qubit 1 --step 1" を実行
@@ -62,10 +62,10 @@ Feature: Quantum Katas BasicGates Task 1.8 BellStateChange1
     When "qni run --symbolic" を実行
     Then 標準出力:
       """
-      <actual symbolic output>
+      <実際の記号表示出力>
       """
 
-  Scenario: Task 1.8 の controlled 検証回路は |000⟩ に戻る
+  Scenario: Task 1.8 の制御付き検証回路は |000⟩ に戻る
     Given 空の 3 qubit 回路がある
     And "qni add H --qubit 0 --step 0" を実行
     And "qni add H --control 0 --qubit 1 --step 1" を実行
@@ -82,88 +82,88 @@ Feature: Quantum Katas BasicGates Task 1.8 BellStateChange1
       """
 ```
 
-symbolic の expected は、実出力を確認してから固定する。
+記号表示の期待値は、実出力を確認してから固定する。
 
-- [ ] **Step 2: focused 実行で red / green を確認する**
+- [ ] **手順 2: 対象を絞った実行で失敗 / 成功を確認する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber features/katas/basic_gates/bell_state_change_1.feature
 ```
 
-Expected:
+期待結果:
 
-- 少なくとも symbolic / controlled のどこで不足があるかを 1 箇所に切り分けられる
-- 既存機能で足りる部分はそのまま PASS
+- 少なくとも記号表示 / 制御付き検証のどこで不足があるかを 1 箇所に切り分けられる
+- 既存機能で足りる部分はそのまま成功する
 
-- [ ] **Step 3: feature-first の追加をコミットする**
+- [ ] **手順 3: 機能仕様優先の追加をコミットする**
 
 ```bash
 git add features/katas/basic_gates/bell_state_change_1.feature
 git commit -m "test: add Task 1.8 kata scenarios"
 ```
 
-## Task 2: 2 qubit symbolic の最小回帰を追加して green にする
+## タスク 2: 2 量子ビットの記号表示に関する最小限の回帰シナリオを追加して成功させる
 
-**Files:**
-- Modify: `features/qni_run.feature`
-- Modify: `lib/qni/symbolic_state_renderer.rb`
-- Modify: `libexec/qni_symbolic_run.py`
-- Optionally modify: `features/qni_expect.feature`
+**ファイル:**
+- 変更: `features/qni_run.feature`
+- 変更: `lib/qni/symbolic_state_renderer.rb`
+- 変更: `libexec/qni_symbolic_run.py`
+- 必要なら変更: `features/qni_expect.feature`
 
-- [ ] **Step 1: 失敗原因を 1 箇所に絞る**
+- [ ] **手順 1: 失敗原因を 1 箇所に絞る**
 
 想定する失敗原因は次に限る。
 
-- `qni run --symbolic` が 2 qubit 回路を拒否する
-- 2 qubit で `H`, `Z`, controlled-`X` の symbolic 適用が足りない
-- 3 qubit controlled 検証が既存 `qni run` / `qni expect` で書けない
+- `qni run --symbolic` が 2 量子ビット回路を拒否する
+- 2 量子ビットで `H`, `Z`, 制御付き `X` の記号適用が足りない
+- 3 量子ビットの制御付き検証が既存 `qni run` / `qni expect` で書けない
 
-- [ ] **Step 2: 既存 feature に 2 qubit symbolic の最小回帰を追加する**
+- [ ] **手順 2: 既存の機能仕様に 2 量子ビット記号表示の最小限の回帰シナリオを追加する**
 
-`features/qni_run.feature` に、Bell 状態の symbolic 表示を確認する最小シナリオを追加する。
+`features/qni_run.feature` に、Bell 状態の記号表示を確認する最小シナリオを追加する。
 
-- [ ] **Step 3: Python helper と Ruby 境界を最小拡張する**
+- [ ] **手順 3: Python 補助スクリプトと Ruby 境界を最小拡張する**
 
-2 qubit 限定で `qni run --symbolic` を拡張する。
+2 量子ビット限定で `qni run --symbolic` を拡張する。
 
-- Python helper は長さ 4 の状態ベクトルと gate 適用を実装する
-- 最低限 `H`, `Z`, controlled-`X`, controlled-`Z` を扱う
-- Ruby 側は 2 qubit 回路を許可し、helper エラーを既存の `Simulator::Error` に変換する
+- Python 補助スクリプトは長さ 4 の状態ベクトルとゲート適用を実装する
+- 最低限 `H`, `Z`, 制御付き `X`, 制御付き `Z` を扱う
+- Ruby 側は 2 量子ビット回路を許可し、補助スクリプトのエラーを既存の `Simulator::Error` に変換する
 
-- [ ] **Step 4: `Task 1.8` feature を再実行して green を確認する**
+- [ ] **手順 4: `Task 1.8` の機能仕様を再実行して成功を確認する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber features/katas/basic_gates/bell_state_change_1.feature
 ```
 
-Expected:
+期待結果:
 
-- `Task 1.8` の feature が PASS
+- `Task 1.8` の機能仕様が成功する
 
-- [ ] **Step 5: 必要な修正をコミットする**
+- [ ] **手順 5: 必要な修正をコミットする**
 
 ```bash
 git add features/katas/basic_gates/bell_state_change_1.feature features/qni_run.feature features/qni_expect.feature lib/qni/symbolic_state_renderer.rb libexec/qni_symbolic_run.py
 git commit -m "feat: support Task 1.8 bell state verification"
 ```
 
-実際に触った file のみ `git add` する。
+実際に触ったファイルのみ `git add` する。
 
-## Task 3: 近接回帰を確認する
+## タスク 3: 近接回帰を確認する
 
-**Files:**
-- Test: `features/qni_run.feature`
-- Test: `features/qni_expect.feature`
-- Test: `features/katas/basic_gates/global_phase_change.feature`
-- Test: `features/katas/basic_gates/bell_state_change_1.feature`
+**ファイル:**
+- テスト: `features/qni_run.feature`
+- テスト: `features/qni_expect.feature`
+- テスト: `features/katas/basic_gates/global_phase_change.feature`
+- テスト: `features/katas/basic_gates/bell_state_change_1.feature`
 
-- [ ] **Step 1: 近接 feature をまとめて実行する**
+- [ ] **手順 1: 近接する機能仕様をまとめて実行する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber \
@@ -173,36 +173,36 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/sha
   features/katas/basic_gates/bell_state_change_1.feature
 ```
 
-Expected:
+期待結果:
 
-- すべて PASS
+- すべて成功する
 
-- [ ] **Step 2: 近接回帰の green をコミットする**
+- [ ] **手順 2: 近接回帰の成功をコミットする**
 
 ```bash
 git commit --allow-empty -m "test: verify Task 1.8 regressions"
 ```
 
-## Task 4: 全量確認して統合準備をする
+## タスク 4: 全量確認して統合準備をする
 
-**Files:**
-- Test: repository-wide checks
+**ファイル:**
+- テスト: リポジトリ全体の確認
 
-- [ ] **Step 1: full cucumber を実行する**
+- [ ] **手順 1: 全 Cucumber を実行する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber
 ```
 
-Expected:
+期待結果:
 
-- 全 scenario が PASS
+- 全シナリオが成功する
 
-- [ ] **Step 2: Ruby 品質チェックを実行する**
+- [ ] **手順 2: Ruby 品質チェックを実行する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec rake rubocop
@@ -211,6 +211,6 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/sha
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec rake flay
 ```
 
-Expected:
+期待結果:
 
-- すべて PASS
+- すべて成功する


### PR DESCRIPTION
## 概要

- YAS-275
- `docs/superpowers/plans/2026-03-20-basic-gates-task-1-8.md` の見出しと本文を見直し、不自然な英日混在表現を自然な日本語に修正しました。
- ファイルパス、コマンド、CLI 引数、Gherkin キーワード、プログラミング言語名、コード識別子は原文のまま維持しました。

## 検証

- `git diff --check`
- `bundle exec rake check`
