### PR TITLE
状態ベクトル DSL 計画書の文体を整える

### DIFF
--- a/docs/superpowers/plans/2026-03-29-state-vector-dsl-controlled-ascii.md
+++ b/docs/superpowers/plans/2026-03-29-state-vector-dsl-controlled-ascii.md
@@ -1,48 +1,48 @@
-# State Vector DSL Controlled ASCII Implementation Plan
+# 状態ベクトル DSL 制御付き ASCII 実装計画
 
-> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **エージェント作業者向け:** 必須: この計画を実装するときは、利用可能なら superpowers:subagent-driven-development を使う。利用できない場合は superpowers:executing-plans を使う。進捗管理にはチェックボックス（`- [ ]`）記法を使う。
 
-**Goal:** `state_flip.feature` の controlled 検証 scenario を state-vector DSL にそろえ、`2 qubit + control` の ASCII 回路と `Ry(π/2)` のような角度つき ASCII 拡張を読めるようにする。
+**目的:** `state_flip.feature` の制御付き検証シナリオを状態ベクトル DSL にそろえ、2 量子ビットと制御を含む ASCII 回路と `Ry(π/2)` のような角度付き ASCII 拡張を読めるようにする。
 
-**Architecture:** まず feature-first で controlled scenario と parser acceptance を赤くし、`初期状態ベクトルは:` の 2 qubit 対応を最小実装する。その後、`AsciiCircuitParser` を「複数 wire を step ごとに読む」形へ広げて 2 qubit controlled / swap を通し、最後に angled gate の ASCII 拡張を 1 qubit から追加する。`qni view` 自体は変更せず、角度つき表記は parser 拡張 DSL として扱う。
+**構成:** まず機能仕様を先に書く方針で、制御付きシナリオとパーサーの受け入れ仕様を赤くし、`初期状態ベクトルは:` の 2 量子ビット対応を最小実装する。その後、`AsciiCircuitParser` を「複数ワイヤーをステップごとに読む」形へ広げて 2 量子ビットの制御付きゲート / swap を通し、最後に角度付きゲートの ASCII 拡張を 1 量子ビットから追加する。`qni view` 自体は変更せず、角度付き表記はパーサー拡張 DSL として扱う。
 
-**Tech Stack:** Ruby, Cucumber, Minitest, Bundler, `qni-cli`
+**技術構成:** Ruby, Cucumber, Minitest, Bundler, `qni-cli`
 
 ---
 
-## File Structure
+## ファイル構成
 
-- Modify: `features/katas/basic_gates/state_flip.feature`
-  - controlled 検証 scenario を `初期状態ベクトルは:` / `次の回路を適用:` / `状態ベクトルは:` の形へそろえる。
-- Modify: `features/ascii_circuit_parser.feature`
-  - 2 qubit controlled ASCII と angled gate ASCII の受け入れ scenario を追加する。
-- Modify: `features/step_definitions/cli_steps.rb`
-  - `初期状態ベクトルは:` の 2 qubit 対応と、必要なら 2 qubit symbolic の比較補助を追加する。
-- Modify: `test/qni/view/ascii_circuit_parser_test.rb`
-  - 2 qubit controlled gate、2 qubit swap、angled gate ASCII の parser unit test を追加する。
-- Modify: `lib/qni/view/ascii_circuit_parser.rb`
-  - 1 qubit 固定幅専用 parser から、2 qubit fixed gate / control / swap と angled gate 拡張を読める parser へ広げる。
-- Optionally modify: `lib/qni/view/ascii_step_cell.rb`
-  - fixed gate cell 判定と angled gate label 判定の責務を整理する。
-- Optionally modify: `lib/qni/view/ascii_step_rows.rb`
-  - 1 wire 専用の固定幅分割責務を、複数 wire / 可変幅 step 分割へ適応させる。
-- Optionally create: `lib/qni/view/ascii_step_parser.rb`
-  - 1 step 分の複数 qubit placement を判定する責務を切り出す場合に追加する。
+- 変更: `features/katas/basic_gates/state_flip.feature`
+  - 制御付き検証シナリオを `初期状態ベクトルは:` / `次の回路を適用:` / `状態ベクトルは:` の形へそろえる。
+- 変更: `features/ascii_circuit_parser.feature`
+  - 2 量子ビット制御付き ASCII と角度付きゲート ASCII の受け入れシナリオを追加する。
+- 変更: `features/step_definitions/cli_steps.rb`
+  - `初期状態ベクトルは:` の 2 量子ビット対応と、必要なら 2 量子ビットの記号的な比較補助を追加する。
+- 変更: `test/qni/view/ascii_circuit_parser_test.rb`
+  - 2 量子ビット制御付きゲート、2 量子ビット swap、角度付きゲート ASCII のパーサー単体テストを追加する。
+- 変更: `lib/qni/view/ascii_circuit_parser.rb`
+  - 1 量子ビット固定幅専用パーサーから、2 量子ビットの固定幅ゲート / 制御 / swap と角度付きゲート拡張を読めるパーサーへ広げる。
+- 必要なら変更: `lib/qni/view/ascii_step_cell.rb`
+  - 固定幅ゲートセル判定と角度付きゲートラベル判定の責務を整理する。
+- 必要なら変更: `lib/qni/view/ascii_step_rows.rb`
+  - 1 ワイヤー専用の固定幅分割責務を、複数ワイヤー / 可変幅ステップ分割へ適応させる。
+- 必要なら作成: `lib/qni/view/ascii_step_parser.rb`
+  - 1 ステップ分の複数量子ビット配置を判定する責務を切り出す場合に追加する。
 
