### PR TITLE
Bloch inline 計画書を日本語化

### DIFF
--- a/docs/superpowers/plans/2026-03-31-qni-bloch-inline.md
+++ b/docs/superpowers/plans/2026-03-31-qni-bloch-inline.md
@@ -97,7 +97,7 @@ end
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec cucumber features/qni_bloch.feature features/qni_cli.feature
 ```
 
-期待結果: 新しいヘルプ文、オプション、インライン描画経路がまだ存在しないため FAIL。
+期待結果: 新しいヘルプ文、オプション、インライン描画経路がまだ存在しないため失敗する。
 
 ### タスク 2: インラインモードの CLI 公開インターフェースと検証を追加する
 
@@ -200,7 +200,7 @@ end
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec ruby -Itest test/qni/kitty_graphics_emitter_test.rb
 ```
 
-期待結果: 出力器クラスがまだ存在しないため FAIL。
+期待結果: 出力器クラスがまだ存在しないため失敗する。
 
 - [ ] **ステップ 3: `Qni::KittyGraphicsEmitter` を実装する**
 
@@ -223,7 +223,7 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec ruby -Itest t
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec ruby -Itest test/qni/kitty_graphics_emitter_test.rb
 ```
 
-期待結果: PASS
+期待結果: 成功する
 
 - [ ] **ステップ 5: 出力器の作業単位をコミットする**
 
@@ -271,7 +271,7 @@ end
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec ruby -Itest test/qni/bloch_renderer_test.rb
 ```
 
-期待結果: `BlochRenderer` が現時点ではファイル書き出ししかできないため FAIL。
+期待結果: `BlochRenderer` が現時点ではファイル書き出ししかできないため失敗する。
 
 - [ ] **ステップ 3: `libexec/qni_bloch_render.py` を拡張する**
 
@@ -300,7 +300,7 @@ python3 -m py_compile libexec/qni_bloch_render.py
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec ruby -Itest test/qni/bloch_renderer_test.rb
 ```
 
-期待結果: どちらも PASS。
+期待結果: どちらも成功する。
 
 - [ ] **ステップ 6: 描画器リファクタリングをコミットする**
 
@@ -356,7 +356,7 @@ inline bloch rendering requires a Kitty-compatible terminal; use --png or --gif 
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec cucumber features/qni_bloch.feature features/qni_cli.feature
 ```
 
-期待結果: PASS
+期待結果: 成功する
 
 - [ ] **ステップ 5: 一気通貫のインライン経路をコミットする**
 
@@ -389,7 +389,7 @@ git commit -m "feat: add inline bloch rendering"
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec cucumber features/qni_bloch.feature features/qni_cli.feature features/qni_run.feature features/qni_export.feature
 ```
 
-期待結果: PASS
+期待結果: 成功する
 
 - [ ] **ステップ 3: 対象を絞った Ruby 品質チェックを実行する**
 
@@ -400,7 +400,7 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec rubocop lib/q
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec reek lib/qni/cli/bloch_command.rb lib/qni/bloch_renderer.rb lib/qni/bloch_inline_renderer.rb lib/qni/kitty_graphics_emitter.rb
 ```
 
-期待結果: PASS
+期待結果: 成功する
 
 - [ ] **ステップ 4: プロジェクト全体の確認を実行する**
 
