### PR TITLE
Sign Flip 計画書の文体を整える

### DIFF
--- a/docs/superpowers/plans/2026-03-31-sign-flip-plus-minus-initial-state.md
+++ b/docs/superpowers/plans/2026-03-31-sign-flip-plus-minus-initial-state.md
@@ -213,7 +213,7 @@ NEGATED_PLUS_MINUS_COEFFICIENT = (-Math.sqrt(0.5)).to_s
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec ruby -Itest test/qni/initial_state_test.rb
 ```
 
-期待結果: PASS
+期待結果: 成功する
 
 - [ ] **ステップ 6: `InitialState` 実装をコミットする**
 
@@ -260,7 +260,7 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec cucumber \
   features/katas/basic_gates/sign_flip.feature
 ```
 
-期待結果: PASS
+期待結果: 成功する
 
 - [ ] **ステップ 4: 互換性を抜き取りで確認する**
 
@@ -272,7 +272,7 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec cucumber \
   features/katas/basic_gates/basis_change.feature
 ```
 
-期待結果: PASS
+期待結果: 成功する
 
 - [ ] **ステップ 5: 高レベル SignFlip をコミットする**
 
@@ -299,7 +299,7 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec rake check
 
 期待結果:
 
-- RuboCop / Reek / Cucumber / Flog / Flay を含む `check` が PASS
+- RuboCop / Reek / Cucumber / Flog / Flay を含む `check` が成功する
 - シナリオ数は最新件数で増えていてよい
 
 - [ ] **ステップ 2: 変更内容を要約してコミット列を確認する**

--- a/docs/superpowers/plans/2026-03-31-sign-flip-plus-minus-initial-state.md
+++ b/docs/superpowers/plans/2026-03-31-sign-flip-plus-minus-initial-state.md
@@ -262,7 +262,7 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec cucumber \
 
 期待結果: PASS
 
-- [ ] **ステップ 4: 互換性を局所確認する**
+- [ ] **ステップ 4: 互換性を抜き取りで確認する**
 
 `|+>, |->` 省略記法が既存の機能仕様を壊していないことを確認するため、次も流す。
 
@@ -316,7 +316,7 @@ git status --short
 - 機能仕様先行の赤いコミット
 - 省略記法の実装コミット
 - 高レベル SignFlip コミット
-- 作業木は clean
+- 作業ツリーはクリーン
 
 - [ ] **ステップ 3: 完了報告**
 

--- a/docs/superpowers/plans/2026-03-31-sign-flip-plus-minus-initial-state.md
+++ b/docs/superpowers/plans/2026-03-31-sign-flip-plus-minus-initial-state.md
@@ -1,44 +1,44 @@
-# Sign Flip Plus/Minus Initial State Implementation Plan
+# Sign Flip のプラス/マイナス初期状態実装計画
 
-> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **エージェント作業者へ:** 必須: この計画を実装するときは、サブエージェントが利用可能なら superpowers:subagent-driven-development、そうでなければ superpowers:executing-plans を使う。進捗管理にはチェックボックス (`- [ ]`) 構文を使う。
 
-**Goal:** `|+>` / `|->` を初期状態 shorthand として正式サポートし、`sign_flip.feature` を Task 1.1 / 1.2 と同じ高レベル DSL に書き換える。
+**目標:** `|+>` / `|->` を初期状態の省略記法として正式サポートし、`sign_flip.feature` をタスク 1.1 / 1.2 と同じ高レベル DSL に書き換える。
 
-**Architecture:** 先に `qni state` と `sign_flip.feature` の acceptance を赤くし、`|+>` / `|->` shorthand を `InitialState` の parse / render の責務として追加する。内部表現は第 1 段では concrete な 2 項 state に展開し、CLI・feature DSL・symbolic / numeric run の既存経路をできるだけ再利用する。
+**設計:** 先に `qni state` と `sign_flip.feature` の受け入れテストを赤くし、`|+>` / `|->` の省略記法を `InitialState` の解析 / 表示の責務として追加する。内部表現は第 1 段では具体的な 2 項状態に展開し、CLI・機能仕様 DSL・記号 / 数値実行の既存経路をできるだけ再利用する。
 
-**Tech Stack:** Ruby, Cucumber, Minitest, Bundler, `InitialState`, `qni-cli`
+**技術構成:** Ruby, Cucumber, Minitest, Bundler, `InitialState`, `qni-cli`
 
 ---
 
-## File Structure
+## ファイル構成
 
-- Modify: `features/qni_state.feature`
-  - `qni state set "|+>"` / `qni state show` の acceptance を追加する。
-- Modify: `features/katas/basic_gates/sign_flip.feature`
-  - low-level な `qni add` / CSV 比較を高レベル DSL へ置き換える。
-- Modify: `features/step_definitions/cli_steps.rb`
+- 変更: `features/qni_state.feature`
+  - `qni state set "|+>"` / `qni state show` の受け入れテストを追加する。
+- 変更: `features/katas/basic_gates/sign_flip.feature`
+  - 低レベルな `qni add` / CSV 比較を高レベル DSL へ置き換える。
+- 変更: `features/step_definitions/cli_steps.rb`
   - 既存の `Given 初期状態ベクトルは:` が `|+>` / `|->` を自然に通せることを押さえる。
-- Modify: `test/qni/initial_state_test.rb`
-  - `|+>` / `|->` の parse / `to_s` / numeric resolve を unit test する。
-- Modify: `lib/qni/initial_state.rb`
-  - `|+>` / `|->` shorthand parse と shorthand-aware `to_s` を追加する。
-- Optional Modify: `lib/qni/state_file.rb`
-  - `state show` が shorthand を返せるか確認し、必要なら整形責務を追加する。
+- 変更: `test/qni/initial_state_test.rb`
+  - `|+>` / `|->` の解析 / `to_s` / 数値解決を単体テストする。
+- 変更: `lib/qni/initial_state.rb`
+  - `|+>` / `|->` の省略記法解析と省略記法対応の `to_s` を追加する。
+- 必要なら変更: `lib/qni/state_file.rb`
+  - `state show` が省略記法を返せるか確認し、必要なら整形責務を追加する。
 
-## Task 1: feature-first で `|+>` / `|->` shorthand の受け入れを赤くする
+## タスク 1: 機能仕様を先に書いて `|+>` / `|->` 省略記法の受け入れを赤くする
 
-**Files:**
-- Modify: `features/qni_state.feature`
-- Modify: `features/katas/basic_gates/sign_flip.feature`
-- Test: `features/qni_state.feature`
-- Test: `features/katas/basic_gates/sign_flip.feature`
+**ファイル:**
+- 変更: `features/qni_state.feature`
+- 変更: `features/katas/basic_gates/sign_flip.feature`
+- テスト: `features/qni_state.feature`
+- テスト: `features/katas/basic_gates/sign_flip.feature`
 
-- [ ] **Step 1: `qni state` の shorthand acceptance を追加する**
+- [ ] **ステップ 1: `qni state` の省略記法受け入れテストを追加する**
 
 `features/qni_state.feature` に少なくとも次を追加する。
 
 ```gherkin