-## Task 1: controlled scenario を理想形で先に赤くする
+## タスク 1: 制御付きシナリオを理想形で先に赤くする
 
-**Files:**
-- Modify: `features/katas/basic_gates/state_flip.feature`
-- Modify: `features/ascii_circuit_parser.feature`
-- Test: `features/katas/basic_gates/state_flip.feature`
-- Test: `features/ascii_circuit_parser.feature`
+**対象ファイル:**
+- 変更: `features/katas/basic_gates/state_flip.feature`
+- 変更: `features/ascii_circuit_parser.feature`
+- テスト: `features/katas/basic_gates/state_flip.feature`
+- テスト: `features/ascii_circuit_parser.feature`
 
-- [ ] **Step 1: `state_flip.feature` の controlled scenario を理想形へ書き換える**
+- [ ] **ステップ 1: `state_flip.feature` の制御付きシナリオを理想形へ書き換える**
 
-`features/katas/basic_gates/state_flip.feature` の最後の scenario を、次の形へ置き換える。
+`features/katas/basic_gates/state_flip.feature` の最後のシナリオを、次の形へ置き換える。
 
 ```gherkin
-Scenario: controlled な X 検証回路は control qubit を |0> に戻す
+Scenario: 制御付き X 検証回路は制御量子ビットを |0> に戻す
   Given 初期状態ベクトルは:
     """
     0.6|00> + 0.8|01>
@@ -61,12 +61,12 @@ Scenario: controlled な X 検証回路は control qubit を |0> に戻す
     """
 ```
 
-- [ ] **Step 2: ASCII parser acceptance を追加する**
+- [ ] **ステップ 2: ASCII パーサーの受け入れ仕様を追加する**
 
-`features/ascii_circuit_parser.feature` に、少なくとも次の 2 scenario を追加する。
+`features/ascii_circuit_parser.feature` に、少なくとも次の 2 シナリオを追加する。
 
 ```gherkin
-Scenario: 2 qubit の controlled X 回路を ASCII アートから作る
+Scenario: 2 量子ビットの制御付き X 回路を ASCII アートから作る
   Given 次の回路がある:
     """
         ┌───┐
@@ -75,14 +75,14 @@ Scenario: 2 qubit の controlled X 回路を ASCII アートから作る
     q1: ┤ X ├
         └───┘
     """
-  Given 2 qubit の初期状態が "|10>" である
+  Given 2 量子ビットの初期状態が "|10>" である
   When "qni run" を実行
   Then 標準出力:
     """
     0.0,0.0,0.0,1.0
     """
 
-Scenario: 1 qubit の Ry(π/2) 回路を拡張 ASCII から作る
+Scenario: 1 量子ビットの Ry(π/2) 回路を拡張 ASCII から作る
   Given 次の回路がある:
     """
         ┌─────────┐
@@ -95,11 +95,11 @@ Scenario: 1 qubit の Ry(π/2) 回路を拡張 ASCII から作る
     """
 ```
 
