### PR TITLE
Task 1.10 計画書の文体を整える

### DIFF
--- a/docs/superpowers/plans/2026-03-26-basic-gates-task-1-10.md
+++ b/docs/superpowers/plans/2026-03-26-basic-gates-task-1-10.md
@@ -4,7 +4,7 @@
 
 **目的:** `BasicGates Task 1.10 BellStateChange3` を `features/katas/basic_gates/bell_state_change_3.feature` に追加し、Quantum Katas の `DumpDiff` と制御付き Bell 状態検証を `qni-cli` 側で再現する。
 
-**構成:** 先に `bell_state_change_3.feature` を追加し、2 量子ビットの数値シナリオ、2 量子ビットのシンボリックシナリオ、3 量子ビットの制御付き検証シナリオを書いて失敗 / 成功を確認する。`Task 1.8` と `Task 1.9` で整えた 2 量子ビットのシンボリック対応はそのまま再利用し、今回の焦点は `Task 1.10` 固有の位相罠を避けるために候補を `qs[0]` に固定することと、`VerifyBellStateConversion(..., 0, 3)` の再現に多重制御 `X` が本当に必要かを機能仕様を先に書く方針で切り分けることに置く。
+**構成:** 先に `bell_state_change_3.feature` を追加し、2 量子ビットの数値シナリオ、2 量子ビットの記号表示シナリオ、3 量子ビットの制御付き検証シナリオを書いて失敗 / 成功を確認する。`Task 1.8` と `Task 1.9` で整えた 2 量子ビットの記号表示対応はそのまま再利用し、今回の焦点は `Task 1.10` 固有の位相罠を避けるために候補を `qs[0]` に固定することと、`VerifyBellStateConversion(..., 0, 3)` の再現に多重制御 `X` が本当に必要かを機能仕様を先に書く方針で切り分けることに置く。
 
 **利用技術:** Ruby, Python, SymPy, Cucumber, Bundler, `qni-cli`
 
@@ -13,9 +13,9 @@
 ## ファイル構成
 
 - 作成: `features/katas/basic_gates/bell_state_change_3.feature`
-  - `Task 1.10` の問題文、2 量子ビットの数値シナリオ、2 量子ビットのシンボリックシナリオ、3 量子ビットの制御付き検証シナリオを追加する。
+  - `Task 1.10` の問題文、2 量子ビットの数値シナリオ、2 量子ビットの記号表示シナリオ、3 量子ビットの制御付き検証シナリオを追加する。
 - 必要なら変更: `features/qni_run.feature`
-  - `Task 1.10` 用の Bell 状態シンボリック表示が未保証なら最小回帰を追加する。
+  - `Task 1.10` 用の Bell 状態の記号表示が未保証なら最小回帰を追加する。
 - 必要なら変更: `features/step_definitions/cli_steps.rb`
   - Bell 系タスクに必要なテスト支援が不足している場合だけ最小追加する。
 - 必要なら変更: `lib/qni/...`
@@ -98,7 +98,7 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/sha
 
 期待結果:
 
-- 数値 / シンボリック表示のどこまで既存機能だけで通るかが分かる
+- 数値 / 記号表示のどこまで既存機能だけで通るかが分かる
 - 制御付き検証で多重制御 `X` 相当が不足しているか、あるいは機能仕様の並びだけで書けるかを切り分けられる
 
 - [ ] **手順 3: 機能仕様を先に追加した内容をコミットする**
@@ -122,14 +122,14 @@ git commit -m "test: add Task 1.10 kata scenarios"
 
 - 制御付き検証回路の書き下ろしが間違っている
 - `Task 1.10` に必要な多重制御 `X`、すなわち `CCNOT` 相当の表現や実行が不足している
