### PR TITLE
APNG 機能文書の日本語表現を整える

### DIFF
--- a/features/cli/bloch/apng.feature.md
+++ b/features/cli/bloch/apng.feature.md
@@ -1,22 +1,22 @@
 # Feature: qni bloch APNG
 
-qni-cli のユーザとして
-1 qubit の状態変化をアニメーションで確認できるように
+qni-cli の利用者として
+1 量子ビットの状態変化をアニメーションで確認できるように
 qni bloch --apng でブロッホ球 APNG を書き出したい。
 
-## Scenario: qni bloch --apng は回転ゲートを含む 1 qubit 回路で成功する
+## Scenario: qni bloch --apng は回転ゲートを含む 1 量子ビット回路で成功する
 
 - Given "qni add Ry --angle π/2 --qubit 0 --step 0" を実行
 - When "qni bloch --apng --output bloch.png" を実行
 - Then コマンドは成功
 
-## Scenario: qni bloch --apng は回転ゲートを含む 1 qubit 回路の APNG を書き出す
+## Scenario: qni bloch --apng は回転ゲートを含む 1 量子ビット回路の APNG を書き出す
 
 - Given "qni add Ry --angle π/2 --qubit 0 --step 0" を実行
 - When "qni bloch --apng --output bloch.png" を実行
 - Then "bloch.png" は APNG 画像である
 
-## Scenario: qni bloch --apng は回転ゲートを含む 1 qubit 回路を複数フレームで書き出す
+## Scenario: qni bloch --apng は回転ゲートを含む 1 量子ビット回路を複数フレームで書き出す
 
 - Given "qni add Ry --angle π/2 --qubit 0 --step 0" を実行
 - When "qni bloch --apng --output bloch.png" を実行


### PR DESCRIPTION
## 概要

- `features/cli/bloch/apng.feature.md` の日本語本文から、不自然な英日混在の表現を自然な日本語に修正しました。
- コマンド例、Gherkin キーワード、期待値、`APNG` などの識別子や仕様用語は維持しました。

## 検証

- [x] `git diff --check`
- [x] `bundle exec rake check`

## Linear

- YAS-330