-最初の scenario は `qni view` 互換寄り、2 本目は parser 拡張 DSL 用の acceptance とする。
+最初のシナリオは `qni view` 互換寄り、2 本目はパーサー拡張 DSL 用の受け入れ仕様とする。
 
-- [ ] **Step 3: red を確認する**
+- [ ] **ステップ 3: 赤になることを確認する**
 
-Run:
+実行:
 
 ```bash
 bundle exec cucumber \
@@ -107,40 +107,40 @@ bundle exec cucumber \
   features/ascii_circuit_parser.feature
 ```
 
-Expected:
+期待結果:
 
-- controlled scenario が undefined か failure で赤くなる
-- ASCII parser acceptance が parser 非対応で赤くなる
+- 制御付きシナリオが未定義か失敗で赤くなる
+- ASCII パーサーの受け入れ仕様がパーサー非対応で赤くなる
 
-- [ ] **Step 4: feature-first の red をコミットする**
+- [ ] **ステップ 4: 機能仕様を先に書いた赤の状態をコミットする**
 
 ```bash
 git add features/katas/basic_gates/state_flip.feature features/ascii_circuit_parser.feature
 git commit -m "test: add controlled ASCII DSL scenarios"
 ```
 
-## Task 2: `初期状態ベクトルは:` を 2 qubit へ広げる
+## タスク 2: `初期状態ベクトルは:` を 2 量子ビットへ広げる
 
-**Files:**
-- Modify: `features/step_definitions/cli_steps.rb`
-- Optionally modify: `features/katas/basic_gates/state_flip.feature`
-- Test: `features/katas/basic_gates/state_flip.feature`
+**対象ファイル:**
+- 変更: `features/step_definitions/cli_steps.rb`
+- 必要なら変更: `features/katas/basic_gates/state_flip.feature`
+- テスト: `features/katas/basic_gates/state_flip.feature`
 
-- [ ] **Step 1: 2 qubit 初期状態の failing expectation を明確にする**
+- [ ] **ステップ 1: 2 量子ビット初期状態の失敗期待を明確にする**
 
-`features/katas/basic_gates/state_flip.feature` の controlled scenario だけを実行し、`0.6|00> + 0.8|01>` が未対応で落ちることを確認する。
+`features/katas/basic_gates/state_flip.feature` の制御付きシナリオだけを実行し、`0.6|00> + 0.8|01>` が未対応で落ちることを確認する。
 
-Run:
+実行:
 
 ```bash
 bundle exec cucumber features/katas/basic_gates/state_flip.feature:78
 ```
 
-Expected:
+期待結果:
 
 - `unsupported ... initial state` か、それに準ずる失敗が出る
 
-- [ ] **Step 2: `cli_steps.rb` に 2 qubit の state-vector setup を足す**
+- [ ] **ステップ 2: `cli_steps.rb` に 2 量子ビットの状態ベクトル準備を足す**
 
 `features/step_definitions/cli_steps.rb` に、少なくとも次の対応を追加する。
 