-Scenario: qni state set は |+> を shorthand のまま表示できる初期状態として保存する
+Scenario: qni state set は |+> を省略記法のまま表示できる初期状態として保存する
   When "qni state set \"|+>\"" を実行
   Then コマンドは成功
   And "qni state show" を実行
@@ -47,7 +47,7 @@ Scenario: qni state set は |+> を shorthand のまま表示できる初期状�
     |+>
     """
 
-Scenario: qni state set は |-> を shorthand のまま表示できる初期状態として保存する
+Scenario: qni state set は |-> を省略記法のまま表示できる初期状態として保存する
   When "qni state set \"|->\"" を実行
   Then コマンドは成功
   And "qni state show" を実行
@@ -59,7 +59,7 @@ Scenario: qni state set は |-> を shorthand のまま表示できる初期状�
 
 必要なら `circuit.json:` 比較も追加して、内部保存が `initial_state` 経由で行われることを固定する。
 
-- [ ] **Step 2: `sign_flip.feature` を高レベル DSL に書き換える**
+- [ ] **ステップ 2: `sign_flip.feature` を高レベル DSL に書き換える**
 
 `features/katas/basic_gates/sign_flip.feature` を次の方向へ更新する。
 
@@ -105,11 +105,11 @@ Scenario: Z ゲートは |-> を |+> に変える
 
 の 3 本も `Given 初期状態ベクトルは:` / `When 次の回路を適用:` / `Then 計算基底での状態ベクトルは:` に揃える。
 
-controlled 検証 scenario はここで削除する。
+制御付き検証シナリオはここで削除する。
 
-- [ ] **Step 3: red を確認する**
+- [ ] **ステップ 3: 赤いことを確認する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec cucumber \
@@ -117,27 +117,27 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec cucumber \
   features/katas/basic_gates/sign_flip.feature
 ```
 
-Expected:
+期待結果:
 
-- `|+>` / `|->` が parse できず赤くなる
-- または `qni state show` が shorthand を返せず赤くなる
-- 失敗理由が typo ではなく機能不足である
+- `|+>` / `|->` が解析できず赤くなる
+- または `qni state show` が省略記法を返せず赤くなる
+- 失敗理由が入力ミスではなく機能不足である
 
-- [ ] **Step 4: red をコミットする**
+- [ ] **ステップ 4: 赤い状態をコミットする**
 
 ```bash
 git add features/qni_state.feature features/katas/basic_gates/sign_flip.feature
 git commit -m "test: add sign flip plus-minus shorthand acceptance"
 ```
 
-## Task 2: `InitialState` に `|+>` / `|->` shorthand を追加する
+## タスク 2: `InitialState` に `|+>` / `|->` 省略記法を追加する
 
-**Files:**
-- Modify: `test/qni/initial_state_test.rb`
-- Modify: `lib/qni/initial_state.rb`
-- Test: `test/qni/initial_state_test.rb`
+**ファイル:**
+- 変更: `test/qni/initial_state_test.rb`
+- 変更: `lib/qni/initial_state.rb`
+- テスト: `test/qni/initial_state_test.rb`
 
-- [ ] **Step 1: unit test を赤く追加する**
+- [ ] **ステップ 1: 単体テストを赤く追加する**
 
 `test/qni/initial_state_test.rb` に少なくとも次を追加する。
 
@@ -161,84 +161,84 @@ end
 
 必要なら `to_h` の期待値も追加して、内部表現の安定性を固定する。
 
-- [ ] **Step 2: unit test が赤いことを確認する**
+- [ ] **ステップ 2: 単体テストが赤いことを確認する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec ruby -Itest test/qni/initial_state_test.rb
 ```
 
-Expected:
+期待結果:
 
 - `invalid initial state term`
 - または `unsupported basis state`
 
-- [ ] **Step 3: `InitialState.parse` に shorthand を実装する**
+- [ ] **ステップ 3: `InitialState.parse` に省略記法を実装する**
 
-`lib/qni/initial_state.rb` に `|+>` / `|->` の special-case parse を追加する。
+`lib/qni/initial_state.rb` に `|+>` / `|->` の特別扱いの解析を追加する。
 
 方針:
 
-- `|+>` は `1/sqrt(2)` 相当の concrete number を係数に持つ 2 項へ展開
+- `|+>` は `1/sqrt(2)` 相当の具体的な数値を係数に持つ 2 項へ展開
 - `|->` は 2 項目だけ負符号を持たせる
 
-第 1 段では係数を concrete string として直接埋めてよい。
+第 1 段では係数を具体的な文字列として直接埋めてよい。
 
 ```ruby
 PLUS_MINUS_COEFFICIENT = Math.sqrt(0.5).to_s
 NEGATED_PLUS_MINUS_COEFFICIENT = (-Math.sqrt(0.5)).to_s
 ```
 
-のような形でもよいが、constant 数が増えすぎないように注意する。
+のような形でもよいが、定数の数が増えすぎないように注意する。
 
-- [ ] **Step 4: `InitialState#to_s` の shorthand 表示を実装する**
+- [ ] **ステップ 4: `InitialState#to_s` の省略記法表示を実装する**
 
-`to_s` は、terms が `|+>` / `|->` と tolerance 内で一致する場合に shorthand を返す。
+`to_s` は、terms が `|+>` / `|->` と許容誤差内で一致する場合に省略記法を返す。
 
 最小案:
 
 - `plus_state?`
 - `minus_state?`
 
-の predicate を追加し、該当するときだけ `|+>` / `|->` を返す。
+の述語メソッドを追加し、該当するときだけ `|+>` / `|->` を返す。
 
-それ以外は既存の ket sum 表示を維持する。
+それ以外は既存の ket の和の表示を維持する。
 
-- [ ] **Step 5: unit test を green にする**
+- [ ] **ステップ 5: 単体テストを緑にする**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec ruby -Itest test/qni/initial_state_test.rb
 ```
 
-Expected: PASS
+期待結果: PASS
 
-- [ ] **Step 6: `InitialState` 実装をコミットする**
+- [ ] **ステップ 6: `InitialState` 実装をコミットする**
 
 ```bash
 git add test/qni/initial_state_test.rb lib/qni/initial_state.rb
 git commit -m "feat: add plus-minus initial state shorthand"
 ```
 
-## Task 3: CLI と feature DSL の挙動を green にする
+## タスク 3: CLI と機能仕様 DSL の挙動を緑にする
 
-**Files:**
-- Modify: `features/qni_state.feature`
-- Modify: `features/katas/basic_gates/sign_flip.feature`
-- Modify: `features/step_definitions/cli_steps.rb`
-- Optional Modify: `lib/qni/state_file.rb`
-- Test: `features/qni_state.feature`
-- Test: `features/katas/basic_gates/sign_flip.feature`
+**ファイル:**
+- 変更: `features/qni_state.feature`
+- 変更: `features/katas/basic_gates/sign_flip.feature`
+- 変更: `features/step_definitions/cli_steps.rb`
+- 必要なら変更: `lib/qni/state_file.rb`
+- テスト: `features/qni_state.feature`
+- テスト: `features/katas/basic_gates/sign_flip.feature`
 
-- [ ] **Step 1: `qni state show` の shorthand 表示を通す**
+- [ ] **ステップ 1: `qni state show` の省略記法表示を通す**
 
-`features/qni_state.feature` の新しい scenario を green にする。
+`features/qni_state.feature` の新しいシナリオを緑にする。
 
 `lib/qni/state_file.rb` に手を入れる必要があるなら、責務は最小に留める。理想は `InitialState#to_s` をそのまま使って `state show` を通すこと。
 
-- [ ] **Step 2: `sign_flip.feature` の高レベル DSL を整える**
+- [ ] **ステップ 2: `sign_flip.feature` の高レベル DSL を整える**
 
 最終形では次の 5 本に揃える。
 
@@ -248,11 +248,11 @@ git commit -m "feat: add plus-minus initial state shorthand"
 - `Z ゲートは実数係数の一般状態で |1> の振幅の符号を反転する`
 - `Z ゲートは α|0> + β|1> を α|0> - β|1> に変える`
 
-必要なら scenario 名を、Task 1.1 / 1.2 と同じ語感に揃えて調整する。
+必要ならシナリオ名を、タスク 1.1 / 1.2 と同じ語感に揃えて調整する。
 
-- [ ] **Step 3: targeted feature を green にする**
+- [ ] **ステップ 3: 対象機能仕様を緑にする**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec cucumber \
@@ -260,11 +260,11 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec cucumber \
   features/katas/basic_gates/sign_flip.feature
 ```
 
-Expected: PASS
+期待結果: PASS
 
-- [ ] **Step 4: 互換性を spot check する**
+- [ ] **ステップ 4: 互換性を局所確認する**
 
-`|+>, |->` shorthand が既存 feature を壊していないことを確認するため、次も流す。
+`|+>, |->` 省略記法が既存の機能仕様を壊していないことを確認するため、次も流す。
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec cucumber \
@@ -272,9 +272,9 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec cucumber \
   features/katas/basic_gates/basis_change.feature
 ```
 
-Expected: PASS
+期待結果: PASS
 
-- [ ] **Step 5: high-level SignFlip をコミットする**
+- [ ] **ステップ 5: 高レベル SignFlip をコミットする**
 
 ```bash
 git add features/qni_state.feature features/katas/basic_gates/sign_flip.feature features/step_definitions/cli_steps.rb lib/qni/state_file.rb
@@ -283,53 +283,53 @@ git commit -m "test: rewrite sign flip as high-level DSL"
 
 `features/step_definitions/cli_steps.rb` や `lib/qni/state_file.rb` に変更がなければ `git add` から外す。
 
-## Task 4: 全体確認をして仕上げる
+## タスク 4: 全体確認をして仕上げる
 
-**Files:**
-- Verify only
+**ファイル:**
+- 検証のみ
 
-- [ ] **Step 1: fresh な全体確認**
+- [ ] **ステップ 1: 最新状態で全体確認する**
 
-Run:
+実行:
 
 ```bash
 bash scripts/setup_symbolic_python.sh
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec rake check
 ```
 
-Expected:
+期待結果:
 
 - RuboCop / Reek / Cucumber / Flog / Flay を含む `check` が PASS
-- scenario 数は最新件数で増えていてよい
+- シナリオ数は最新件数で増えていてよい
 
-- [ ] **Step 2: 変更内容を要約してコミット列を確認する**
+- [ ] **ステップ 2: 変更内容を要約してコミット列を確認する**
 
-Run:
+実行:
 
 ```bash
 git log --oneline --decorate -5
 git status --short
 ```
 
-Expected:
+期待結果:
 
-- feature-first red commit
-- shorthand implementation commit
-- high-level SignFlip commit
-- worktree は clean
+- 機能仕様先行の赤いコミット
+- 省略記法の実装コミット
+- 高レベル SignFlip コミット
+- 作業木は clean
 
-- [ ] **Step 3: 完了報告**
+- [ ] **ステップ 3: 完了報告**
 
 完了時には少なくとも次を伝える。
 
-- `|+>` / `|->` initial state shorthand が入ったこと
-- `sign_flip.feature` が high-level DSL へ揃ったこと
-- 実行した verification command と結果
+- `|+>` / `|->` 初期状態省略記法が入ったこと
+- `sign_flip.feature` が高レベル DSL へ揃ったこと
+- 実行した検証コマンドと結果
 
-## Notes for the Implementer
+## 実装者向けメモ
 
-- `AGENTS.md` に従い、feature を先に変える。
-- `sign_flip.feature` の controlled scenario は戻さない。
+- `AGENTS.md` に従い、機能仕様を先に変える。
+- `sign_flip.feature` の制御付きシナリオは戻さない。
 - 第 1 段では `|+>` / `|->` のみ。`|+i>` などへは広げない。
-- shorthand の内部表現は concrete number 展開で十分。一般の数式 parser を増やさない。
-- この plan 実行前に、作業中の [sign_flip.feature](/home/yasuhito/Work/qni-cli/features/katas/basic_gates/sign_flip.feature) の未コミット差分が何かを確認し、誤って消さないこと。
+- 省略記法の内部表現は具体的な数値への展開で十分。一般の数式パーサーを増やさない。
+- この計画を実行する前に、作業中の [sign_flip.feature](/home/yasuhito/Work/qni-cli/features/katas/basic_gates/sign_flip.feature) の未コミット差分が何かを確認し、誤って消さないこと。


### PR DESCRIPTION
## 概要

- `docs/superpowers/plans/2026-03-31-sign-flip-plus-minus-initial-state.md` の英日混在表現を自然な日本語に整えました。
- コマンド例、ファイルパス、コード識別子、Gherkin キーワード、エラーメッセージ、コミットメッセージ例は原文を維持しました。
- 対応課題: YAS-288

## 検証

- `git diff --check`
- `bundle exec rake check`
