### PR TITLE
Ry ゲート仕様の文体を整える

### DIFF
--- a/features/cli/add/add_ry_gate.feature.md
+++ b/features/cli/add/add_ry_gate.feature.md
@@ -1,7 +1,7 @@
 # Feature: Ry ゲートを追加
 
 qni-cli のユーザとして、コマンドラインから量子回路を組み立てるために、
-指定した step と qubit に Ry ゲートを追加したい。
+指定したステップと量子ビットに Ry ゲートを追加したい。
 
 ## Scenario: Ry ゲート追加コマンドは成功
 
@@ -50,7 +50,7 @@ qni-cli のユーザとして、コマンドラインから量子回路を組み
   }
   ```
 
-## Scenario: Ry ゲートは変数 angle をそのまま保存できる
+## Scenario: Ry ゲートは角度を変数のまま保存できる
 
 - When "qni add Ry --angle theta --qubit 0 --step 0" を実行
 - Then "circuit.json" の内容:


### PR DESCRIPTION
## 概要

- `features/cli/add/add_ry_gate.feature.md` の日本語本文に残っていた英語普通名詞を自然な日本語へ置き換えました。
- CLI 引数、JSON キー、Gherkin キーワード、期待値は原文のまま維持しています。

## 検証
- `git diff --check`
- `bundle exec rake check`

## Linear
- YAS-317: https://linear.app/yasuhito/issue/YAS-317/featurescliaddadd-ry-gatefeaturemd-のルー語をレビューして直す