@@ -154,42 +154,42 @@ TWO_QUBIT_INITIAL_STATE_COLS = {
 }.freeze
 ```
 
-`Given('初期状態ベクトルは:')` は、`|...>` の桁数や登録済み literal を見て 1 qubit / 2 qubit を切り替える。
+`Given('初期状態ベクトルは:')` は、`|...>` の桁数や登録済みリテラルを見て 1 量子ビット / 2 量子ビットを切り替える。
 
-- [ ] **Step 3: controlled scenario の state setup だけ green にする**
+- [ ] **ステップ 3: 制御付きシナリオの状態準備だけを緑にする**
 
-Run:
+実行:
 
 ```bash
 bundle exec cucumber features/katas/basic_gates/state_flip.feature
 ```
 
-Expected:
+期待結果:
 
-- 初期状態の failure は消える
+- 初期状態の失敗は消える
 - ただし `次の回路を適用:` 側がまだ赤でもよい
 
-- [ ] **Step 4: state-vector setup 拡張をコミットする**
+- [ ] **ステップ 4: 状態ベクトル準備の拡張をコミットする**
 
 ```bash
 git add features/step_definitions/cli_steps.rb
 git commit -m "feat: support 2-qubit state-vector DSL setup"
 ```
 
-## Task 3: 2 qubit controlled / swap を読む parser 基盤を作る
+## タスク 3: 2 量子ビットの制御付きゲート / swap を読むパーサー基盤を作る
 
-**Files:**
-- Modify: `lib/qni/view/ascii_circuit_parser.rb`
-- Optionally modify: `lib/qni/view/ascii_step_cell.rb`
-- Optionally modify: `lib/qni/view/ascii_step_rows.rb`
-- Optionally create: `lib/qni/view/ascii_step_parser.rb`
-- Modify: `test/qni/view/ascii_circuit_parser_test.rb`
-- Test: `test/qni/view/ascii_circuit_parser_test.rb`
-- Test: `features/ascii_circuit_parser.feature`
+**対象ファイル:**
+- 変更: `lib/qni/view/ascii_circuit_parser.rb`
+- 必要なら変更: `lib/qni/view/ascii_step_cell.rb`
+- 必要なら変更: `lib/qni/view/ascii_step_rows.rb`
+- 必要なら作成: `lib/qni/view/ascii_step_parser.rb`
+- 変更: `test/qni/view/ascii_circuit_parser_test.rb`
+- テスト: `test/qni/view/ascii_circuit_parser_test.rb`
+- テスト: `features/ascii_circuit_parser.feature`
 
-- [ ] **Step 1: unit test で 2 qubit controlled X を赤くする**
+- [ ] **ステップ 1: 単体テストで 2 量子ビットの制御付き X を赤くする**
 
-`test/qni/view/ascii_circuit_parser_test.rb` に、少なくとも次の fixture と期待値を追加する。
+`test/qni/view/ascii_circuit_parser_test.rb` に、少なくとも次のフィクスチャと期待値を追加する。
 
 ```ruby
 CONTROLLED_X_GATE = <<~CIRCUIT
@@ -215,36 +215,36 @@ end
 
 必要なら `SWAP` の最小ケースも同時に赤くする。
 
-- [ ] **Step 2: parser を「複数 wire の step placement」中心へ最小リファクタする**
+- [ ] **ステップ 2: パーサーを「複数ワイヤーのステップ配置」中心へ最小リファクタリングする**
 
 実装方針:
 
 - 各 `qN:` 行を抽出する
-- wire 全体を step ごとに分割する
-- 各 step について、qubit ごとのセル集合から placement を判定する
-- placement が
-  - single gate なら `Circuit#add_gate`
-  - controlled gate なら `Circuit#add_controlled_gate`
+- ワイヤー全体をステップごとに分割する
+- 各ステップについて、量子ビットごとのセル集合から配置を判定する
+- 配置が
+  - 単一ゲートなら `Circuit#add_gate`
+  - 制御付きゲートなら `Circuit#add_controlled_gate`
   - swap なら `Circuit#add_swap_gate`
   へ落とす
 
-最初の green 対象は `2 qubit + controlled X + fixed-width` のみでよい。
+最初に緑にする対象は 2 量子ビットの制御付き X 固定幅回路のみでよい。
 
-- [ ] **Step 3: 2 qubit parser unit / acceptance を green にする**
+- [ ] **ステップ 3: 2 量子ビットパーサーの単体テスト / 受け入れ仕様を緑にする**
 
-Run:
+実行:
 
 ```bash
 bundle exec ruby -Itest test/qni/view/ascii_circuit_parser_test.rb
 bundle exec cucumber features/ascii_circuit_parser.feature
 ```
 
-Expected:
+期待結果:
 
-- controlled X の unit test が PASS
-- 2 qubit controlled ASCII の feature が PASS
+- 制御付き X の単体テストが PASS
+- 2 量子ビット制御付き ASCII の機能仕様が PASS
 
