### PR TITLE
位相反転計画書の文体を整理

### DIFF
--- a/docs/superpowers/plans/2026-03-31-phase-flip-y-basis.md
+++ b/docs/superpowers/plans/2026-03-31-phase-flip-y-basis.md
@@ -1,240 +1,240 @@
-# Phase Flip High-Level Y-Basis Implementation Plan
+# 位相反転の高水準 Y 基底実装計画
 
-> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **自律エージェント作業者向け:** 必須: この計画を実装するときは、サブエージェントを利用できる場合は superpowers:subagent-driven-development を、利用できない場合は superpowers:executing-plans を使う。各手順は進捗管理のためチェックボックス（`- [ ]`）形式で書いている。
 
-**Goal:** Rewrite Task 1.5 `phase_flip.feature` in the same high-level style as Tasks 1.1〜1.4, while adding Y-basis state display and `|+i>` / `|-i>` shorthand so the action of the `S` gate can be read naturally.
+**目的:** タスク 1.5 の `phase_flip.feature` をタスク 1.1〜1.4 と同じ高水準の文体で書き直す。あわせて、Y 基底での状態表示と `|+i>` / `|-i>` の短縮表記を追加し、`S` ゲートの作用を自然に読めるようにする。
 
-**Architecture:** Reuse the existing symbolic-state pipeline. Extend `InitialState` with Y-basis shorthand, extend the symbolic Python helper with a `y` basis renderer for 1-qubit circuits, add a dedicated feature step for Y-basis assertions, and then rewrite `phase_flip.feature` to use only high-level state/circuit DSL.
+**構成:** 既存の記号的状態表示の処理経路を再利用する。`InitialState` に Y 基底の短縮表記を追加し、記号計算用の Python 補助処理に 1 量子ビット回路向けの `y` 基底表示を追加する。さらに Y 基底の検証専用ステップを追加してから、`phase_flip.feature` を高水準の状態・回路 DSL だけで書き直す。
 
-**Tech Stack:** Ruby, Thor, Cucumber, Minitest, Python, SymPy, existing `InitialState`, `SymbolicStateRenderer`, `qni_symbolic_run.py`, kata features
+**技術要素:** Ruby、Thor、Cucumber、Minitest、Python、SymPy、既存の `InitialState`、`SymbolicStateRenderer`、`qni_symbolic_run.py`、kata の機能ファイル
 
 ---
 
-## File Structure
+## ファイル構成
 
-- Modify: `features/qni_state.feature`
-  - Add acceptance for `qni state set "|+i>"` and `qni state set "|-i>"`.
-- Modify: `features/qni_run.feature`
-  - Add acceptance for `qni run --symbolic --basis y`.
-- Modify: `features/qni_cli.feature`
-  - Extend `qni run --help` expectations with `y` basis support.
-- Modify: `features/katas/basic_gates/phase_flip.feature`
-  - Rewrite Task 1.5 scenarios into the high-level DSL.
-- Modify: `features/step_definitions/cli_steps.rb`
-  - Add `Then |+i>, |-i> 基底での状態ベクトルは:` and any normalization helpers required.
-- Modify: `lib/qni/initial_state.rb`
-  - Parse and serialize `|+i>` / `|-i>`.
-- Modify: `lib/qni/symbolic_state_renderer.rb`
-  - Permit `basis: 'y'` under the same 1-qubit constraint as `x`.
-- Modify: `lib/qni/cli/run_help.rb`
-  - Document `--basis y`.
-- Modify: `libexec/qni_symbolic_run.py`
-  - Add Y-basis rendering and any helper normalization for `|+i>` / `|-i>`.
-- Test: `test/qni/initial_state_test.rb`
-  - Add unit coverage for `|+i>` / `|-i>`.
-- Test: `test/qni/symbolic_state_renderer_test.rb`
-  - Add unit coverage for `basis: 'y'` validation if needed.
+- 変更: `features/qni_state.feature`
+  - `qni state set "|+i>"` と `qni state set "|-i>"` の受け入れテストを追加する。
+- 変更: `features/qni_run.feature`
+  - `qni run --symbolic --basis y` の受け入れテストを追加する。
+- 変更: `features/qni_cli.feature`
+  - `qni run --help` の期待値に `y` 基底対応を追加する。
+- 変更: `features/katas/basic_gates/phase_flip.feature`
+  - タスク 1.5 のシナリオを高水準 DSL へ書き直す。
+- 変更: `features/step_definitions/cli_steps.rb`
+  - `Then |+i>, |-i> 基底での状態ベクトルは:` と、必要な正規化補助処理を追加する。
+- 変更: `lib/qni/initial_state.rb`
+  - `|+i>` / `|-i>` を読み込み、保存できるようにする。
+- 変更: `lib/qni/symbolic_state_renderer.rb`
+  - `x` と同じ 1 量子ビット制約の下で `basis: 'y'` を許可する。
+- 変更: `lib/qni/cli/run_help.rb`
+  - `--basis y` を説明する。
+- 変更: `libexec/qni_symbolic_run.py`
+  - Y 基底表示と、`|+i>` / `|-i>` に必要な正規化補助処理を追加する。
+- テスト: `test/qni/initial_state_test.rb`
+  - `|+i>` / `|-i>` の単体テストを追加する。
+- テスト: `test/qni/symbolic_state_renderer_test.rb`
+  - 必要であれば `basis: 'y'` の検証を単体テストに追加する。
 