@@ -411,7 +411,7 @@ bash scripts/setup_symbolic_python.sh
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec rake check
 ```
 
-期待結果: PASS
+期待結果: 成功する
 
 - [ ] **ステップ 5: 検証作業をコミットする**
 

--- a/docs/superpowers/plans/2026-03-31-qni-bloch-inline.md
+++ b/docs/superpowers/plans/2026-03-31-qni-bloch-inline.md
@@ -1,52 +1,52 @@
-# qni bloch Inline Terminal Implementation Plan
+# qni bloch インライン端末実装計画
 
-> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **エージェント作業者向け:** 必須: この計画を実装するときは、利用できる場合は superpowers:subagent-driven-development を、そうでない場合は superpowers:executing-plans を使う。手順の進捗管理にはチェックボックス (`- [ ]`) 構文を使う。
 
-**Goal:** Add `qni bloch --inline` so Ghostty and other Kitty-graphics-compatible terminals can preview 1-qubit Bloch spheres directly in the terminal, with optional inline animation.
+**目標:** `qni bloch --inline` を追加し、Ghostty やその他の Kitty graphics 互換端末で、1 量子ビットのブロッホ球を端末内で直接プレビューできるようにする。任意でインラインアニメーションにも対応する。
 
-**Architecture:** Keep the existing `qni bloch` numeric sampling pipeline. Ruby will extend the CLI surface, validate `--inline` and `--animate`, detect whether the current terminal is suitable for Kitty graphics, and format the actual Kitty protocol escape sequences. Python will continue to own image generation through `matplotlib`, but it will gain in-memory PNG output modes so Ruby can either write files or stream frames inline without going through GIF/APNG/WebP first.
+**構成:** 既存の `qni bloch` の数値サンプリング処理を維持する。Ruby は CLI の公開インターフェース、`--inline` と `--animate` の検証、現在の端末が Kitty graphics に適しているかどうかの検出、実際の Kitty graphics protocol エスケープシーケンスの整形を担当する。Python は引き続き `matplotlib` による画像生成を担当するが、Ruby がファイルを書き出す場合も、GIF/APNG/WebP を経由せずにフレームをインライン出力する場合も扱えるように、メモリ上の PNG 出力モードを追加する。
 
-**Tech Stack:** Ruby, Thor, Cucumber, Minitest, Python, matplotlib, Pillow, Kitty graphics protocol, existing `Qni::BlochSampler` / `Qni::BlochRenderer`
+**技術構成:** Ruby, Thor, Cucumber, Minitest, Python, matplotlib, Pillow, Kitty graphics protocol, 既存の `Qni::BlochSampler` / `Qni::BlochRenderer`
 
 ---
 
-## File Structure
+## ファイル構成
 
-- Modify: `features/qni_bloch.feature`
-  - Add acceptance coverage for `--inline`, `--inline --animate`, invalid option combinations, and unsupported-terminal failure.
-- Modify: `features/qni_cli.feature`
-  - Extend top-level help and `qni bloch --help` expectations with inline options.
-- Modify: `features/step_definitions/cli_steps.rb`
-  - Add helpers for capturing inline escape sequences and injecting terminal-capability test seams.
-- Modify: `lib/qni/cli.rb`
-  - Expose `--inline` and `--animate` on the `bloch` command.
-- Modify: `lib/qni/cli/bloch_command.rb`
-  - Validate the new option matrix and dispatch either file rendering or inline rendering.
-- Modify: `lib/qni/cli/bloch_help.rb`
-  - Document the new inline usage and constraints.
-- Modify: `lib/qni/bloch_renderer.rb`
-  - Refactor the Python bridge so it can request either file output or in-memory PNG frame payloads.
-- Create: `lib/qni/bloch_inline_renderer.rb`
-  - Own the Ruby-side inline workflow: request rendered frames, enforce terminal support, and send Kitty graphics protocol sequences to the terminal.
-- Create: `lib/qni/kitty_graphics_emitter.rb`
-  - Format and emit Kitty graphics protocol escape sequences for static images and frame-by-frame animation.
-- Modify: `libexec/qni_bloch_render.py`
-  - Add modes that return PNG bytes for one frame or many frames instead of always writing files.
-- Test: `test/qni/kitty_graphics_emitter_test.rb`
-  - Unit-test protocol formatting independently from the CLI.
-- Test: `test/qni/bloch_renderer_test.rb`
-  - Unit-test the Ruby/Python payload boundary for the new inline modes.
+- 変更: `features/qni_bloch.feature`
+  - `--inline`、`--inline --animate`、無効なオプション組み合わせ、未対応端末での失敗について受け入れ確認を追加する。
+- 変更: `features/qni_cli.feature`
+  - 最上位ヘルプと `qni bloch --help` の期待値にインライン用オプションを追加する。
+- 変更: `features/step_definitions/cli_steps.rb`
+  - インラインのエスケープシーケンスを捕捉し、端末機能を差し替えるテスト用の継ぎ目を追加する補助処理を用意する。
+- 変更: `lib/qni/cli.rb`
+  - `bloch` コマンドに `--inline` と `--animate` を公開する。
+- 変更: `lib/qni/cli/bloch_command.rb`
+  - 新しいオプションの組み合わせを検証し、ファイル描画またはインライン描画へ振り分ける。
+- 変更: `lib/qni/cli/bloch_help.rb`
+  - 新しいインライン利用方法と制約を説明する。
+- 変更: `lib/qni/bloch_renderer.rb`
+  - Python 連携をリファクタリングし、ファイル出力またはメモリ上の PNG フレームペイロードのどちらでも要求できるようにする。
+- 作成: `lib/qni/bloch_inline_renderer.rb`
+  - Ruby 側のインライン処理を担当する。描画済みフレームの要求、端末対応状況の確認、Kitty graphics protocol シーケンスの端末送信を行う。
+- 作成: `lib/qni/kitty_graphics_emitter.rb`
+  - 静止画像とフレーム単位アニメーション向けに Kitty graphics protocol のエスケープシーケンスを整形して出力する。
+- 変更: `libexec/qni_bloch_render.py`
+  - 常にファイルへ書き出すのではなく、1 フレームまたは複数フレームの PNG バイト列を返すモードを追加する。
+- テスト: `test/qni/kitty_graphics_emitter_test.rb`
+  - CLI から独立してプロトコルの整形を単体テストする。
+- テスト: `test/qni/bloch_renderer_test.rb`
+  - 新しいインラインモードの Ruby/Python 間のペイロード境界を単体テストする。
 
-### Task 1: Add failing acceptance coverage for inline Bloch output
+### タスク 1: インライン Bloch 出力の失敗する受け入れ確認を追加する
 
-**Files:**
-- Modify: `features/qni_bloch.feature`
-- Modify: `features/qni_cli.feature`
-- Modify: `features/step_definitions/cli_steps.rb`
+**ファイル:**
+- 変更: `features/qni_bloch.feature`
+- 変更: `features/qni_cli.feature`
+- 変更: `features/step_definitions/cli_steps.rb`
 
-- [ ] **Step 1: Extend CLI help expectations**
+- [ ] **ステップ 1: CLI ヘルプの期待値を拡張する**
 
-Add help coverage to `features/qni_cli.feature` so `qni bloch --help` now includes lines along these lines:
+`features/qni_cli.feature` にヘルプ確認を追加し、`qni bloch --help` が次のような行を含むようにする。
 
 ```text
 Usage:
