### PR TITLE
仕様書の日本語文体を整える

### DIFF
--- a/docs/superpowers/specs/2026-03-31-angled-gate-stacked-angle-design.md
+++ b/docs/superpowers/specs/2026-03-31-angled-gate-stacked-angle-design.md
@@ -1,23 +1,23 @@
-# Angled Gate Stacked Angle Design
+# 角度付きゲートの上置き角度設計
 
-Date: 2026-03-31
+日付: 2026-03-31
 
-## Goal
+## 目的
 
-`Rx`, `Ry`, `Rz`, `P` のような回転ゲートを、横長の箱ではなく「角度を箱の上に中央揃えで載せる」正規形で表示し、その形を ASCII parser でもそのまま受けられるようにする。
+`Rx`, `Ry`, `Rz`, `P` のような回転ゲートを、横長の箱ではなく「角度を箱の上に中央揃えで載せる」正規形で表示し、その形を ASCII パーサーでもそのまま受けられるようにする。
 
-これにより、固定ゲートと回転ゲートの箱サイズをそろえ、`qni view` と feature の ASCII 回路記述を読みやすくする。
+これにより、固定ゲートと回転ゲートの箱サイズをそろえ、`qni view` とフィーチャーファイルの ASCII 回路記述を読みやすくする。
 
-## Non-Goals
+## 対象外
 
 - 旧式の横長箱表記との後方互換
 - 量子回路以外の注釈行の導入
-- fixed gate の見た目変更
-- LaTeX / PNG export の見た目変更
+- 固定ゲートの見た目変更
+- LaTeX / PNG 出力の見た目変更
 
-## Canonical ASCII Form
+## 正規 ASCII 形式
 
