### PR TITLE
位相回転 DSL 計画書の文体を整える

### DIFF
--- a/docs/superpowers/plans/2026-04-01-phase-change-high-level-dsl.md
+++ b/docs/superpowers/plans/2026-04-01-phase-change-high-level-dsl.md
@@ -29,7 +29,7 @@
 - 変更: `features/katas/basic_gates/phase_change.feature`
 - テスト: `features/katas/basic_gates/phase_change.feature`
 
-- [ ] **手順 1: feature ファイルの見出しをタスク 1.6 の数学に合わせて整理する**
+- [ ] **手順 1: 機能ファイルの見出しをタスク 1.6 の数学に合わせて整理する**
 
 `features/katas/basic_gates/phase_change.feature` の導入文を、少なくとも次の内容へ寄せる。
 
@@ -39,7 +39,7 @@
 
 - [ ] **手順 2: 低レベルシナリオを 4 本の高レベルシナリオに置き換える**
 
-feature ファイルを次の方向へ更新する。
+機能ファイルを次の方向へ更新する。
 
 ```gherkin
 Scenario: 位相回転は |0> を変えない
@@ -129,7 +129,7 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec cucumber \
 
 で失敗する。
 
-- [ ] **手順 4: 失敗する feature をコミットする**
+- [ ] **手順 4: 失敗する機能ファイルをコミットする**
 
 ```bash
 git add features/katas/basic_gates/phase_change.feature
@@ -175,7 +175,7 @@ git commit -m "test: rewrite phase change scenarios"
 
 などの正規化を壊さない最小変更にとどめる。
 
-- [ ] **手順 4: 対象 feature ファイルを成功させる**
+- [ ] **手順 4: 対象の機能ファイルを成功させる**
 
 実行:
 
@@ -272,7 +272,7 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec rake check
 確認:
 
 - 変更が `phase_change.feature` と `cli_steps.rb` 中心に収まっている
-- 無関係な CLI / renderer / basis API の変更が入っていない
+- 無関係な CLI / 描画処理 / 基底 API の変更が入っていない
 
 - [ ] **手順 4: 最終コミットを追加する**
 

--- a/docs/superpowers/plans/2026-04-01-phase-change-high-level-dsl.md
+++ b/docs/superpowers/plans/2026-04-01-phase-change-high-level-dsl.md
@@ -1,35 +1,35 @@
-# Phase Change High-Level DSL Implementation Plan
+# 位相回転高レベル DSL 実装計画
 
-> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **エージェント作業者向け:** 必須: この計画の実装には superpowers:subagent-driven-development (サブエージェントが利用可能な場合) または superpowers:executing-plans を使う。手順の進捗管理にはチェックボックス (`- [ ]`) 形式を使う。
 
-**Goal:** `phase_change.feature` を Task 1.1〜1.5 と同じ高レベル DSL に書き換え、Task 1.6 の本質である「一般角の位相回転」を scenario からそのまま読めるようにする。
+**目的:** `phase_change.feature` をタスク 1.1〜1.5 と同じ高レベル DSL に書き換え、タスク 1.6 の本質である「一般角の位相回転」をシナリオからそのまま読めるようにする。
 
-**Architecture:** 先に [phase_change.feature](/home/yasuhito/Work/qni-cli/.worktrees/codex-phase-change-rewrite/features/katas/basic_gates/phase_change.feature) を concept-centered な high-level scenario へ赤く書き換える。次に [features/step_definitions/cli_steps.rb](/home/yasuhito/Work/qni-cli/.worktrees/codex-phase-change-rewrite/features/step_definitions/cli_steps.rb) の symbolic 比較 helper だけを最小限拡張し、`exp(iθ)` や `exp(iθ)β` の人間向け表記を既存の `qni run --symbolic` 出力と同値に扱えるようにして green にする。
+**構成:** 先に [phase_change.feature](/home/yasuhito/Work/qni-cli/.worktrees/codex-phase-change-rewrite/features/katas/basic_gates/phase_change.feature) を概念中心の高レベルシナリオへ書き換えて失敗を確認する。次に [features/step_definitions/cli_steps.rb](/home/yasuhito/Work/qni-cli/.worktrees/codex-phase-change-rewrite/features/step_definitions/cli_steps.rb) の記号表現比較ヘルパーだけを最小限拡張し、`exp(iθ)` や `exp(iθ)β` の人間向け表記を既存の `qni run --symbolic` 出力と同値に扱えるようにして成功させる。
 
-**Tech Stack:** Ruby, Cucumber, Bundler, existing high-level kata DSL, `cli_steps.rb`, `qni run --symbolic`
+**技術構成:** Ruby, Cucumber, Bundler, 既存の高レベル kata DSL, `cli_steps.rb`, `qni run --symbolic`
 
 ---
 