@@ -54,117 +54,117 @@ Usage:
   qni bloch --inline --animate
 ```
 
-and options like:
+次のようなオプションも含める。
 
 ```text
 --inline        # render a Bloch sphere inline in a Kitty-compatible terminal
 --animate       # animate inline Bloch output; valid only with --inline
 ```
 
-- [ ] **Step 2: Add behavior scenarios to `features/qni_bloch.feature`**
+- [ ] **ステップ 2: `features/qni_bloch.feature` に振る舞いシナリオを追加する**
 
-Add scenarios for:
-- `qni bloch --inline` succeeding on a 1-qubit circuit and emitting Kitty graphics escape sequences
-- `qni bloch --inline --animate` succeeding on a 1-qubit rotation circuit and emitting multiple inline frames
-- `qni bloch --inline --output bloch.png` failing with a clear `--output is not supported with --inline` message
-- `qni bloch --gif --animate --output bloch.gif` failing with a clear `--animate is supported only with --inline` message
-- `qni bloch --inline` failing on unsupported terminals with a clear fallback message such as `inline bloch rendering requires a Kitty-compatible terminal; use --png or --gif instead`
+次のシナリオを追加する。
+- `qni bloch --inline` が 1 量子ビット回路で成功し、Kitty graphics のエスケープシーケンスを出力する
+- `qni bloch --inline --animate` が 1 量子ビット回転回路で成功し、複数のインラインフレームを出力する
+- `qni bloch --inline --output bloch.png` が明確な `--output is not supported with --inline` メッセージで失敗する
+- `qni bloch --gif --animate --output bloch.gif` が明確な `--animate is supported only with --inline` メッセージで失敗する
+- `qni bloch --inline` が未対応端末では `inline bloch rendering requires a Kitty-compatible terminal; use --png or --gif instead` のような明確な代替手段の案内で失敗する
 
-Keep the existing PNG/GIF scenarios untouched.
+既存の PNG/GIF シナリオは変更しない。
 
-- [ ] **Step 3: Add inline-capture helpers in `cli_steps.rb`**
+- [ ] **ステップ 3: `cli_steps.rb` にインライン捕捉の補助処理を追加する**
 
-Extend `features/step_definitions/cli_steps.rb` with helpers that can:
-- run `qni` under a controlled environment like `QNI_TEST_FORCE_INLINE=1`
-- capture stdout as binary rather than treating it as ordinary text output
-- assert that inline output contains Kitty APC framing such as `ESC _ G`
+`features/step_definitions/cli_steps.rb` を拡張し、次を実行できる補助処理を追加する。
+- `QNI_TEST_FORCE_INLINE=1` のような制御された環境で `qni` を実行する
+- stdout を通常のテキスト出力ではなくバイナリとして捕捉する
+- インライン出力に `ESC _ G` のような Kitty APC フレーミングが含まれることを検証する
 
-Add a step like:
+次のようなステップを追加する。
 
 ```ruby