-- [ ] **Step 4: parser 基盤変更をコミットする**
+- [ ] **ステップ 4: パーサー基盤変更をコミットする**
 
 ```bash
 git add \
@@ -256,61 +256,61 @@ git add \
 git commit -m "feat: parse 2-qubit controlled ASCII circuits"
 ```
 
-実際に作成 / 変更した file だけ `git add` する。
+実際に作成 / 変更したファイルだけ `git add` する。
 
-## Task 4: controlled scenario を green にする
+## タスク 4: 制御付きシナリオを緑にする
 
-**Files:**
-- Modify: `features/katas/basic_gates/state_flip.feature`
-- Modify: `features/step_definitions/cli_steps.rb`
-- Test: `features/katas/basic_gates/state_flip.feature`
+**対象ファイル:**
+- 変更: `features/katas/basic_gates/state_flip.feature`
+- 変更: `features/step_definitions/cli_steps.rb`
+- テスト: `features/katas/basic_gates/state_flip.feature`
 
-- [ ] **Step 1: controlled scenario だけを再実行する**
+- [ ] **ステップ 1: 制御付きシナリオだけを再実行する**
 
-Run:
-
-```bash
-bundle exec cucumber features/katas/basic_gates/state_flip.feature
-```
-
-Expected:
-
-- controlled scenario だけが残っていれば、その failure が局所化される
-
-- [ ] **Step 2: symbolic 比較や literal 表記の差分を最小修正で吸収する**
-
-必要なら `features/step_definitions/cli_steps.rb` の `assert_symbolic_state_matches!` にだけ最小修正を入れる。ここでは 2 qubit ket 表記や係数 1 の省略で余計な一般化をしない。
-
-- [ ] **Step 3: `state_flip.feature` を green にする**
-
-Run:
+実行:
 
 ```bash
 bundle exec cucumber features/katas/basic_gates/state_flip.feature
 ```
 
-Expected:
+期待結果:
 
-- `state_flip.feature` の全 scenario が PASS
+- 制御付きシナリオだけが残っていれば、その失敗が局所化される
 
-- [ ] **Step 4: controlled scenario の green をコミットする**
+- [ ] **ステップ 2: 記号的な比較やリテラル表記の差分を最小修正で吸収する**
+
+必要なら `features/step_definitions/cli_steps.rb` の `assert_symbolic_state_matches!` にだけ最小修正を入れる。ここでは 2 量子ビット ket 表記や係数 1 の省略で余計な一般化をしない。
+
+- [ ] **ステップ 3: `state_flip.feature` を緑にする**
+
+実行:
+
+```bash
+bundle exec cucumber features/katas/basic_gates/state_flip.feature
+```
+
+期待結果:
+
+- `state_flip.feature` の全シナリオが PASS
+
+- [ ] **ステップ 4: 制御付きシナリオの緑をコミットする**
 
 ```bash
 git add features/katas/basic_gates/state_flip.feature features/step_definitions/cli_steps.rb
 git commit -m "feat: rewrite controlled StateFlip scenario"
 ```
 
-## Task 5: angled gate の ASCII 拡張を追加する
+## タスク 5: 角度付きゲートの ASCII 拡張を追加する
 
-**Files:**
-- Modify: `lib/qni/view/ascii_circuit_parser.rb`
-- Optionally modify: `lib/qni/view/ascii_step_cell.rb`
-- Modify: `test/qni/view/ascii_circuit_parser_test.rb`
-- Modify: `features/ascii_circuit_parser.feature`
-- Test: `test/qni/view/ascii_circuit_parser_test.rb`
-- Test: `features/ascii_circuit_parser.feature`
+**対象ファイル:**
+- 変更: `lib/qni/view/ascii_circuit_parser.rb`
+- 必要なら変更: `lib/qni/view/ascii_step_cell.rb`
+- 変更: `test/qni/view/ascii_circuit_parser_test.rb`
+- 変更: `features/ascii_circuit_parser.feature`
+- テスト: `test/qni/view/ascii_circuit_parser_test.rb`
+- テスト: `features/ascii_circuit_parser.feature`
 
