### PR TITLE
振幅変化 DSL 設計仕様の文体を整える

### DIFF
--- a/docs/superpowers/specs/2026-03-31-amplitude-change-high-level-dsl-design.md
+++ b/docs/superpowers/specs/2026-03-31-amplitude-change-high-level-dsl-design.md
@@ -1,6 +1,6 @@
-# Amplitude Change High-Level DSL Design
+# 振幅変化の高レベル DSL 設計
 
-## Problem
+## 課題
 
 現在の [amplitude_change.feature](/home/yasuhito/Work/qni-cli/features/katas/basic_gates/amplitude_change.feature) は、
 
@@ -8,9 +8,9 @@
 - `qni variable set alpha ...`
 - `qni run`
 - 数値 CSV 出力の比較
-- controlled 検証 scenario
+- 制御付き検証シナリオ
 
-という low-level な書き方になっている。
+という低レベルな書き方になっている。
 
 そのため、すでに高レベル化した
 
@@ -24,33 +24,33 @@
 - `|1> -> -sin(θ)|0> + cos(θ)|1>`
 - 一般状態の振幅回転
 
-という task の本質が scenario から直接読み取りにくい。
+というタスクの本質がシナリオから直接読み取りにくい。
 
-また、Task 1.4 の実装は `Ry(2θ)` で自然に表せるが、feature 上で `2θ` を毎回見せると、
+また、Task 1.4 の実装は `Ry(2θ)` で自然に表せるが、`.feature` ファイル上で `2θ` を毎回見せると、
 
 - 学習者には「なぜ 2 倍なのか」がノイズになりやすい
-- task の主題である「振幅を θ だけ回転する」が隠れやすい
+- タスクの主題である「振幅を θ だけ回転する」が隠れやすい
 
 という問題がある。
 
-## Goal
+## 目標
 
-- [amplitude_change.feature](/home/yasuhito/Work/qni-cli/features/katas/basic_gates/amplitude_change.feature) を 1 qubit の状態変化を高レベルに読む feature へ書き換える
-- `Ry(2θ)` の実装詳細を feature から隠し、「振幅を θ だけ回転する」という task の意味をそのまま読めるようにする
+- [amplitude_change.feature](/home/yasuhito/Work/qni-cli/features/katas/basic_gates/amplitude_change.feature) を 1 量子ビットの状態変化を高レベルに読める `.feature` ファイルへ書き換える
+- `Ry(2θ)` の実装詳細を `.feature` ファイルから隠し、「振幅を θ だけ回転する」というタスクの意味をそのまま読めるようにする
 - 既存の
   - `Given 初期状態ベクトルは:`
   - `Then 状態ベクトルは:`
   を活かしつつ、最小の DSL 拡張で済ませる
-- symbolic 一般式 scenario も Task 1.1 / 1.3 と同じ読みやすさへ寄せる
+- 記号的な一般式のシナリオも Task 1.1 / 1.3 と同じ読みやすさへ寄せる
 
-## Non-Goals
+## 対象外
 
-- controlled 検証 scenario を残すこと
+- 制御付き検証シナリオを残すこと
 - `Ry(2θ)` を ASCII 回路として常に明示すること
-- 2 qubit 以上の振幅回転 DSL を同時に設計すること
-- Bloch 球や幾何学的説明を feature DSL に直接埋め込むこと
+- 2 量子ビット以上の振幅回転 DSL を同時に設計すること
+- Bloch 球や幾何学的説明を `.feature` ファイルの DSL に直接埋め込むこと
 
-## Approaches Considered
+## 検討した案
 
 ### 1. `Ry(2θ)` をそのまま `次の回路を適用:` に書く
 
@@ -67,9 +67,9 @@ When 次の回路を適用:
 
 - 既存 DSL にそのまま乗る
 - 実装の追加は少ない
-- ただし `2θ` が task の意味より前に出てしまい、読みやすさが下がる
+- ただし `2θ` がタスクの意味より前に出てしまい、読みやすさが下がる
 