-Then('標準出力は Kitty graphics escape sequence を含む') do
+Then('標準出力は Kitty graphics のエスケープシーケンスを含む') do
   expect(@stdout).to include("\e_G")
 end
 ```
 
-and another one to assert multiple inline frames by counting escape-sequence occurrences.
+さらに、エスケープシーケンスの出現回数を数えて複数インラインフレームを検証するステップも追加する。
 
-- [ ] **Step 4: Run focused cucumber and verify failure**
+- [ ] **ステップ 4: 対象を絞った cucumber を実行し、失敗を確認する**
 
-Run:
+実行する。
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec cucumber features/qni_bloch.feature features/qni_cli.feature
 ```
 
-Expected: FAIL because the new help text, options, and inline rendering path do not exist yet.
+期待結果: 新しいヘルプ文、オプション、インライン描画経路がまだ存在しないため FAIL。
 
-### Task 2: Add the CLI surface and validation for inline mode
+### タスク 2: インラインモードの CLI 公開インターフェースと検証を追加する
 
-**Files:**
-- Modify: `lib/qni/cli.rb`
-- Modify: `lib/qni/cli/bloch_command.rb`
-- Modify: `lib/qni/cli/bloch_help.rb`
+**ファイル:**
+- 変更: `lib/qni/cli.rb`
+- 変更: `lib/qni/cli/bloch_command.rb`
+- 変更: `lib/qni/cli/bloch_help.rb`
 
-- [ ] **Step 1: Add `--inline` and `--animate` to the Thor command**
+- [ ] **ステップ 1: Thor コマンドに `--inline` と `--animate` を追加する**
 
-Update `lib/qni/cli.rb` so `qni bloch` declares:
+`lib/qni/cli.rb` を更新し、`qni bloch` に次を宣言する。
 
 ```ruby
 method_option :inline, type: :boolean, default: false, desc: 'Render inline in a Kitty-compatible terminal'
 method_option :animate, type: :boolean, default: false, desc: 'Animate inline Bloch output'
 ```
 
-without disturbing the existing `--png`, `--gif`, `--dark`, `--light`, and `--output`.
+既存の `--png`、`--gif`、`--dark`、`--light`、`--output` は変えない。
 
-- [ ] **Step 2: Update shared help text**
+- [ ] **ステップ 2: 共通ヘルプ文を更新する**
 
-Extend `lib/qni/cli/bloch_help.rb` to document:
-- inline usage examples
-- that `--output` is for file modes only
-- that `--animate` is meaningful only with `--inline`
-- that Ghostty / Kitty-compatible terminals are required
+`lib/qni/cli/bloch_help.rb` を拡張し、次を説明する。
+- インライン利用例
+- `--output` はファイルモード専用であること
+- `--animate` は `--inline` と組み合わせる場合だけ意味があること
+- Ghostty / Kitty 互換端末が必要であること
 
-- [ ] **Step 3: Expand option validation in `BlochCommand`**
+- [ ] **ステップ 3: `BlochCommand` のオプション検証を拡張する**
 
-Refactor the validation logic in `lib/qni/cli/bloch_command.rb` so it enforces:
-- exactly one of `--png`, `--gif`, `--inline`
-- `--output` required for `--png` / `--gif`
-- `--output` forbidden for `--inline`
-- `--animate` allowed only with `--inline`
-- still at most one of `--dark` / `--light`
+`lib/qni/cli/bloch_command.rb` の検証ロジックをリファクタリングし、次を強制する。
+- `--png`、`--gif`、`--inline` のうちちょうど 1 つだけを指定する
+- `--png` / `--gif` では `--output` が必須
+- `--inline` では `--output` を禁止
+- `--animate` は `--inline` と組み合わせる場合のみ許可
+- `--dark` / `--light` はこれまでどおり最大 1 つだけ
 
-Use exact error strings that match the feature text.
+feature ファイル内のテキストに一致する正確なエラー文字列を使う。
 
-- [ ] **Step 4: Leave a temporary inline placeholder**
+- [ ] **ステップ 4: 一時的なインライン仮実装を置く**
 