-### Task 1: Add failing acceptance coverage for Y-basis and shorthand
+### タスク 1: Y 基底と短縮表記の失敗する受け入れテストを追加する
 
-**Files:**
-- Modify: `features/qni_state.feature`
-- Modify: `features/qni_run.feature`
-- Modify: `features/qni_cli.feature`
+**対象ファイル:**
+- 変更: `features/qni_state.feature`
+- 変更: `features/qni_run.feature`
+- 変更: `features/qni_cli.feature`
 
-- [ ] **Step 1: Extend `qni state` acceptance with Y-basis shorthand**
+- [ ] **手順 1: `qni state` の受け入れテストに Y 基底の短縮表記を追加する**
 
-Add scenarios to `features/qni_state.feature` for:
-- `qni state set "|+i>"` stores a 1-qubit initial state and `qni state show` prints `|+i>`
-- `qni state set "|-i>"` stores a 1-qubit initial state and `qni state show` prints `|-i>`
+`features/qni_state.feature` に次のシナリオを追加する。
+- `qni state set "|+i>"` が 1 量子ビットの初期状態を保存し、`qni state show` が `|+i>` を出力する
+- `qni state set "|-i>"` が 1 量子ビットの初期状態を保存し、`qni state show` が `|-i>` を出力する
 
-- [ ] **Step 2: Extend symbolic run acceptance with Y basis**
+- [ ] **手順 2: 記号的な実行の受け入れテストに Y 基底を追加する**
 
-Add scenarios to `features/qni_run.feature` for:
-- `qni run --symbolic --basis y` showing `|+i>` after applying `S` to `|+>`
-- `qni run --symbolic --basis y` showing a general result such as `alpha|+i> + beta|-i>` if appropriate
-- rejecting `--basis y` on 2-qubit circuits with a clear error, parallel to the existing X-basis restriction
+`features/qni_run.feature` に次のシナリオを追加する。
+- `qni run --symbolic --basis y` が、`S` を `|+>` に適用した後に `|+i>` を表示する
+- 適切であれば、`qni run --symbolic --basis y` が `alpha|+i> + beta|-i>` のような一般的な結果を表示する
+- 2 量子ビット回路で `--basis y` を指定した場合、既存の X 基底制約と同じように明確なエラーで拒否する
 
-- [ ] **Step 3: Extend CLI help expectations**
+- [ ] **手順 3: CLI ヘルプの期待値を広げる**
 
