### PR TITLE
CNOT 追加仕様の文体を整える

### DIFF
--- a/features/cli/add/add_cnot.feature.md
+++ b/features/cli/add/add_cnot.feature.md
@@ -1,7 +1,7 @@
 # Feature: CNOT ゲートを追加
 
 qni-cli のユーザとして、コマンドラインから量子回路を組み立てるために、
-指定した step と control と target に CNOT ゲートを追加したい。
+指定したステップ、制御量子ビット、対象量子ビットに CNOT ゲートを追加したい。
 
 ## Scenario: CNOT ゲート追加コマンドは成功
 
@@ -40,7 +40,7 @@ qni-cli のユーザとして、コマンドラインから量子回路を組み
   }
   ```
 
-## Scenario: CNOT ゲートは decimal step でも circuit.json を作成
+## Scenario: CNOT ゲートは小数のステップ値でも circuit.json を作成
 
 - When "qni add X --control 0 --qubit 1 --step 0.0" を実行
 - Then "circuit.json" の内容:


### PR DESCRIPTION
## 概要

- YAS-313
- `features/cli/add/add_cnot.feature.md` の日本語本文に混ざっていた `step` / `control` / `target` と `decimal step` を自然な日本語に修正しました。
- コマンド例、Gherkin キーワード、期待値、ステップ文は変更していません。

## 検証

- `git diff --check`
- `bundle exec rake check`

## 補足

- `symphony` ラベルはリポジトリに存在しなかったため付与していません。