-Before wiring the real renderer, make the `--inline` branch fail with a temporary explicit message such as:
+実際の描画器を接続する前に、`--inline` 分岐では次のような一時的で明示的なメッセージで失敗させる。
 
 ```ruby
 raise Thor::Error, 'inline bloch rendering is not implemented yet'
 ```
 
-This should let help and validation scenarios turn green while rendering scenarios stay red in a controlled way.
+これにより、ヘルプと検証シナリオは通過し、描画シナリオは制御された形で失敗したままになる。
 
-- [ ] **Step 5: Run focused cucumber again**
+- [ ] **ステップ 5: 対象を絞った cucumber を再実行する**
 
-Run:
+実行する。
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec cucumber features/qni_bloch.feature features/qni_cli.feature
 ```
 
-Expected: help and validation scenarios pass; inline rendering scenarios still fail on the placeholder.
+期待結果: ヘルプと検証シナリオは通過し、インライン描画シナリオは仮実装でまだ失敗する。
 
-### Task 3: Add a focused Ruby unit for Kitty graphics emission
+### タスク 3: Kitty graphics 出力の小さな Ruby 単体テストを追加する
 
-**Files:**
-- Create: `test/qni/kitty_graphics_emitter_test.rb`
-- Create: `lib/qni/kitty_graphics_emitter.rb`
+**ファイル:**
+- 作成: `test/qni/kitty_graphics_emitter_test.rb`
+- 作成: `lib/qni/kitty_graphics_emitter.rb`
 
-- [ ] **Step 1: Write the failing emitter tests**
+- [ ] **ステップ 1: 失敗する出力器テストを書く**
 
-Create `test/qni/kitty_graphics_emitter_test.rb` with small, protocol-focused tests such as:
+`test/qni/kitty_graphics_emitter_test.rb` を作成し、次のようなプロトコルに焦点を絞った小さなテストを書く。
 
 ```ruby
 def test_static_image_emits_single_kitty_graphics_payload
@@ -178,7 +178,7 @@ def test_static_image_emits_single_kitty_graphics_payload
 end
 ```
 
-and:
+さらに次も追加する。
 
 ```ruby
 def test_animation_emits_multiple_frames
@@ -190,58 +190,58 @@ def test_animation_emits_multiple_frames
 end
 ```
 
-Keep the tests at the string/protocol level; do not make them depend on a real terminal.
+テストは文字列とプロトコルの水準に留め、実際の端末には依存させない。
 
-- [ ] **Step 2: Run the new unit test and confirm failure**
+- [ ] **ステップ 2: 新しい単体テストを実行し、失敗を確認する**
 
-Run:
+実行する。
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec ruby -Itest test/qni/kitty_graphics_emitter_test.rb
 ```
 
-Expected: FAIL because the emitter class does not exist yet.
+期待結果: 出力器クラスがまだ存在しないため FAIL。
 
-- [ ] **Step 3: Implement `Qni::KittyGraphicsEmitter`**
+- [ ] **ステップ 3: `Qni::KittyGraphicsEmitter` を実装する**
 
-Create `lib/qni/kitty_graphics_emitter.rb` with a narrow API:
-- initialize with a writable `io:`
+狭い API を持つ `lib/qni/kitty_graphics_emitter.rb` を作成する。
+- 書き込み可能な `io:` で初期化する
 - `emit_png_frame(png_bytes)`
 - `emit_animation(png_frames)`
 
-Implementation notes:
-- base64-encode the PNG bytes
-- wrap payloads in Kitty APC framing (`\e_G ... \e\\`)
-- chunk large payloads so very long base64 strings are not written as one giant escape sequence
-- keep protocol details isolated in this file so CLI code never hand-builds escape strings
+実装メモ:
+- PNG バイト列を base64 エンコードする
+- ペイロードを Kitty APC フレーミング (`\e_G ... \e\\`) で囲む
+- 長い base64 文字列を 1 つの巨大なエスケープシーケンスとして書かないように分割する
+- プロトコルの詳細はこのファイルに閉じ込め、CLI コードがエスケープ文字列を直接組み立てないようにする
 
-- [ ] **Step 4: Run the unit test and make it pass**
+- [ ] **ステップ 4: 単体テストを実行し、通過させる**
 
