### PR TITLE
qni add ヘルプ仕様の文体を整える

### DIFF
--- a/features/cli/add/help.feature.md
+++ b/features/cli/add/help.feature.md
@@ -1,15 +1,14 @@
-# Feature: qni add のヘルプ
+# Feature: add コマンドのヘルプ表示
 
-qni-cli の利用者として
-add コマンドの使い方を知るために
-qni add のヘルプを見たい
+qni-cli の利用者として、add コマンドの使い方を確認するために、
+`qni add` の使い方をヘルプで見たい。
 
 ## Scenario: qni add は成功する
 
 - When "qni add" を実行
 - Then コマンドは成功
 
-## Scenario: qni add は add コマンドの使い方を表示する
+## Scenario: qni add は add コマンドの使い方を表示
 
 - When "qni add" を実行
 - Then 標準出力:
@@ -56,7 +55,7 @@ qni add のヘルプを見たい
 - When "qni add --help" を実行
 - Then コマンドは成功
 
-## Scenario: qni add --help は add コマンドの使い方を表示する
+## Scenario: qni add --help は add コマンドの使い方を表示
 
 - When "qni add --help" を実行
 - Then 標準出力:

--- a/features/cli/add/help.feature.md
+++ b/features/cli/add/help.feature.md
@@ -1,15 +1,15 @@
-# Feature: qni add help
+# Feature: qni add のヘルプ
 
-qni-cli のユーザとして
+qni-cli の利用者として
 add コマンドの使い方を知るために
-qni add の help を見たい
+qni add のヘルプを見たい
 
 ## Scenario: qni add は成功する
 
 - When "qni add" を実行
 - Then コマンドは成功
 
-## Scenario: qni add は add コマンドの使い方を表示
+## Scenario: qni add は add コマンドの使い方を表示する
 
 - When "qni add" を実行
 - Then 標準出力:
@@ -56,7 +56,7 @@ qni add の help を見たい
 - When "qni add --help" を実行
 - Then コマンドは成功
 
-## Scenario: qni add --help は add コマンドの使い方を表示
+## Scenario: qni add --help は add コマンドの使い方を表示する
 
 - When "qni add --help" を実行
 - Then 標準出力:


### PR DESCRIPTION
## 概要

- `features/cli/add/help.feature.md` の `Feature` 見出しと導入文を自然な日本語に整えました。
- 同系統の CLI ヘルプ仕様に合わせ、期待 stdout、ステップ文、シナリオ見出し、コマンド例、仕様上の意味は変更していません。

## Linear

- YAS-329

## 検証

- `git diff --check`
- `bundle exec rake check`