-- `Task 1.10` 用の Bell 状態シンボリック表示が既存の `qni run --symbolic` で未保証である
+- `Task 1.10` 用の Bell 状態の記号表示が既存の `qni run --symbolic` で未保証である
 
 - [ ] **手順 2: 製品コードに不足がある場合だけ既存の機能仕様に最小回帰を追加する**
 
 不足が製品コードにある場合のみ、対応する既存の機能仕様に最小シナリオを追加する。
 
 - `CCNOT` 相当が不足しているなら、その表現と実行を保証する機能仕様を先に追加する
-- シンボリック出力の不足なら `features/qni_run.feature` に最小回帰を追加する
+- 記号表示出力の不足なら `features/qni_run.feature` に最小回帰を追加する
 
 - [ ] **手順 3: 必要な最小実装だけを入れる**
 
@@ -148,7 +148,7 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/sha
 
 期待結果:
 
-- `Task 1.10` の機能仕様が PASS
+- `Task 1.10` の機能仕様が成功する
 
 - [ ] **手順 5: 必要な修正をコミットする**
 
@@ -181,7 +181,7 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/sha
 
 期待結果:
 
-- すべて PASS
+- すべて成功する
 
 - [ ] **手順 2: 近接回帰の成功確認をコミットする**
 
@@ -204,7 +204,7 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/sha
 
 期待結果:
 
-- 全シナリオが PASS
+- 全シナリオが成功する
 
 - [ ] **手順 2: Ruby 品質チェックを実行する**
 
@@ -219,4 +219,4 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/sha
 
 期待結果:
 
-- すべて PASS
+- すべて成功する

--- a/docs/superpowers/plans/2026-03-26-basic-gates-task-1-10.md
+++ b/docs/superpowers/plans/2026-03-26-basic-gates-task-1-10.md
@@ -1,37 +1,37 @@
-# BasicGates Task 1.10 Implementation Plan
+# BasicGates Task 1.10 実装計画
 
-> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **自律作業者向け:** 必須: この計画の実装には、利用できる場合は `superpowers:subagent-driven-development`、それ以外は `superpowers:executing-plans` を使う。進捗管理にはチェックボックス記法（`- [ ]`）を使う。
 
-**Goal:** `BasicGates Task 1.10 BellStateChange3` を `features/katas/basic_gates/bell_state_change_3.feature` に追加し、Quantum Katas の `DumpDiff` と controlled Bell state 検証を `qni-cli` 側で再現する。
+**目的:** `BasicGates Task 1.10 BellStateChange3` を `features/katas/basic_gates/bell_state_change_3.feature` に追加し、Quantum Katas の `DumpDiff` と制御付き Bell 状態検証を `qni-cli` 側で再現する。
 
-**Architecture:** 先に `bell_state_change_3.feature` を追加し、2 qubit の数値シナリオ、2 qubit の symbolic シナリオ、3 qubit の controlled 検証シナリオを書いて red / green を確認する。`Task 1.8` と `Task 1.9` で整えた 2 qubit symbolic はそのまま再利用し、今回の焦点は `Task 1.10` 固有の位相罠を避けるために candidate を `qs[0]` に固定することと、`VerifyBellStateConversion(..., 0, 3)` の再現に multi-controlled `X` が本当に必要かを feature-first で切り分けることに置く。
+**構成:** 先に `bell_state_change_3.feature` を追加し、2 量子ビットの数値シナリオ、2 量子ビットのシンボリックシナリオ、3 量子ビットの制御付き検証シナリオを書いて失敗 / 成功を確認する。`Task 1.8` と `Task 1.9` で整えた 2 量子ビットのシンボリック対応はそのまま再利用し、今回の焦点は `Task 1.10` 固有の位相罠を避けるために候補を `qs[0]` に固定することと、`VerifyBellStateConversion(..., 0, 3)` の再現に多重制御 `X` が本当に必要かを機能仕様を先に書く方針で切り分けることに置く。
 
-**Tech Stack:** Ruby, Python, SymPy, Cucumber, Bundler, `qni-cli`
+**利用技術:** Ruby, Python, SymPy, Cucumber, Bundler, `qni-cli`
 
 ---
 
-## File Structure
+## ファイル構成
 