-Run:
+実行する。
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec ruby -Itest test/qni/kitty_graphics_emitter_test.rb
 ```
 
-Expected: PASS
+期待結果: PASS
 
-- [ ] **Step 5: Commit the emitter slice**
+- [ ] **ステップ 5: 出力器の作業単位をコミットする**
 
 ```bash
 git add test/qni/kitty_graphics_emitter_test.rb lib/qni/kitty_graphics_emitter.rb
 git commit -m "feat: add kitty graphics emitter"
 ```
 
-### Task 4: Refactor the Bloch Python bridge for in-memory frame output
+### タスク 4: メモリ上のフレーム出力に向けて Bloch の Python 連携をリファクタリングする
 
-**Files:**
-- Test: `test/qni/bloch_renderer_test.rb`
-- Modify: `lib/qni/bloch_renderer.rb`
-- Modify: `libexec/qni_bloch_render.py`
+**ファイル:**
+- テスト: `test/qni/bloch_renderer_test.rb`
+- 変更: `lib/qni/bloch_renderer.rb`
+- 変更: `libexec/qni_bloch_render.py`
 
-- [ ] **Step 1: Add a failing Ruby-side renderer contract test**
+- [ ] **ステップ 1: Ruby 側の描画器契約を固定する失敗テストを追加する**
 
-Create `test/qni/bloch_renderer_test.rb` with tests that pin the new modes, for example:
+`test/qni/bloch_renderer_test.rb` を作成し、次のように新しいモードを固定するテストを書く。
 
 ```ruby
 def test_png_bytes_mode_returns_binary_png_data
@@ -251,7 +251,7 @@ def test_png_bytes_mode_returns_binary_png_data
 end
 ```
 
-and:
+さらに次も追加する。
 
 ```ruby
 def test_inline_animation_mode_returns_multiple_png_frames
@@ -261,159 +261,159 @@ def test_inline_animation_mode_returns_multiple_png_frames
 end
 ```
 
-If direct helper invocation is awkward in unit tests, add a seam that stubs the helper result while still pinning the Ruby API.
+単体テストから補助スクリプトを直接呼ぶのが扱いづらい場合は、Ruby API を固定しつつ補助スクリプトの結果を差し替える継ぎ目を追加する。
 
-- [ ] **Step 2: Run the new unit test and confirm failure**
+- [ ] **ステップ 2: 新しい単体テストを実行し、失敗を確認する**
 
-Run:
+実行する。
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec ruby -Itest test/qni/bloch_renderer_test.rb
 ```
 
-Expected: FAIL because `BlochRenderer` only writes files today.
+期待結果: `BlochRenderer` が現時点ではファイル書き出ししかできないため FAIL。
 
-- [ ] **Step 3: Extend `libexec/qni_bloch_render.py`**
+- [ ] **ステップ 3: `libexec/qni_bloch_render.py` を拡張する**
 
-Add helper modes that:
-- keep the existing `png` and `gif` file-writing behavior intact
-- add a mode that writes one PNG image to stdout
-- add a mode that writes a framed JSON payload describing multiple PNG frames, with each frame base64-encoded
+次の補助モードを追加する。
+- 既存の `png` と `gif` のファイル書き出し動作はそのまま維持する
+- 1 枚の PNG 画像を stdout に書き出すモードを追加する
+- 複数 PNG フレームを base64 エンコードし、フレーム化した JSON ペイロードとして書き出すモードを追加する
 
-Do not teach the Python helper Kitty protocol details.
+Python 補助スクリプトに Kitty graphics protocol の詳細は持たせない。
 
-- [ ] **Step 4: Refactor `Qni::BlochRenderer`**
+- [ ] **ステップ 4: `Qni::BlochRenderer` をリファクタリングする**
 
-Change `lib/qni/bloch_renderer.rb` so it can:
-- keep the existing file-output API for `png` and `gif`
-- return PNG bytes for static inline mode
-- return an array of PNG byte strings for animated inline mode
+`lib/qni/bloch_renderer.rb` を変更し、次ができるようにする。
+- `png` と `gif` の既存ファイル出力 API を維持する
+- 静的インラインモードでは PNG バイト列を返す
+- アニメーションのインラインモードでは PNG バイト列の配列を返す
 
-Keep Python invocation, JSON payload construction, and helper error handling in this class so the rest of the code still sees one Ruby abstraction for Bloch-image generation.
+Python 呼び出し、JSON ペイロード構築、補助スクリプトのエラー処理はこのクラス内に保ち、他のコードからは Bloch 画像生成用の 1 つの Ruby 抽象として見える状態を維持する。
 
-- [ ] **Step 5: Verify the helper boundary**
+- [ ] **ステップ 5: 補助スクリプトとの境界を検証する**
 