-## File Structure
+## ファイル構成
 
-- Modify: `features/katas/basic_gates/phase_change.feature`
-  - low-level な `qni add P ...` / numeric CSV 比較 / controlled 検証を、高レベル DSL の 1-qubit scenario へ置き換える。
-- Modify: `features/step_definitions/cli_steps.rb`
-  - `Then 状態ベクトルは:` の symbolic 比較 helper を拡張し、`exp(iθ)` 形式と乗算順の差を最小限 canonicalize する。
-- Verify: `features/katas/basic_gates/phase_flip.feature`
-  - Task 1.5 の `|+i>` / `|-i>` DSL が Task 1.6 の rewrite で回帰していないことを確認する。
-- Verify: `features/katas/basic_gates/state_flip.feature`
+- 変更: `features/katas/basic_gates/phase_change.feature`
+  - 低レベルな `qni add P ...` / 数値 CSV 比較 / 制御つき検証を、高レベル DSL の 1量子ビットシナリオへ置き換える。
+- 変更: `features/step_definitions/cli_steps.rb`
+  - `Then 状態ベクトルは:` の記号表現比較ヘルパーを拡張し、`exp(iθ)` 形式と乗算順の差を最小限正規化する。
+- 確認: `features/katas/basic_gates/phase_flip.feature`
+  - タスク 1.5 の `|+i>` / `|-i>` DSL がタスク 1.6 の書き換えで回帰していないことを確認する。
+- 確認: `features/katas/basic_gates/state_flip.feature`
   - 既存の `Then 状態ベクトルは:` 比較が壊れていないことを確認する。
-- Verify: `features/qni_run.feature`
-  - `qni run --symbolic` の既存 acceptance が比較 helper の変更で影響を受けていないことを full check で確認する。
+- 確認: `features/qni_run.feature`
+  - `qni run --symbolic` の既存受け入れ条件が比較ヘルパーの変更で影響を受けていないことを全体チェックで確認する。
 
-## Task 1: `phase_change.feature` を高レベル DSL に先に書き換えて赤くする
+## タスク 1: `phase_change.feature` を高レベル DSL に先に書き換えて失敗させる
 
-**Files:**
-- Modify: `features/katas/basic_gates/phase_change.feature`
-- Test: `features/katas/basic_gates/phase_change.feature`
+**ファイル:**
+- 変更: `features/katas/basic_gates/phase_change.feature`
+- テスト: `features/katas/basic_gates/phase_change.feature`
 
-- [ ] **Step 1: feature header を Task 1.6 の数学に合わせて整理する**
+- [ ] **手順 1: feature ファイルの見出しをタスク 1.6 の数学に合わせて整理する**
 
 `features/katas/basic_gates/phase_change.feature` の導入文を、少なくとも次の内容へ寄せる。
 
@@ -37,9 +37,9 @@
 - 入力状態は `α|0⟩ + β|1⟩`
 - 目標は `α|0⟩ + exp(iθ)β|1⟩`
 
-- [ ] **Step 2: low-level scenario を 4 本の high-level scenario に置き換える**
+- [ ] **手順 2: 低レベルシナリオを 4 本の高レベルシナリオに置き換える**
 
-feature を次の方向へ更新する。
+feature ファイルを次の方向へ更新する。
 
 ```gherkin
 Scenario: 位相回転は |0> を変えない
@@ -111,102 +111,102 @@ Scenario: 位相回転は α|0> + β|1> を α|0> + exp(iθ)β|1> に変える
     """
 ```
 
-この task で controlled 検証 scenario は削除する。
+このタスクで制御つき検証シナリオは削除する。
 
