### PR TITLE
qni view 罫線描画設計仕様の文体を整える

### DIFF
--- a/docs/superpowers/specs/2026-03-28-qni-view-box-drawing-design.md
+++ b/docs/superpowers/specs/2026-03-28-qni-view-box-drawing-design.md
@@ -1,24 +1,24 @@
-# qni View Box Drawing Design
+# `qni view` の罫線描画設計
 
-## Goal
+## 目的
 
-`qni view` を Qiskit 風の box-drawing 形式へ置き換え、各 step を将来パースしやすい 3 行セル表現で描画する。
+`qni view` を Qiskit 風の罫線形式へ置き換え、各ステップを将来解析しやすい 3 行セル表現で描画する。
 
-## Approach
+## 方針
 
-- qni の既存モデルを活かし、`1 step = 1 text layer` とする。
-- 各 qubit wire は `top/mid/bot` の 3 行で描く。
-- 単一ゲートは箱で囲み、control は `■`、swap は `X` を接続線付きで描く。
+- qni の既存モデルを活かし、1 ステップを 1 つのテキスト層とする。
+- 各量子ビット線は `top/mid/bot` の 3 行で描く。
+- 単一ゲートは箱で囲み、制御点は `■`、SWAP は `X` を接続線付きで描く。
 - 空セルも固定幅セルで描き、出力が決定的になるようにする。
 
-## Constraints
+## 制約
 
-- 現在の `cols` 形式は step 内の完全なゲート構造を保存していない。
-- そのため renderer は現行の qni 制約に合わせて、単純な単一ゲート、control + target、swap、独立単一ゲートを優先対応とする。
-- 将来の逆パースを見据えて、セル境界と記号体系は安定化する。
+- 現在の `cols` 形式はステップ内の完全なゲート構造を保存していない。
+- そのため描画処理は現行の qni 制約に合わせて、単純な単一ゲート、制御点 + 対象、SWAP、独立単一ゲートを優先対応とする。
+- 将来の逆解析を見据えて、セル境界と記号体系は安定化する。
 
-## Testing
+## テスト
 
 - 先に `features/qni_view.feature` を Qiskit 風の期待値へ更新する。
-- 代表的な `add_*.feature` にも `qni view` 比較を追加し、見た目から結果が分かる feature にする。
-- 代表ケースは H, X, angled gate, CNOT, SWAP, 複数同時単一ゲートを含める。
+- 代表的な `add_*.feature` にも `qni view` 比較を追加し、見た目から結果が分かる機能仕様にする。
+- 代表ケースは H、X、角度付きゲート、CNOT、SWAP、複数同時単一ゲートを含める。


### PR DESCRIPTION
## 概要

- `docs/superpowers/specs/2026-03-28-qni-view-box-drawing-design.md` の見出しを日本語へ修正しました。
- 日本語本文に混ざっていた `box-drawing`、`step`、`text layer`、`qubit wire`、`renderer` などの英語普通名詞を自然な日本語へ直しました。
- `qni view`、`Qiskit`、`cols`、`features/qni_view.feature`、`top/mid/bot` など、識別子や固有技術用語は原文を保ちました。

## Linear

- YAS-294

## 検証

- `git diff --check`
- `bundle exec rake check`