-Update `features/qni_cli.feature` so `qni run --help` and related help text mention that `--basis` supports both `x` and `y` for symbolic 1-qubit output.
+`features/qni_cli.feature` を更新し、`qni run --help` と関連するヘルプ文で、`--basis` が記号的な 1 量子ビット出力として `x` と `y` の両方を扱えることを示す。
 
-- [ ] **Step 4: Run focused cucumber and verify RED**
+- [ ] **手順 4: 対象を絞った Cucumber を実行し、失敗を確認する**
 
-Run:
+実行する。
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec cucumber features/qni_state.feature features/qni_run.feature features/qni_cli.feature
 ```
 
-Expected: FAIL because `|+i>`, `|-i>`, and `--basis y` are not implemented yet.
+期待値: `|+i>`、`|-i>`、`--basis y` はまだ実装されていないため失敗する。
 
-### Task 2: Add Y-basis shorthand to `InitialState`
+### タスク 2: `InitialState` に Y 基底の短縮表記を追加する
 
-**Files:**
-- Modify: `lib/qni/initial_state.rb`
-- Modify: `test/qni/initial_state_test.rb`
+**対象ファイル:**
+- 変更: `lib/qni/initial_state.rb`
+- 変更: `test/qni/initial_state_test.rb`
 
-- [ ] **Step 1: Add failing unit tests**
+- [ ] **手順 1: 失敗する単体テストを追加する**
 
-Add tests for:
-- parsing `|+i>`
-- parsing `|-i>`
-- serializing those states back to shorthand form if shorthand display is the chosen rule
+次のテストを追加する。
+- `|+i>` の読み込み
+- `|-i>` の読み込み
+- 短縮表記で表示する方針を採る場合は、それらの状態を短縮表記へ戻す保存処理
 
-- [ ] **Step 2: Run the unit test and confirm failure**
+- [ ] **手順 2: 単体テストを実行し、失敗を確認する**
 
-Run:
+実行する。
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec ruby -Itest test/qni/initial_state_test.rb
 ```
 
-Expected: FAIL because the new shorthand is not recognized.
+期待値: 新しい短縮表記はまだ認識されていないため失敗する。
 
-- [ ] **Step 3: Implement shorthand parsing and display**
+- [ ] **手順 3: 短縮表記の読み込みと表示を実装する**
 
-Extend `InitialState` so:
-- `|+i>` means `(1/sqrt(2))|0> + (i/sqrt(2))|1>`
-- `|-i>` means `(1/sqrt(2))|0> - (i/sqrt(2))|1>`
-- `qni state show` prefers the shorthand when the stored state exactly matches one of these named states
+`InitialState` を拡張し、次を満たすようにする。
+- `|+i>` は `(1/sqrt(2))|0> + (i/sqrt(2))|1>` を意味する
+- `|-i>` は `(1/sqrt(2))|0> - (i/sqrt(2))|1>` を意味する
+- 保存された状態がこれらの名前付き状態のどちらかと完全に一致する場合、`qni state show` は短縮表記を優先する
 
-- [ ] **Step 4: Re-run the unit test**
+- [ ] **手順 4: 単体テストを再実行する**
 
-Make `test/qni/initial_state_test.rb` pass before moving on.
+次へ進む前に、`test/qni/initial_state_test.rb` を成功させる。
 
-### Task 3: Add symbolic Y-basis rendering
+### タスク 3: 記号的な Y 基底表示を追加する
 
-**Files:**
-- Modify: `libexec/qni_symbolic_run.py`
-- Modify: `lib/qni/symbolic_state_renderer.rb`
-- Modify: `test/qni/symbolic_state_renderer_test.rb`
+**対象ファイル:**
+- 変更: `libexec/qni_symbolic_run.py`
+- 変更: `lib/qni/symbolic_state_renderer.rb`
+- 変更: `test/qni/symbolic_state_renderer_test.rb`
 
-- [ ] **Step 1: Add failing tests or focused acceptance**
+- [ ] **手順 1: 失敗するテスト、または対象を絞った受け入れテストを追加する**
 