-- [ ] **Step 3: focused cucumber で red を確認する**
+- [ ] **手順 3: 対象 Cucumber で失敗を確認する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec cucumber \
   features/katas/basic_gates/phase_change.feature
 ```
 
-Expected:
+期待結果:
 
-- `exp(iθ)` と現在の symbolic 出力 `exp(I*theta)` の差
-- `exp(iθ)β` と現在の symbolic 出力 `beta*exp(I*theta)` の差
+- `exp(iθ)` と現在の記号表現出力 `exp(I*theta)` の差
+- `exp(iθ)β` と現在の記号表現出力 `beta*exp(I*theta)` の差
 
-で fail する。
+で失敗する。
 
-- [ ] **Step 4: failing feature をコミットする**
+- [ ] **手順 4: 失敗する feature をコミットする**
 
 ```bash
 git add features/katas/basic_gates/phase_change.feature
 git commit -m "test: rewrite phase change scenarios"
 ```
 
-## Task 2: symbolic 比較 helper を位相回転の記法に合わせて最小拡張する
+## タスク 2: 記号表現比較ヘルパーを位相回転の記法に合わせて最小拡張する
 
-**Files:**
-- Modify: `features/step_definitions/cli_steps.rb`
-- Test: `features/katas/basic_gates/phase_change.feature`
+**ファイル:**
+- 変更: `features/step_definitions/cli_steps.rb`
+- テスト: `features/katas/basic_gates/phase_change.feature`
 
-- [ ] **Step 1: comparison の赤テストを helper 観点で固定する**
+- [ ] **手順 1: 比較の失敗テストをヘルパー観点で固定する**
 
-Task 1 の red を再実行して、失敗理由が次の 2 種に限定されていることを確認する。
+タスク 1 の失敗を再実行して、失敗理由が次の 2 種に限定されていることを確認する。
 
 - `exp(iθ)` と `exp(I*theta)` の表記差
 - `exp(iθ)β` と `beta*exp(I*theta)` の乗算順差
 
-- [ ] **Step 2: `exp(iθ)` 形式を canonicalize する helper を追加する**
+- [ ] **手順 2: `exp(iθ)` 形式を正規化するヘルパーを追加する**
 
-`features/step_definitions/cli_steps.rb` に、少なくとも次を吸収する最小 helper を追加する。
+`features/step_definitions/cli_steps.rb` に、少なくとも次を吸収する最小ヘルパーを追加する。
 
 - `exp(iθ)` -> `exp(i*theta)`
 - `exp(iπ/2)` -> `exp(i*pi/2)`
-- `exp(iθ)β` -> 比較用 canonical form
+- `exp(iθ)β` -> 比較用の正規形
 
 実装方針は次のどちらかに絞る。
 
-- expected 側を `beta*exp(i*theta)` に寄せる
-- actual / expected の両方を同じ phase-product canonical form に寄せる
+- 期待値側を `beta*exp(i*theta)` に寄せる
+- 実際値 / 期待値の両方を同じ位相積の正規形に寄せる
 
-この task では YAGNI でよい。Task 1.6 で使う形だけを通せれば十分。
+このタスクでは YAGNI でよい。タスク 1.6 で使う形だけを通せれば十分。
 
-- [ ] **Step 3: `Then 状態ベクトルは:` が既存 scenario を壊さないことを意識して実装する**
+- [ ] **手順 3: `Then 状態ベクトルは:` が既存シナリオを壊さないことを意識して実装する**
 
-比較 helper の変更は、既存の
+比較ヘルパーの変更は、既存の
 
 - `|0>`
 - `α|0> + β|1>`
 - `i|1>`
 - `sqrt(2)/2|0> + sqrt(2)/2|1>`
 
-などの canonicalization を壊さない最小変更にとどめる。
+などの正規化を壊さない最小変更にとどめる。
 
-- [ ] **Step 4: focused feature を green にする**
+- [ ] **手順 4: 対象 feature ファイルを成功させる**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec cucumber \
   features/katas/basic_gates/phase_change.feature
 ```
 
-Expected:
+期待結果:
 
-- 4 scenario が PASS
-- `θ = π/2` の scenario が `|+i>` で green
-- 一般式 scenario が `α|0> + exp(iθ)β|1>` で green
+- 4 シナリオが成功する
+- `θ = π/2` のシナリオが `|+i>` で成功する
+- 一般式シナリオが `α|0> + exp(iθ)β|1>` で成功する
 
-- [ ] **Step 5: helper 実装をコミットする**
+- [ ] **手順 5: ヘルパー実装をコミットする**
 
 ```bash
 git add features/step_definitions/cli_steps.rb features/katas/basic_gates/phase_change.feature
 git commit -m "feat: support high-level phase change DSL"
 ```
 
-## Task 3: 近接 kata の読み口と回帰を確認する
+## タスク 3: 近接 kata の読み口と回帰を確認する
 
-**Files:**
-- Verify: `features/katas/basic_gates/phase_change.feature`
-- Verify: `features/katas/basic_gates/phase_flip.feature`
-- Verify: `features/katas/basic_gates/state_flip.feature`
+**ファイル:**
+- 確認: `features/katas/basic_gates/phase_change.feature`
+- 確認: `features/katas/basic_gates/phase_flip.feature`
+- 確認: `features/katas/basic_gates/state_flip.feature`
 
