### PR TITLE
BellStateChange1 仕様書の文体を整える

### DIFF
--- a/docs/superpowers/specs/2026-04-01-bell-state-change-1-high-level-dsl-design.md
+++ b/docs/superpowers/specs/2026-04-01-bell-state-change-1-high-level-dsl-design.md
@@ -1,82 +1,82 @@
-# Bell State Change 1 High-Level DSL Design
+# Bell State Change 1 の高レベル DSL 設計
 
-## Problem
+## 問題
 
 現在の [bell_state_change_1.feature](/home/yasuhito/Work/qni-cli/features/katas/basic_gates/bell_state_change_1.feature) は、
 
 - `qni add H ...`
 - `qni add X --control ...`
-- numeric CSV の比較
-- controlled 検証回路
+- 数値 CSV の比較
+- 制御付き検証回路
 
 が前面に出ており、[state_flip.feature](/home/yasuhito/Work/qni-cli/features/katas/basic_gates/state_flip.feature) から [global_phase_change.feature](/home/yasuhito/Work/qni-cli/features/katas/basic_gates/global_phase_change.feature) までで整ってきた高レベル DSL の流れから外れている。
 
-そのため、Task 1.8 の本質である
+そのため、課題 1.8 の本質である
 
 - `|Φ+>` を `|Φ->` に変える
 - Bell 状態を Bell 基底のまま読む
-- 一般には Bell 基底上の論理 qubit に `Z` が作用する
+- 一般には Bell 基底上の論理量子ビットに `Z` が作用する
 
-が scenario から直接読み取りにくい。
+がシナリオから直接読み取りにくい。
 
 また、現状の DSL には次がない。
 
-- `|Φ+>`, `|Φ->`, `|Ψ+>`, `|Ψ->` shorthand
+- `|Φ+>`, `|Φ->`, `|Ψ+>`, `|Ψ->` の短縮表記
 - `qni run --symbolic --basis bell`
 - `Then Bell 基底での状態ベクトルは:`
 
-このため、Task 1.8 を Task 1.1〜1.7 と同じ温度感で書くには、Bell 基底を first-class に扱える必要がある。
+このため、課題 1.8 を課題 1.1〜1.7 と同じ温度感で書くには、Bell 基底を第一級の概念として扱える必要がある。
 
-## Goal
+## 目的
 
 - [bell_state_change_1.feature](/home/yasuhito/Work/qni-cli/features/katas/basic_gates/bell_state_change_1.feature) を高レベル DSL に書き換える
 - Bell 状態を計算基底へ展開せず、そのまま `|Φ+>` / `|Φ->` で読めるようにする
-- `qni state set` と `Given 初期状態ベクトルは:` で Bell 状態 shorthand を正式サポートする
-- CLI に `qni run --symbolic --basis bell` を追加し、feature step でも再利用する
+- `qni state set` と `Given 初期状態ベクトルは:` で Bell 状態の短縮表記を正式サポートする
+- CLI に `qni run --symbolic --basis bell` を追加し、ステップ定義でも再利用する
 
-## Non-Goals
+## 対象外
 
-- 3 qubit 以上の entangled basis を追加すること
-- Bell 基底以外の 2 qubit 基底を同時に追加すること
-- controlled 検証 scenario を残すこと
-- Bell 基底の numeric 表示や測定 DSL まで同時に広げること
+- 3 量子ビット以上のエンタングル基底を追加すること
+- Bell 基底以外の 2 量子ビット基底を同時に追加すること
+- 制御付き検証シナリオを残すこと
+- Bell 基底の数値表示や測定 DSL まで同時に広げること
 
-## Approaches Considered
+## 検討した案
 
-### 1. Scenario 名だけ高レベルにして、中身は計算基底のままにする
+### 1. シナリオ名だけ高レベルにして、中身は計算基底のままにする
 
-- scenario 名は `Z ゲートは |Φ+> を |Φ-> に変える`
-- ただし expected output は `sqrt(2)/2|00> - sqrt(2)/2|11>`
+- シナリオ名は `Z ゲートは |Φ+> を |Φ-> に変える`
+- ただし期待出力は `sqrt(2)/2|00> - sqrt(2)/2|11>`
 
-最小実装ではあるが、Task 1.8 の主語と expected output の視点がずれる。
+最小実装ではあるが、課題 1.8 の主語と期待出力の視点がずれる。
 
-### 2. 初期状態だけ Bell shorthand にし、結果は計算基底のままにする
+### 2. 初期状態だけ Bell 状態の短縮表記にし、結果は計算基底のままにする
 
 - `Given 初期状態ベクトルは: |Φ+>`
 - `Then 状態ベクトルは: sqrt(2)/2|00> - sqrt(2)/2|11>`
 
-入り口は自然になるが、結果が Bell 状態 task らしく読めない。
+入り口は自然になるが、結果が Bell 状態の課題らしく読めない。
 
-### 3. Bell 基底を first-class にし、入力も出力も Bell 基底で読めるようにする
+### 3. Bell 基底を第一級の概念にし、入力も出力も Bell 基底で読めるようにする
 
 - `qni state set "|Φ+>"`
 - `qni run --symbolic --basis bell`
 - `Then Bell 基底での状態ベクトルは:`
 
-Task 1.8 を最も自然に書けるうえ、Task 1.9 以降の Bell 系 task にも再利用しやすい。
+課題 1.8 を最も自然に書けるうえ、課題 1.9 以降の Bell 系の課題にも再利用しやすい。
 
-## Decision
+## 決定
 