-Use `features/qni_run.feature` as the primary failing test. Add a unit test only if it clarifies Ruby-side validation.
+主な失敗テストとして `features/qni_run.feature` を使う。Ruby 側の検証を明確にする場合に限り、単体テストを追加する。
 
-- [ ] **Step 2: Implement Y-basis rendering in the Python helper**
+- [ ] **手順 2: Python 補助処理に Y 基底表示を実装する**
 
-Add a renderer analogous to the X-basis renderer.
+X 基底表示と同様の表示処理を追加する。
 
-Target definitions:
+目標とする定義:
 
 ```text
 |+i> = (|0> + i|1>) / sqrt(2)
 |-i> = (|0> - i|1>) / sqrt(2)
 ```
 
-For a computational-basis state `a|0> + b|1>`, derive Y-basis amplitudes and render them with the same symbolic simplification policy used for X basis.
+計算基底の状態 `a|0> + b|1>` について Y 基底の振幅を導出し、X 基底で使っている記号的な簡約方針と同じ方針で表示する。
 
-- [ ] **Step 3: Permit `basis: 'y'` in Ruby**
+- [ ] **手順 3: Ruby で `basis: 'y'` を許可する**
 
-Update `lib/qni/symbolic_state_renderer.rb` so `basis == 'y'` shares the same 1-qubit restriction and helper invocation path as `basis == 'x'`.
+`lib/qni/symbolic_state_renderer.rb` を更新し、`basis == 'y'` が `basis == 'x'` と同じ 1 量子ビット制約および補助処理の呼び出し経路を共有するようにする。
 
-- [ ] **Step 4: Update help text**
+- [ ] **手順 4: ヘルプ文を更新する**
 
-Document `--basis y` in `lib/qni/cli/run_help.rb`.
+`lib/qni/cli/run_help.rb` で `--basis y` を説明する。
 
-- [ ] **Step 5: Run focused acceptance**
+- [ ] **手順 5: 対象を絞った受け入れテストを実行する**
 
-Run:
+実行する。
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec cucumber features/qni_state.feature features/qni_run.feature features/qni_cli.feature
 ```
 
-Expected: GREEN for the new Y-basis behavior.
+期待値: 新しい Y 基底の動作が成功する。
 
-### Task 4: Add a high-level Y-basis feature step
+### タスク 4: 高水準の Y 基底ステップ定義を追加する
 
-**Files:**
-- Modify: `features/step_definitions/cli_steps.rb`
+**対象ファイル:**
+- 変更: `features/step_definitions/cli_steps.rb`
 
-- [ ] **Step 1: Add the failing step usage in a kata feature**
+- [ ] **手順 1: kata の機能ファイルに失敗するステップの使用例を追加する**
 
-Before implementing the step, rewrite one `phase_flip.feature` scenario to use:
+ステップ定義を実装する前に、`phase_flip.feature` のシナリオを 1 つ書き換え、次を使う。
 
 ```gherkin
 Then |+i>, |-i> 基底での状態ベクトルは:
 ```
 
-and confirm it fails as an undefined step or behavior mismatch.
+未定義ステップ、または動作不一致として失敗することを確認する。
 
-- [ ] **Step 2: Implement the step**
+- [ ] **手順 2: ステップ定義を実装する**
 
-Add a helper that runs:
+次を実行する補助処理を追加する。
 
 ```text
 qni run --symbolic --basis y
 ```
 
-and compares the output against normalized Y-basis notation. Reuse the current symbolic comparison helpers where possible; add only the minimum Y-basis normalization needed.
+そのうえで、出力を正規化した Y 基底表記と比較する。既存の記号的な比較補助処理をできるだけ再利用し、Y 基底に必要な最小限の正規化だけを追加する。
 
-- [ ] **Step 3: Verify the new step**
+- [ ] **手順 3: 新しいステップ定義を検証する**
 
-Run the relevant kata feature slice and confirm the step behaves correctly.
+関連する kata の機能ファイルの範囲を実行し、ステップ定義が正しく動作することを確認する。
 
-### Task 5: Rewrite `phase_flip.feature` into the high-level DSL
+### タスク 5: `phase_flip.feature` を高水準 DSL へ書き直す
 
-**Files:**
-- Modify: `features/katas/basic_gates/phase_flip.feature`
+**対象ファイル:**
+- 変更: `features/katas/basic_gates/phase_flip.feature`
 
-- [ ] **Step 1: Replace low-level scenarios with high-level ones**
+- [ ] **手順 1: 低水準のシナリオを高水準のシナリオへ置き換える**
 
-Rewrite the feature around scenarios like:
+次のようなシナリオを中心に機能ファイルを書き直す。
 - `S ゲートは |0> を変えない`
 - `S ゲートは |1> に i を掛ける`
 - `S ゲートは |+> を |+i> に変える`
 - `S ゲートは α|0> + β|1> を α|0> + iβ|1> に変える`
 
-Use:
+使うステップ:
 - `Given 初期状態ベクトルは:`
 - `When 次の回路を適用:`
 - `Then 状態ベクトルは:`
 - `Then |+i>, |-i> 基底での状態ベクトルは:`
 
-- [ ] **Step 2: Remove the controlled verification scenario**
+- [ ] **手順 2: 制御付きの検証シナリオを削除する**
 
-Delete the old low-level controlled scenario so the feature matches the educational, high-level style used by Tasks 1.1〜1.4.
+古い低水準の制御付きシナリオを削除し、タスク 1.1〜1.4 で使っている教育向けの高水準文体に機能ファイルを合わせる。
 
-- [ ] **Step 3: Run the kata feature in isolation**
+- [ ] **手順 3: kata の機能ファイルを単独で実行する**
 
-Run:
+実行する。
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec cucumber features/katas/basic_gates/phase_flip.feature
 ```
 