-### 2. 振幅回転専用の high-level step を足す
+### 2. 振幅回転専用の高レベルステップを足す
 
 例:
 
@@ -77,11 +77,11 @@ When 次の回路を適用:
 When 振幅を θ だけ回転:
 ```
 
-- task の意図が最もストレートに読める
+- タスクの意図が最も直接的に読める
 - `Ry(2θ)` の内部実装を隠せる
-- 追加 DSL は 1 step で済む
+- 追加 DSL は 1 ステップで済む
 
-### 3. `状態ベクトル` 以外の専用出力 step も増やす
+### 3. `状態ベクトル` 以外の専用出力ステップも増やす
 
 例:
 
@@ -89,16 +89,16 @@ When 振幅を θ だけ回転:
 - `Then 回転行列の作用は:`
 
 - 説明力は高い
-- ただし DSL が task 依存に広がりすぎる
-- 既存の kata feature との一貫性が下がる
+- ただし DSL がタスク依存に広がりすぎる
+- 既存の kata の `.feature` ファイルとの一貫性が下がる
 
-## Decision
+## 決定
 
-Approach 2 を採用する。
+案 2 を採用する。
 
-- 新しい step として `When 振幅を {angle} だけ回転:` を追加する
-- 内部ではその step が `Ry(2*angle)` の 1-step 回路を append する
-- feature では `Ry` ではなく「振幅回転」という task の意味を前面に出す
+- 新しいステップとして `When 振幅を {angle} だけ回転:` を追加する
+- 内部ではそのステップが `Ry(2*angle)` の 1 ステップ回路を追加する
+- `.feature` ファイルでは `Ry` ではなく「振幅回転」というタスクの意味を前面に出す
 - 結果確認は既存の `Then 状態ベクトルは:` を使う
 
 これにより、Task 1.4 も Task 1.1 / 1.2 / 1.3 と同じく、
@@ -109,11 +109,11 @@ Approach 2 を採用する。
 
 という形へ揃えられる。
 
-## User-Facing DSL
+## 利用者向け DSL
 
-### New Step
+### 新しいステップ
 
-新しく次の step を追加する。
+新しく次のステップを追加する。
 
 ```gherkin
 When 振幅を θ だけ回転:
@@ -127,19 +127,19 @@ When 振幅を θ だけ回転:
 - `2π/3`
 - `-π/4`
 
-第 1 段では doc string は持たず、1 行 step とする。
+第 1 段ではドキュメント文字列は持たず、1 行ステップとする。
 
-### Internal Meaning
+### 内部での意味
 
-この step は内部で次に等価とする。
+このステップは内部で次に等価とする。
 
 ```text
 Ry(2*θ)
 ```
 
-つまり task 文脈での「振幅を θ だけ回転する」を、実装上の `Ry(2θ)` へ写像する。
+つまりタスク文脈での「振幅を θ だけ回転する」を、実装上の `Ry(2θ)` へ写像する。
 
-## Feature Shape
+## `.feature` ファイルの形
 
 書き換え後の [amplitude_change.feature](/home/yasuhito/Work/qni-cli/features/katas/basic_gates/amplitude_change.feature) は、次の 4 本を基本形とする。
 