-- Create: `features/katas/basic_gates/bell_state_change_3.feature`
-  - `Task 1.10` の問題文、2 qubit の数値シナリオ、2 qubit の symbolic シナリオ、3 qubit の controlled 検証シナリオを追加する。
-- Optionally modify: `features/qni_run.feature`
-  - `Task 1.10` 用の Bell 状態 symbolic が未保証なら最小回帰を追加する。
-- Optionally modify: `features/step_definitions/cli_steps.rb`
-  - Bell 系 task に必要な test support が不足している場合だけ最小追加する。
-- Optionally modify: `lib/qni/...`
-  - `Task 1.10` の controlled 検証で multi-controlled `X` が不足した場合のみ、既存 gate 実行系に最小追加する。
-- Verify: `features/katas/basic_gates/bell_state_change_1.feature`
+- 作成: `features/katas/basic_gates/bell_state_change_3.feature`
+  - `Task 1.10` の問題文、2 量子ビットの数値シナリオ、2 量子ビットのシンボリックシナリオ、3 量子ビットの制御付き検証シナリオを追加する。
+- 必要なら変更: `features/qni_run.feature`
+  - `Task 1.10` 用の Bell 状態シンボリック表示が未保証なら最小回帰を追加する。
+- 必要なら変更: `features/step_definitions/cli_steps.rb`
+  - Bell 系タスクに必要なテスト支援が不足している場合だけ最小追加する。
+- 必要なら変更: `lib/qni/...`
+  - `Task 1.10` の制御付き検証で多重制御 `X` が不足した場合のみ、既存ゲート実行系に最小追加する。
+- 検証: `features/katas/basic_gates/bell_state_change_1.feature`
   - `Task 1.8` が回帰していないことを確認する。
-- Verify: `features/katas/basic_gates/bell_state_change_2.feature`
+- 検証: `features/katas/basic_gates/bell_state_change_2.feature`
   - `Task 1.9` が回帰していないことを確認する。
 
-## Task 1: `Task 1.10` feature を先に追加して不足を切り分ける
+## タスク 1: `Task 1.10` の機能仕様を先に追加して不足を切り分ける
 
-**Files:**
-- Create: `features/katas/basic_gates/bell_state_change_3.feature`
-- Test: `features/katas/basic_gates/bell_state_change_3.feature`
+**ファイル:**
+- 作成: `features/katas/basic_gates/bell_state_change_3.feature`
+- テスト: `features/katas/basic_gates/bell_state_change_3.feature`
 
-- [ ] **Step 1: `Task 1.10` の問題文とシナリオを書く**
+- [ ] **手順 1: `Task 1.10` の問題文とシナリオを書く**
 
 `features/katas/basic_gates/bell_state_change_3.feature` を新規作成し、少なくとも次を追加する。
 
@@ -55,7 +55,7 @@ Feature: Quantum Katas BasicGates Task 1.10 BellStateChange3
       0.0,0.7071067811865475,-0.7071067811865475,0.0
       """
 
-  Scenario: Task 1.10 は symbolic 表示で |Ψ⁻⟩ を示す
+  Scenario: Task 1.10 はシンボリック表示で |Ψ⁻⟩ を示す
     Given 空の 2 qubit 回路がある
     And "qni add H --qubit 0 --step 0" を実行
     And "qni add X --control 0 --qubit 1 --step 1" を実行
@@ -67,7 +67,7 @@ Feature: Quantum Katas BasicGates Task 1.10 BellStateChange3
       0.707106781186547|01> - 0.707106781186547|10>
       """
 
-  Scenario: Task 1.10 の controlled 検証回路は |000⟩ に戻る
+  Scenario: Task 1.10 の制御付き検証回路は |000⟩ に戻る
     Given 空の 3 qubit 回路がある
     And "qni add H --qubit 0 --step 0" を実行
     And "qni add H --control 0 --qubit 1 --step 1" を実行