-回転ゲートの canonical form は次の 4 行とする。
+回転ゲートの正規形は次の 4 行とする。
 
 ```text
           2θ
@@ -30,70 +30,70 @@ q0: ──┤ Ry├──
 
 - 角度は箱の真上に中央揃えで置く
 - 箱の幅は固定ゲートと同じ小箱とする
-- 箱の中には gate 名だけを書く
-- wire は箱の左右で通常どおり伸ばす
+- 箱の中にはゲート名だけを書く
+- ワイヤーは箱の左右で通常どおり伸ばす
 - `Rx`, `Ry`, `Rz`, `P` はすべてこの形式に統一する
 
-## Behavioral Changes
+## 振る舞いの変更
 
 ### qni view
 
-- 回転ゲートを含む step は 4 行で描画する
-- 同じ step の他 qubit 側には空の angle 行を挿入して高さをそろえる
-- 回転ゲートを含まない step は従来どおり 3 行のまま
+- 回転ゲートを含むステップは 4 行で描画する
+- 同じステップの他の量子ビット側には空の角度行を挿入して高さをそろえる
+- 回転ゲートを含まないステップは従来どおり 3 行のまま
 
-### ASCII parser
+### ASCII パーサー
 
 - 新しい 4 行形式だけを正規入力として受ける
 - 旧式の横長箱:
   - `┤ Ry(2θ) ├`
   - `┤ Rx(π/2) ├`
   - などは受けない
-- parser は angle 行と gate 名行を結びつけて `Ry(2*theta)` のような内部表現へ正規化する
+- パーサーは角度行とゲート名行を結びつけて `Ry(2*theta)` のような内部表現へ正規化する
 
-### Feature DSL
+### フィーチャー DSL
 
 - `When 次の回路を適用:` では、新しい 4 行形式の回転ゲートを書く
-- `amplitude_change.feature` など回転ゲートを含む feature は canonical form に更新する
+- `amplitude_change.feature` など回転ゲートを含むフィーチャーファイルは正規形に更新する
 
-## Design
+## 設計
 
-### Renderer
+### レンダラー
 
-`TextRenderer` に「step の高さ」を持ち込み、回転ゲートを含む step では 4 行の layer を生成する。
+`TextRenderer` に「ステップの高さ」を持ち込み、回転ゲートを含むステップでは 4 行分の描画層を生成する。
 
 方針:
 
-- `BoxOnQuWire` は fixed gate 用として維持する
+- `BoxOnQuWire` は固定ゲート用として維持する
 - 新しく `AngledBoxOnQuWire` を追加する
 - `AngledBoxOnQuWire` は次の 4 つの文字列を返す:
-  - angle line
-  - top line
-  - mid line
-  - bottom line
-- step 内に 1 つでも angled gate があれば、その step の各 qubit は 4 行で描画する
-- angled gate のない qubit には空の angle line を返す空セルを使う
+  - 角度行
+  - 上線
+  - 中線
+  - 下線
+- ステップ内に 1 つでも角度付きゲートがあれば、そのステップの各量子ビットは 4 行で描画する
+- 角度付きゲートのない量子ビットには空の角度行を返す空セルを使う
 
-### Parser
+### パーサー
 
-ASCII parser は「wire ごとに 3 行」という前提をやめ、step ごとに 3 行または 4 行を扱えるようにする。
+ASCII パーサーは「ワイヤーごとに 3 行」という前提をやめ、ステップごとに 3 行または 4 行を扱えるようにする。
 
 方針:
 
-- `AsciiWireLayout` が step 幅だけでなく step 高さも判断する
-- 回転ゲートを含む step では:
-  - angle line
-  - top wire
-  - mid wire
-  - bottom wire
-  を 1 step として切り出す
-- `AsciiStepParser` は boxed gate の label に加えて、対応する angle line を受け取る
-- angle 行があり gate 名が `Rx/Ry/Rz/P` のときだけ angled gate を組み立てる
-- gate 名だけで angle 行がない場合は angled gate とみなさない
+- `AsciiWireLayout` がステップ幅だけでなくステップ高さも判断する
+- 回転ゲートを含むステップでは:
+  - 角度行
+  - 上ワイヤー
+  - 中ワイヤー
+  - 下ワイヤー
+  を 1 ステップとして切り出す
+- `AsciiStepParser` は箱入りゲートのラベルに加えて、対応する角度行を受け取る
+- 角度行がありゲート名が `Rx/Ry/Rz/P` のときだけ角度付きゲートを組み立てる
+- ゲート名だけで角度行がない場合は角度付きゲートとみなさない
 
-## Internal Representation
+## 内部表現
 
-表示と parser 入力は Unicode を含むが、内部保存は今までどおり ASCII ベースの canonical string に正規化する。
+表示とパーサー入力は Unicode を含むが、内部保存は今までどおり ASCII を基準にした正規文字列に正規化する。
 
 例:
 
@@ -101,43 +101,43 @@ ASCII parser は「wire ごとに 3 行」という前提をやめ、step ごと
 - `Rx(π/2)` -> `Rx(π/2)`
 - `P(-θ)` -> `P(-theta)`
 
-## Test Plan
+## テスト計画
 
-最初に feature を赤くする。
+最初にフィーチャーファイルを赤くする。
 
 1. `features/qni_view.feature`
-   - 回転ゲートの表示が angle-on-top になることを追加
+   - 回転ゲートの表示が角度を上に載せる表示になることを追加
 2. `features/ascii_circuit_parser.feature`
-   - 新しい 4 行形式を受け入れる scenario を追加
-   - 旧横長箱を reject する scenario を追加
+   - 新しい 4 行形式を受け入れるシナリオを追加
+   - 旧横長箱を拒否するシナリオを追加
 3. `features/katas/basic_gates/amplitude_change.feature`
-   - 新しい canonical form に書き換える
+   - 新しい正規形に書き換える
 4. `test/qni/view/ascii_circuit_parser_test.rb`
-   - 4 行形式の parser unit test を追加
-5. renderer 側の unit test が足りなければ追加する
+   - 4 行形式のパーサー単体テストを追加
+5. レンダラー側の単体テストが足りなければ追加する
 
-最後に `bundle exec rake check` を fresh に通す。
+最後に `bundle exec rake check` を最新状態で通す。
 
-## Risks
+## リスク
 
-### Step Height Complexity
+### ステップ高さの複雑さ
 
-`TextRenderer` と `AsciiWireLayout` はこれまで 3 行前提が強い。step 高さの導入で merge ロジックが複雑になる可能性がある。
-
-対策:
-
-- angled gate 専用の行だけを明示的に分離する
-- fixed gate の既存 merge ロジックはできるだけそのまま残す
-
-### Controlled Gate Interaction
-
-回転ゲートと control が同じ step に来たとき、angle 行だけが増えて縦位置が崩れる可能性がある。
+`TextRenderer` と `AsciiWireLayout` はこれまで 3 行前提が強い。ステップ高さの導入で合成処理が複雑になる可能性がある。
 
 対策:
 
-- step 単位で高さを決める
-- control や empty wire 側にも空の angle 行を足してそろえる
+- 角度付きゲート専用の行だけを明示的に分離する
+- 固定ゲートの既存合成処理はできるだけそのまま残す
 
-## Recommendation
+### 制御ゲートとの相互作用
 
-後方互換を捨てる前提なので、回転ゲートの ASCII 表現はこの 4 行形式へ一気に統一する。表示と parser を同時に切り替え、feature も canonical form にそろえるのが最もシンプルでわかりやすい。
+回転ゲートと制御が同じステップに来たとき、角度行だけが増えて縦位置が崩れる可能性がある。
+
+対策:
+
+- ステップ単位で高さを決める
+- 制御や空ワイヤー側にも空の角度行を足してそろえる
+
+## 推奨方針
+
+後方互換を捨てる前提なので、回転ゲートの ASCII 表現はこの 4 行形式へ一気に統一する。表示とパーサーを同時に切り替え、フィーチャーファイルも正規形にそろえるのが最もシンプルでわかりやすい。


### PR DESCRIPTION
## 概要

- YAS-300
- `docs/superpowers/specs/2026-03-31-angled-gate-stacked-angle-design.md` の見出しと本文を自然な日本語表現へ整理しました。
- コード識別子、ファイルパス、コマンド、ASCII 図、期待値は変更していません。

## 検証

- `git diff --check`
- `bundle exec rake check`