-Approach 3 を採用する。
+案 3 を採用する。
 
-- Bell 状態 shorthand を `InitialState` の正式入力として追加する
+- Bell 状態の短縮表記を `InitialState` の正式入力として追加する
 - CLI に `qni run --symbolic --basis bell` を追加する
-- feature step に `Then Bell 基底での状態ベクトルは:` を追加する
-- [bell_state_change_1.feature](/home/yasuhito/Work/qni-cli/features/katas/basic_gates/bell_state_change_1.feature) は controlled scenario を外し、高レベル DSL にそろえる
+- ステップ定義に `Then Bell 基底での状態ベクトルは:` を追加する
+- [bell_state_change_1.feature](/home/yasuhito/Work/qni-cli/features/katas/basic_gates/bell_state_change_1.feature) は制御付きシナリオを外し、高レベル DSL にそろえる
 
-## User-Facing API
+## ユーザー向け API
 
-### Bell State Shorthand
+### Bell 状態の短縮表記
 
 次を正式サポートする。
 
@@ -96,7 +96,7 @@ Approach 3 を採用する。
 |Ψ-> = (|01> - |10>) / sqrt(2)
 ```
 
-v1 では parser 内で concrete な計算基底の 2 qubit state に展開してよい。
+v1 ではパーサー内で具体的な計算基底の 2 量子ビット状態に展開してよい。
 
 また、次のような Bell 基底上の線形結合も正式サポートする。
 
@@ -113,7 +113,7 @@ v1 では parser 内で concrete な計算基底の 2 qubit state に展開し�
 qni run --symbolic --basis bell
 ```
 
-v1 では 2 qubit 限定とする。
+v1 では 2 量子ビット限定とする。
 
 また、次も受け付ける。
 
@@ -122,9 +122,9 @@ qni state set "|Φ+>"
 qni state set "α|Φ+> + β|Φ->"
 ```
 
-`qni state show` は、保存時に Bell shorthand を使った場合は Bell 基底のまま表示してよい。
+`qni state show` は、保存時に Bell 状態の短縮表記を使った場合は Bell 基底のまま表示してよい。
 
-### Feature Steps
+### ステップ定義
 
 次を追加する。
 
@@ -132,11 +132,11 @@ qni state set "α|Φ+> + β|Φ->"
 Then Bell 基底での状態ベクトルは:
 ```
 
-内部では `qni run --symbolic --basis bell` を使い、Bell 基底での symbolic 表示と比較する。
+内部では `qni run --symbolic --basis bell` を使い、Bell 基底での記号表示と比較する。
 
-## Bell Basis Rendering
+## Bell 基底表示
 
-任意の 2 qubit symbolic state
+任意の 2 量子ビットの記号状態
 
 ```text
 a|00> + b|01> + c|10> + d|11>
@@ -153,10 +153,10 @@ a|00> + b|01> + c|10> + d|11>
 v1 では次を優先する。
 
 - 0 係数の項は省く
-- `sqrt(2)/2` や `α` など exact symbolic 表示を保つ
+- `sqrt(2)/2` や `α` など厳密な記号表示を保つ
 - 項順は `|Φ+>`, `|Φ->`, `|Ψ+>`, `|Ψ->`
 
-## BellStateChange1 Feature Shape
+## BellStateChange1 の機能仕様の形
 
 書き換え後の [bell_state_change_1.feature](/home/yasuhito/Work/qni-cli/features/katas/basic_gates/bell_state_change_1.feature) は、次の 4 本を基本形とする。
 
@@ -242,10 +242,9 @@ Scenario: α|Φ+> + β|Φ-> に Z ゲートを適用すると、Bell 基底で�
     """
 ```
 
-## Testing Strategy
+## 検証方針
 
-- [features/qni_state.feature](/home/yasuhito/Work/qni-cli/features/qni_state.feature) に Bell shorthand の acceptance を追加する
-- [features/qni_run.feature](/home/yasuhito/Work/qni-cli/features/qni_run.feature) に `--basis bell` の acceptance を追加する
+- [features/qni_state.feature](/home/yasuhito/Work/qni-cli/features/qni_state.feature) に Bell 状態の短縮表記の受け入れ仕様を追加する
+- [features/qni_run.feature](/home/yasuhito/Work/qni-cli/features/qni_run.feature) に `--basis bell` の受け入れ仕様を追加する
 - [bell_state_change_1.feature](/home/yasuhito/Work/qni-cli/features/katas/basic_gates/bell_state_change_1.feature) は高レベル DSL に書き換える
-- 既存の計算基底・X 基底・Y 基底表示を壊していないことを full check で確認する
-
+- 既存の計算基底・X 基底・Y 基底表示を壊していないことを全体チェックで確認する

--- a/docs/superpowers/specs/2026-04-01-bell-state-change-1-high-level-dsl-design.md
+++ b/docs/superpowers/specs/2026-04-01-bell-state-change-1-high-level-dsl-design.md
@@ -1,4 +1,4 @@
-# Bell State Change 1 の高レベル DSL 設計
+# BellStateChange1 の高レベル DSL 設計
 
 ## 問題
 


### PR DESCRIPTION
## 概要

- YAS-303
- `docs/superpowers/specs/2026-04-01-bell-state-change-1-high-level-dsl-design.md` の見出しと本文を日本語中心の文体に整理しました。
- コマンド例、ファイルパス、API 名、CLI オプション、Gherkin キーワードは原文のまま保持しました。

## 検証

- `git diff --check`
- `bundle exec rake check`