@@ -86,90 +86,90 @@ Feature: Quantum Katas BasicGates Task 1.10 BellStateChange3
       """
 ```
 
-この時点で feature に書く controlled 検証シナリオ自体は、`VerifyBellStateConversion(..., 0, 3)` の意図した回路を正確に表す。red が出る場合は、`CCNOT` 相当の不足や実行系の不足を示すものとして解釈する。
+この時点で機能仕様に書く制御付き検証シナリオ自体は、`VerifyBellStateConversion(..., 0, 3)` の意図した回路を正確に表す。失敗が出る場合は、`CCNOT` 相当の不足や実行系の不足を示すものとして解釈する。
 
-- [ ] **Step 2: focused 実行で red / green を確認する**
+- [ ] **手順 2: 対象を絞った実行で失敗 / 成功を確認する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber features/katas/basic_gates/bell_state_change_3.feature
 ```
 
-Expected:
+期待結果:
 
-- 数値 / symbolic のどこまで既存機能だけで通るかが分かる
-- controlled 検証で multi-controlled `X` 相当が不足しているか、あるいは feature の並びだけで書けるかを切り分けられる
+- 数値 / シンボリック表示のどこまで既存機能だけで通るかが分かる
+- 制御付き検証で多重制御 `X` 相当が不足しているか、あるいは機能仕様の並びだけで書けるかを切り分けられる
 
-- [ ] **Step 3: feature-first の追加をコミットする**
+- [ ] **手順 3: 機能仕様を先に追加した内容をコミットする**
 
 ```bash
 git add features/katas/basic_gates/bell_state_change_3.feature
 git commit -m "test: add Task 1.10 kata scenarios"
 ```
 
-## Task 2: 必要なら最小修正で green にする
+## タスク 2: 必要なら最小修正で成功させる
 
-**Files:**
-- Modify: `features/katas/basic_gates/bell_state_change_3.feature`
-- Optionally modify: `features/qni_run.feature`
-- Optionally modify: `features/step_definitions/cli_steps.rb`
-- Optionally modify: `lib/qni/...`
+**ファイル:**
+- 変更: `features/katas/basic_gates/bell_state_change_3.feature`
+- 必要なら変更: `features/qni_run.feature`
+- 必要なら変更: `features/step_definitions/cli_steps.rb`
+- 必要なら変更: `lib/qni/...`
 
-- [ ] **Step 1: 失敗原因を 1 箇所に絞る**
+- [ ] **手順 1: 失敗原因を 1 箇所に絞る**
 
 想定する失敗原因は次に限る。
 
-- controlled 検証回路の書き下ろしが間違っている
-- `Task 1.10` に必要な multi-controlled `X`、すなわち `CCNOT` 相当の表現や実行が不足している
-- `Task 1.10` 用の Bell 状態 symbolic が既存の `qni run --symbolic` で未保証である
+- 制御付き検証回路の書き下ろしが間違っている
+- `Task 1.10` に必要な多重制御 `X`、すなわち `CCNOT` 相当の表現や実行が不足している
+- `Task 1.10` 用の Bell 状態シンボリック表示が既存の `qni run --symbolic` で未保証である
 
-- [ ] **Step 2: product code 不足がある場合だけ既存 feature に最小回帰を追加する**
+- [ ] **手順 2: 製品コードに不足がある場合だけ既存の機能仕様に最小回帰を追加する**
 
-不足が product code にある場合のみ、対応する既存 feature に最小シナリオを追加する。
+不足が製品コードにある場合のみ、対応する既存の機能仕様に最小シナリオを追加する。
 
-- `CCNOT` 相当が不足しているなら、その表現と実行を保証する feature を先に追加する
-- symbolic 出力の不足なら `features/qni_run.feature` に最小回帰を追加する
+- `CCNOT` 相当が不足しているなら、その表現と実行を保証する機能仕様を先に追加する
+- シンボリック出力の不足なら `features/qni_run.feature` に最小回帰を追加する
 
-- [ ] **Step 3: 必要な最小実装だけを入れる**
+- [ ] **手順 3: 必要な最小実装だけを入れる**
 
 実装変更は、実際に失敗した箇所のみに限定する。
 
-- multi-controlled `X` が必要なら、それを支える最小実装だけを追加する
+- 多重制御 `X` が必要なら、それを支える最小実装だけを追加する
 - `Task 1.10` 自体に不要な一般化はしない
 
-- [ ] **Step 4: `Task 1.10` feature を再実行して green を確認する**
+- [ ] **手順 4: `Task 1.10` の機能仕様を再実行して成功を確認する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber features/katas/basic_gates/bell_state_change_3.feature
 ```
 
-Expected:
+期待結果:
 
-- `Task 1.10` の feature が PASS
+- `Task 1.10` の機能仕様が PASS
 
-- [ ] **Step 5: 必要な修正をコミットする**
+- [ ] **手順 5: 必要な修正をコミットする**
 
 ```bash
 git add features/katas/basic_gates/bell_state_change_3.feature features/qni_run.feature features/step_definitions/cli_steps.rb lib/qni
 git commit -m "feat: support Task 1.10 bell state verification"
 ```
 
-実際に触った file のみ `git add` する。
+実際に触ったファイルのみ `git add` する。
 
-## Task 3: 近接回帰を確認する
+## タスク 3: 近接回帰を確認する
 
-**Files:**
-- Test: `features/qni_run.feature`
-- Test: `features/katas/basic_gates/bell_state_change_1.feature`
-- Test: `features/katas/basic_gates/bell_state_change_2.feature`
-- Test: `features/katas/basic_gates/bell_state_change_3.feature`
+**ファイル:**
+- テスト: `features/qni_run.feature`
+- テスト: `features/katas/basic_gates/bell_state_change_1.feature`
+- テスト: `features/katas/basic_gates/bell_state_change_2.feature`
+- テスト: `features/katas/basic_gates/bell_state_change_3.feature`
 
-- [ ] **Step 1: 近接 feature をまとめて実行する**
+- [ ] **手順 1: 近接機能仕様をまとめて実行する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber \
@@ -179,36 +179,36 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/sha
   features/katas/basic_gates/bell_state_change_3.feature
 ```
 
-Expected:
+期待結果:
 
 - すべて PASS
 
-- [ ] **Step 2: 近接回帰の green をコミットする**
+- [ ] **手順 2: 近接回帰の成功確認をコミットする**
 
 ```bash
 git commit --allow-empty -m "test: verify Task 1.10 regressions"
 ```
 
-## Task 4: 全量確認して統合準備をする
+## タスク 4: 全量確認して統合準備をする
 
-**Files:**
-- Test: repository-wide checks
+**ファイル:**
+- テスト: リポジトリ全体のチェック
 
-- [ ] **Step 1: full cucumber を実行する**
+- [ ] **手順 1: Cucumber 全体を実行する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec cucumber
 ```
 
-Expected:
+期待結果:
 
-- 全 scenario が PASS
+- 全シナリオが PASS
 
-- [ ] **Step 2: Ruby 品質チェックを実行する**
+- [ ] **手順 2: Ruby 品質チェックを実行する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec rake rubocop
@@ -217,6 +217,6 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/sha
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor /home/yasuhito/.local/share/gem/ruby/3.4.0/bin/bundle exec rake flay
 ```
 
-Expected:
+期待結果:
 
 - すべて PASS


### PR DESCRIPTION
## 概要

- docs/superpowers/plans/2026-03-26-basic-gates-task-1-10.md の見出しと本文を自然な日本語へ整えました。
- PR 指摘を受け、計画書本文に残っていた `PASS` と `シンボリック...` 表現を日本語へ寄せました。
- コマンド、ファイルパス、Gherkin キーワード、CLI 引数、識別子は原文を保っています。
- Linear: YAS-278

## 検証
- git diff --check
- bundle exec rake check

## 補足
- PR テンプレートはリポジトリに存在しなかったため、この本文を明示指定しています。
- GitHub ラベル `symphony` は存在しなかったため未設定です。