-Run:
+実行する。
 
 ```bash
 python3 -m py_compile libexec/qni_bloch_render.py
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec ruby -Itest test/qni/bloch_renderer_test.rb
 ```
 
-Expected: both pass
+期待結果: どちらも PASS。
 
-- [ ] **Step 6: Commit the renderer refactor**
+- [ ] **ステップ 6: 描画器リファクタリングをコミットする**
 
 ```bash
 git add test/qni/bloch_renderer_test.rb lib/qni/bloch_renderer.rb libexec/qni_bloch_render.py
 git commit -m "feat: add in-memory bloch frame rendering"
 ```
 
-### Task 5: Wire `qni bloch --inline` end to end
+### タスク 5: `qni bloch --inline` を一気通貫で接続する
 
-**Files:**
-- Create: `lib/qni/bloch_inline_renderer.rb`
-- Modify: `lib/qni/cli/bloch_command.rb`
-- Modify: `features/step_definitions/cli_steps.rb`
+**ファイル:**
+- 作成: `lib/qni/bloch_inline_renderer.rb`
+- 変更: `lib/qni/cli/bloch_command.rb`
+- 変更: `features/step_definitions/cli_steps.rb`
 
-- [ ] **Step 1: Add a narrow inline renderer class**
+- [ ] **ステップ 1: 狭いインライン描画器クラスを追加する**
 
-Create `lib/qni/bloch_inline_renderer.rb` that owns:
-- checking whether inline output is being attempted on a usable terminal
-- deciding between static and animated inline modes
-- asking `Qni::BlochRenderer` for PNG bytes or frame arrays
-- passing those bytes to `Qni::KittyGraphicsEmitter`
+`lib/qni/bloch_inline_renderer.rb` を作成し、次を担当させる。
+- インライン出力を使おうとしている端末が利用可能かを確認する
+- 静的インラインモードとアニメーションインラインモードを選ぶ
+- `Qni::BlochRenderer` に PNG バイト列またはフレーム配列を要求する
+- それらのバイト列を `Qni::KittyGraphicsEmitter` に渡す
 
-Keep the CLI command thin by moving all inline-specific orchestration here.
+CLI コマンドを薄く保つため、インライン固有の調整はすべてここへ移す。
 
-- [ ] **Step 2: Add terminal capability policy**
+- [ ] **ステップ 2: 端末機能の方針を追加する**
 
-Implement the first-release support check in `Qni::BlochInlineRenderer` with a deliberately strict policy:
-- stdout must be a TTY, unless the test seam explicitly forces inline mode
-- environment must indicate a Kitty-compatible terminal, with Ghostty treated as supported
-- otherwise raise:
+`Qni::BlochInlineRenderer` に、初回リリース向けの意図的に厳しい対応確認を実装する。
+- テスト用の継ぎ目で明示的にインラインモードを強制している場合を除き、stdout は TTY でなければならない
+- 環境変数が Kitty 互換端末を示している必要があり、Ghostty は対応端末として扱う
+- それ以外では次を raise する。
 
 ```text
 inline bloch rendering requires a Kitty-compatible terminal; use --png or --gif instead
 ```
 
-Use a small helper method so this logic can be unit-tested and adjusted later.
+あとで単体テストや調整ができるよう、小さな補助メソッドにする。
 
-- [ ] **Step 3: Replace the placeholder in `BlochCommand`**
+- [ ] **ステップ 3: `BlochCommand` の仮実装を置き換える**
 
-In `lib/qni/cli/bloch_command.rb`, route:
-- `--png` / `--gif` to the existing file path
-- `--inline` to `Qni::BlochInlineRenderer`
-- `--inline --animate` to the animated branch
+`lib/qni/cli/bloch_command.rb` で次のように経路を振り分ける。
+- `--png` / `--gif` は既存のファイル出力経路へ送る
+- `--inline` は `Qni::BlochInlineRenderer` へ送る
+- `--inline --animate` はアニメーション分岐へ送る
 
-Keep sampling in one place by reusing the already-built `frames = BlochSampler.new(...).frames`.
+`frames = BlochSampler.new(...).frames` で組み立て済みの frames を再利用し、サンプリングは 1 か所に保つ。
 
-- [ ] **Step 4: Run focused cucumber and make the inline scenarios pass**
+- [ ] **ステップ 4: 対象を絞った cucumber を実行し、インラインシナリオを通過させる**
 