-- [ ] **Step 1: `Ry(π/2)` の unit / acceptance を赤くする**
+- [ ] **ステップ 1: `Ry(π/2)` の単体テスト / 受け入れ仕様を赤くする**
 
 `test/qni/view/ascii_circuit_parser_test.rb` に次を追加する。
 
@@ -334,34 +334,34 @@ def test_parse_angled_ry_gate_circuit
 end
 ```
 
-`features/ascii_circuit_parser.feature` の `Ry(π/2)` scenario もこの時点で red を確認する。
+`features/ascii_circuit_parser.feature` の `Ry(π/2)` シナリオもこの時点で赤を確認する。
 
-- [ ] **Step 2: angled gate label 判定を追加する**
+- [ ] **ステップ 2: 角度付きゲートラベル判定を追加する**
 
 実装方針:
 
-- fixed gate label lookup と angled gate label lookup を分ける
-- angled gate は `Name(angle)` の形をそのまま serialized gate として返す
+- 固定幅ゲートのラベル探索と角度付きゲートのラベル探索を分ける
+- 角度付きゲートは `Name(angle)` の形をそのままシリアライズ済みゲートとして返す
 - `Name` は `P`, `Rx`, `Ry`, `Rz` に限定する
 - `angle` は既存 `AngleExpression` が読める文字列だけ通す
 
-ここでは 1 qubit / single gate / single step から始め、2 qubit controlled target への angled gate は将来拡張に回してよい。
+ここでは 1 量子ビット / 単一ゲート / 単一ステップから始め、2 量子ビット制御付きゲートの対象への角度付きゲートは将来拡張に回してよい。
 
-- [ ] **Step 3: angled gate parser の focused green を確認する**
+- [ ] **ステップ 3: 角度付きゲートパーサーの対象を絞った緑を確認する**
 
-Run:
+実行:
 
 ```bash
 bundle exec ruby -Itest test/qni/view/ascii_circuit_parser_test.rb
 bundle exec cucumber features/ascii_circuit_parser.feature
 ```
 
-Expected:
+期待結果:
 
-- `Ry(π/2)` の unit / acceptance が PASS
-- 既存 1 qubit / 2 qubit controlled parser が回帰していない
+- `Ry(π/2)` の単体テスト / 受け入れ仕様が PASS
+- 既存の 1 量子ビット / 2 量子ビット制御付きパーサーが回帰していない
 
-- [ ] **Step 4: angled gate ASCII 拡張をコミットする**
+- [ ] **ステップ 4: 角度付きゲート ASCII 拡張をコミットする**
 
 ```bash
 git add \
@@ -372,17 +372,17 @@ git add \
 git commit -m "feat: support angled gate ASCII syntax"
 ```
 
-## Task 6: focused 回帰と全量確認をする
+## タスク 6: 対象を絞った回帰確認と全量確認をする
 
-**Files:**
-- Test: `features/katas/basic_gates/state_flip.feature`
-- Test: `features/ascii_circuit_parser.feature`
-- Test: `test/qni/view/ascii_circuit_parser_test.rb`
-- Test: repository-wide checks
+**対象ファイル:**
+- テスト: `features/katas/basic_gates/state_flip.feature`
+- テスト: `features/ascii_circuit_parser.feature`
+- テスト: `test/qni/view/ascii_circuit_parser_test.rb`
+- テスト: リポジトリ全体の確認
 
-- [ ] **Step 1: focused parser / DSL 回帰を実行する**
+- [ ] **ステップ 1: 対象を絞ったパーサー / DSL 回帰確認を実行する**
 
-Run:
+実行:
 
 ```bash
 bundle exec ruby -Itest test/qni/view/ascii_circuit_parser_test.rb