@@ -203,16 +203,16 @@ Scenario: 振幅回転は α|0> + β|1> を一般式どおりに変える
     """
 ```
 
-## Why This Shape Is Better
+## この形がよい理由
 
-- `Ry(2θ)` の `2` という実装都合を feature から隠せる
+- `Ry(2θ)` の `2` という実装都合を `.feature` ファイルから隠せる
 - `Task 1.4` の主語が「振幅回転」になり、学習者の視点に近い
 - 既存の高レベル kata と同じリズムで読める
-- symbolic scenario も「回転行列の作用」がそのまま見える
+- 記号的なシナリオも「回転行列の作用」がそのまま見える
 
-## Internal Design
+## 内部設計
 
-### 1. Step Definition
+### 1. ステップ定義
 
 [features/step_definitions/cli_steps.rb](/home/yasuhito/Work/qni-cli/features/step_definitions/cli_steps.rb) に
 
@@ -222,19 +222,19 @@ When('振幅を {string} だけ回転:') do |angle|
 end
 ```
 
-相当の step を追加する。
+相当のステップを追加する。
 
-この step は内部で 1-qubit の回路
+このステップは内部で 1 量子ビットの回路
 
 ```json
 { "qubits": 1, "cols": [["Ry(2*theta)"]] }
 ```
 
-のような 1 column を append する。
+のような 1 列を追加する。
 
-### 2. Angle Normalization
+### 2. 角度の正規化
 
-step は表示上の Greek 文字を受け付けつつ、内部では既存の ASCII angle parser に寄せる。
+ステップは表示上のギリシャ文字を受け付けつつ、内部では既存の ASCII 角度パーサーに寄せる。
 
 最小案:
 
@@ -243,19 +243,19 @@ step は表示上の Greek 文字を受け付けつつ、内部では既存の A
 
 だけを行い、その結果を `Ry(2*...)` へ埋め込む。
 
-### 3. Existing Infrastructure Reuse
+### 3. 既存基盤の再利用
 
-数値 run と symbolic run は既存の `Ry` 実装をそのまま使う。
+数値実行と記号的な実行は既存の `Ry` 実装をそのまま使う。
 
 したがって追加実装は主に
 
-- feature の書き換え
-- `振幅を ... だけ回転` step
+- `.feature` ファイルの書き換え
+- `振幅を ... だけ回転` ステップ
 - 角度文字列の軽い正規化
 
 に留められる。
 
-## Risks
+## リスク
 
 ### 1. 一般式の期待値が長くなる
 
@@ -267,19 +267,19 @@ step は表示上の Greek 文字を受け付けつつ、内部では既存の A
 
 となり、Task 1.1 や 1.3 より少し複雑である。
 
-ただしこれは task の数学そのものなので、省略せず見せる価値が高い。
+ただしこれはタスクの数学そのものなので、省略せず見せる価値が高い。
 
-### 2. `When` step が task 専用になる
+### 2. `When` ステップがタスク専用になる
 
-`振幅を ... だけ回転` は Task 1.4 向けの domain-specific step である。
+`振幅を ... だけ回転` は Task 1.4 向けのタスク専用ステップである。
 
-ただし 1 本だけで task の意味を大きく改善できるので、過剰な DSL 拡張とはみなさない。
+ただし 1 本だけでタスクの意味を大きく改善できるので、過剰な DSL 拡張とはみなさない。
 
-## Follow-Up
+## 後続作業
 
-この spec が承認されたら、次は implementation plan で以下を刻む。
+この仕様が承認されたら、次は実装計画で以下を刻む。
 
-- `amplitude_change.feature` の acceptance を先に高レベル化する
+- `amplitude_change.feature` の受け入れ条件を先に高レベル化する
 - `cli_steps.rb` に `When 振幅を ... だけ回転:` を追加する
-- targeted cucumber で green にする
-- fresh な `bundle exec rake check` を通す
+- 対象を絞った Cucumber で成功させる
+- 最新の `bundle exec rake check` を通す


### PR DESCRIPTION
## 概要

- `docs/superpowers/specs/2026-03-31-amplitude-change-high-level-dsl-design.md` の見出しと本文を自然な日本語に整えました。
- `low-level`、`scenario`、`task`、`step`、`append` など、日本語本文中の不自然な英語普通名詞を置き換えました。
- `.feature`、`DSL`、Gherkin キーワード、コード例、ファイルパスなど、識別子や固有技術用語は保持しました。

## Linear

- YAS-299

## 検証

- `git diff --check`
- `bundle exec rake check`