-Expected: GREEN with the new high-level wording and Y-basis step.
+期待値: 新しい高水準の文言と Y 基底ステップで成功する。
 
-### Task 6: Full regression and cleanup
+### タスク 6: 全体回帰確認と仕上げ
 
-**Files:**
-- Modify only as needed based on regressions
+**対象ファイル:**
+- 回帰に応じて必要な範囲だけ変更する
 
-- [ ] **Step 1: Run full check**
+- [ ] **手順 1: 全体チェックを実行する**
 
-Run:
+実行する。
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec rake check
 ```
 
-Expected: all suites pass cleanly.
+期待値: すべてのテストが問題なく成功する。
 
-- [ ] **Step 2: Verify neighboring kata readability**
+- [ ] **手順 2: 近接する kata の読みやすさを確認する**
 
-Spot-check:
+次を確認する。
 - `features/katas/basic_gates/state_flip.feature`
 - `features/katas/basic_gates/basis_change.feature`
 - `features/katas/basic_gates/sign_flip.feature`
 - `features/katas/basic_gates/phase_flip.feature`
 
-Confirm Task 1.1〜1.5 now read as one consistent high-level progression.
+タスク 1.1〜1.5 が、一貫した高水準の流れとして読めることを確認する。
 
-- [ ] **Step 3: Commit with a focused message**
+- [ ] **手順 3: 範囲を絞ったコミットメッセージでコミットする**
 
-Commit once everything is green with a message such as:
+すべて成功したら、次のようなメッセージでコミットする。
 
 ```text
 feat: add y-basis phase flip DSL


### PR DESCRIPTION
## 概要

- `docs/superpowers/plans/2026-03-31-phase-flip-y-basis.md` の英語中心の普通名詞を自然な日本語へ整理しました。
- コマンド例、ファイルパス、コード識別子、Gherkin キーワード、`superpowers:*` の識別子は維持しました。

## 確認

- `git diff --check`
- `bundle exec rake check`

## Linear

- YAS-284


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメンテーション
* Y基底フェーズフリップの実装計画書を作成しました。|+i> / |-i> のショートハンド表記、Y基底レンダリング機能、および包括的なテストとCLIサポートに関する詳細なロードマップを提供しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->