@@ -397,26 +397,26 @@ bundle exec rubocop \
   test/qni/view/ascii_circuit_parser_test.rb
 ```
 
-Expected:
+期待結果:
 
-- focused tests と RuboCop が PASS
+- 対象を絞ったテストと RuboCop が PASS
 
-- [ ] **Step 2: repo 全体の確認を実行する**
+- [ ] **ステップ 2: リポジトリ全体の確認を実行する**
 
-Run:
+実行:
 
 ```bash
 bundle exec rake check
 ```
 
-Expected:
+期待結果:
 
 - RuboCop, Cucumber, Reek, Flog, Flay を含む既存チェックが PASS
 
-- [ ] **Step 3: 最終確認コミットを作る**
+- [ ] **ステップ 3: 最終確認コミットを作る**
 
 ```bash
 git commit --allow-empty -m "test: verify controlled ASCII DSL support"
 ```
 
-この commit は verification 済みの区切りとして使う。不要ならスキップしてよいが、plan 実行時は verification の終了点を明確に残す。
+このコミットは検証済みの区切りとして使う。不要ならスキップしてよいが、計画実行時は検証の終了点を明確に残す。

--- a/docs/superpowers/plans/2026-03-29-state-vector-dsl-controlled-ascii.md
+++ b/docs/superpowers/plans/2026-03-29-state-vector-dsl-controlled-ascii.md
@@ -75,7 +75,7 @@ Scenario: 2 量子ビットの制御付き X 回路を ASCII アートから作�
     q1: ┤ X ├
         └───┘
     """
-  Given 2 量子ビットの初期状態が "|10>" である
+  Given 2 qubit の初期状態が "|10>" である
   When "qni run" を実行
   Then 標準出力:
     """
@@ -241,8 +241,8 @@ bundle exec cucumber features/ascii_circuit_parser.feature
 
 期待結果:
 
-- 制御付き X の単体テストが PASS
-- 2 量子ビット制御付き ASCII の機能仕様が PASS
+- 制御付き X の単体テストが成功する
+- 2 量子ビット制御付き ASCII の機能仕様が成功する
 
 - [ ] **ステップ 4: パーサー基盤変更をコミットする**
 
@@ -291,7 +291,7 @@ bundle exec cucumber features/katas/basic_gates/state_flip.feature
 
 期待結果:
 
-- `state_flip.feature` の全シナリオが PASS
+- `state_flip.feature` の全シナリオが成功する
 
 - [ ] **ステップ 4: 制御付きシナリオの緑をコミットする**
 
@@ -358,7 +358,7 @@ bundle exec cucumber features/ascii_circuit_parser.feature
 
 期待結果:
 
-- `Ry(π/2)` の単体テスト / 受け入れ仕様が PASS
+- `Ry(π/2)` の単体テスト / 受け入れ仕様が成功する
 - 既存の 1 量子ビット / 2 量子ビット制御付きパーサーが回帰していない
 
 - [ ] **ステップ 4: 角度付きゲート ASCII 拡張をコミットする**
@@ -399,7 +399,7 @@ bundle exec rubocop \
 
 期待結果:
 
-- 対象を絞ったテストと RuboCop が PASS
+- 対象を絞ったテストと RuboCop が成功する
 
 - [ ] **ステップ 2: リポジトリ全体の確認を実行する**
 
@@ -411,7 +411,7 @@ bundle exec rake check
 
 期待結果:
 
-- RuboCop, Cucumber, Reek, Flog, Flay を含む既存チェックが PASS
+- RuboCop, Cucumber, Reek, Flog, Flay を含む既存チェックがすべて成功する
 
 - [ ] **ステップ 3: 最終確認コミットを作る**
 


### PR DESCRIPTION
## 概要

- YAS-279
- `docs/superpowers/plans/2026-03-29-state-vector-dsl-controlled-ascii.md` の英語見出しと普通名詞混在を自然な日本語へ直しました。
- レビュー指摘を受け、本文の期待状態に残っていた `PASS` を日本語化しました。
- Gherkin ブロック内の実行されるステップ本文は、既存ステップ定義に合わせて `Given 2 qubit の初期状態が "|10>" である` に戻しました。
- ファイルパス、コマンド、コード識別子、コミットメッセージ例など、原文維持すべき語はそのまま残しています。

## 検証

- `git diff --check`
- `bundle exec rake check`

## 備考

- `symphony` ラベルはリポジトリに存在しなかったため未設定です。