-Run:
+実行する。
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec cucumber features/qni_bloch.feature features/qni_cli.feature
 ```
 
-Expected: PASS
+期待結果: PASS
 
-- [ ] **Step 5: Commit the end-to-end inline path**
+- [ ] **ステップ 5: 一気通貫のインライン経路をコミットする**
 
 ```bash
 git add lib/qni/bloch_inline_renderer.rb lib/qni/cli/bloch_command.rb features/qni_bloch.feature features/qni_cli.feature features/step_definitions/cli_steps.rb
 git commit -m "feat: add inline bloch rendering"
 ```
 
-### Task 6: Run regression checks and polish the help text
+### タスク 6: 回帰確認を実行し、ヘルプ文を整える
 
-**Files:**
-- Modify: `lib/qni/cli/bloch_help.rb`
-- Modify: `features/qni_cli.feature`
-- Modify: `features/qni_bloch.feature`
+**ファイル:**
+- 変更: `lib/qni/cli/bloch_help.rb`
+- 変更: `features/qni_cli.feature`
+- 変更: `features/qni_bloch.feature`
 
-- [ ] **Step 1: Re-read the final user-facing help**
+- [ ] **ステップ 1: 最終的なユーザー向けヘルプを読み直す**
 
-Check `lib/qni/cli/bloch_help.rb` and `features/qni_cli.feature` together and make sure they clearly communicate:
-- `--inline` for terminal preview
-- `--animate` only with `--inline`
-- `--png` / `--gif` still require `--output`
+`lib/qni/cli/bloch_help.rb` と `features/qni_cli.feature` を一緒に確認し、次が明確に伝わることを確かめる。
+- `--inline` は端末内プレビュー用であること
+- `--animate` は `--inline` と一緒に使う場合だけ有効であること
+- `--png` / `--gif` ではこれまでどおり `--output` が必要であること
 
-Keep wording short and parallel with the existing CLI tone.
+表現は短くし、既存 CLI の語調と並べる。
 
-- [ ] **Step 2: Run the focused Bloch regression set**
+- [ ] **ステップ 2: 対象を絞った Bloch 回帰確認を実行する**
 
-Run:
+実行する。
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec cucumber features/qni_bloch.feature features/qni_cli.feature features/qni_run.feature features/qni_export.feature
 ```
 
-Expected: PASS
+期待結果: PASS
 
-- [ ] **Step 3: Run targeted Ruby quality checks**
+- [ ] **ステップ 3: 対象を絞った Ruby 品質チェックを実行する**
 
-Run:
+実行する。
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec rubocop lib/qni/cli/bloch_command.rb lib/qni/cli/bloch_help.rb lib/qni/bloch_renderer.rb lib/qni/bloch_inline_renderer.rb lib/qni/kitty_graphics_emitter.rb test/qni/kitty_graphics_emitter_test.rb test/qni/bloch_renderer_test.rb
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec reek lib/qni/cli/bloch_command.rb lib/qni/bloch_renderer.rb lib/qni/bloch_inline_renderer.rb lib/qni/kitty_graphics_emitter.rb
 ```
 
-Expected: PASS
+期待結果: PASS
 
-- [ ] **Step 4: Run the full project check**
+- [ ] **ステップ 4: プロジェクト全体の確認を実行する**
 
-Run:
+実行する。
 
 ```bash
 bash scripts/setup_symbolic_python.sh
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec rake check
 ```
 
-Expected: PASS
+期待結果: PASS
 
-- [ ] **Step 5: Commit the verification pass**
+- [ ] **ステップ 5: 検証作業をコミットする**
 
 ```bash
 git add features/qni_bloch.feature features/qni_cli.feature lib/qni/cli/bloch_help.rb


### PR DESCRIPTION
## 概要
- YAS-287
- `docs/superpowers/plans/2026-03-31-qni-bloch-inline.md` の本文を自然な日本語へ修正しました。
- PR 指摘を受け、計画書本文の期待結果に残っていた `PASS` / `FAIL` を日本語の期待状態へ揃えました。
- コマンド例、ファイルパス、コード識別子、エラー文字列は原文のまま維持しました。

## 検証
- `git diff --check`
- `bundle exec rake check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Kitty互換ターミナルでBloch図表をインライン表示できるようになりました。
  * blochコマンドに`--inline`オプションを追加しました。
  * `--animate`オプションでインラインBloch出力のアニメーション化に対応しました。

* **ドキュメント**
  * CLIヘルプを更新し、インライン機能の使用方法とターミナル互換性要件を記載しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->