-- [ ] **Step 1: phase 系 kata をまとめて実行する**
+- [ ] **手順 1: 位相系 kata をまとめて実行する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec cucumber \
@@ -215,72 +215,72 @@ BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec cucumber \
   features/katas/basic_gates/phase_change.feature
 ```
 
-Expected:
+期待結果:
 
-- PASS
-- Task 1.5 の `S` と Task 1.6 の一般位相回転が、連続した教材として読める
+- 成功する
+- タスク 1.5 の `S` とタスク 1.6 の一般位相回転が、連続した教材として読める
 
-- [ ] **Step 2: scenario 名と step の視点が揃っていることを目視確認する**
+- [ ] **手順 2: シナリオ名とステップの視点が揃っていることを目視確認する**
 
-Check:
+確認:
 
 - `phase_flip.feature` は固定角 `i`
 - `phase_change.feature` は一般角 `exp(iθ)`
 - どちらも `When 次の回路を適用:` を使っている
 
-- [ ] **Step 3: 回帰確認をコミットする**
+- [ ] **手順 3: 回帰確認をコミットする**
 
 ```bash
 git add features/katas/basic_gates/phase_change.feature features/step_definitions/cli_steps.rb
 git commit -m "test: verify phase kata DSL progression"
 ```
 
-## Task 4: full check を fresh に通す
+## タスク 4: 全体チェックを最新状態で通す
 
-**Files:**
-- Verify: repo-wide checks
+**ファイル:**
+- 確認: リポジトリ全体のチェック
 
-- [ ] **Step 1: symbolic runtime を先に整える**
+- [ ] **手順 1: 記号表現の実行環境を先に整える**
 
-Run:
+実行:
 
 ```bash
 bash scripts/setup_symbolic_python.sh
 ```
 
-Expected:
+期待結果:
 
-- SymPy version が表示される
+- SymPy のバージョンが表示される
 
-- [ ] **Step 2: repo 全体の品質チェックを実行する**
+- [ ] **手順 2: リポジトリ全体の品質チェックを実行する**
 
-Run:
+実行:
 
 ```bash
 BUNDLE_PATH=/home/yasuhito/Work/qni-cli/.bundle/vendor bundle exec rake check
 ```
 
-Expected:
+期待結果:
 
-- cucumber PASS
-- RuboCop PASS
-- reek PASS
-- flog / flay PASS
+- Cucumber が成功する
+- RuboCop が成功する
+- reek が成功する
+- flog / flay が成功する
 
-- [ ] **Step 3: 最終差分を確認する**
+- [ ] **手順 3: 最終差分を確認する**
 
-Check:
+確認:
 
 - 変更が `phase_change.feature` と `cli_steps.rb` 中心に収まっている
-- unrelated な CLI / renderer / basis API の変更が入っていない
+- 無関係な CLI / renderer / basis API の変更が入っていない
 
-- [ ] **Step 4: 最終 commit を追加する**
+- [ ] **手順 4: 最終コミットを追加する**
 
 ```bash
 git add features/katas/basic_gates/phase_change.feature features/step_definitions/cli_steps.rb
 git commit -m "test: complete phase change high-level DSL"
 ```
 
-- [ ] **Step 5: integration handoff**
+- [ ] **手順 5: 統合引き継ぎ**
 
-If the branch is clean and `rake check` passed, merge or prepare PR using the repo’s usual completion flow.
+ブランチがクリーンで `rake check` が成功している場合、リポジトリの通常の完了手順に従ってマージするか PR を準備する。

--- a/docs/superpowers/plans/2026-04-01-phase-change-high-level-dsl.md
+++ b/docs/superpowers/plans/2026-04-01-phase-change-high-level-dsl.md
@@ -13,7 +13,7 @@
 ## ファイル構成
 
 - 変更: `features/katas/basic_gates/phase_change.feature`
-  - 低レベルな `qni add P ...` / 数値 CSV 比較 / 制御つき検証を、高レベル DSL の 1量子ビットシナリオへ置き換える。
+  - 低レベルな `qni add P ...` / 数値 CSV 比較 / 制御付き検証を、高レベル DSL の 1量子ビットシナリオへ置き換える。
 - 変更: `features/step_definitions/cli_steps.rb`
   - `Then 状態ベクトルは:` の記号表現比較ヘルパーを拡張し、`exp(iθ)` 形式と乗算順の差を最小限正規化する。
 - 確認: `features/katas/basic_gates/phase_flip.feature`
@@ -111,7 +111,7 @@ Scenario: 位相回転は α|0> + β|1> を α|0> + exp(iθ)β|1> に変える
     """
 ```
 
-このタスクで制御つき検証シナリオは削除する。
+このタスクで制御付き検証シナリオは削除する。
 
 - [ ] **手順 3: 対象 Cucumber で失敗を確認する**
 


### PR DESCRIPTION
## 概要

- YAS-292 の対象文書 `docs/superpowers/plans/2026-04-01-phase-change-high-level-dsl.md` の文体を見直しました。
- 英語見出しや本文中の不自然な英日混在を自然な日本語に修正しました。
- コマンド、ファイルパス、Gherkin キーワード、API 名、識別子は原文を維持しています。

## 検証

- `git diff --check`
- `bundle exec rake check`

## Linear

- YAS-292
