### PR TITLE
ブロッホ球インライン機能仕様の文体を整える

### DIFF
--- a/features/cli/bloch/inline.feature.md
+++ b/features/cli/bloch/inline.feature.md
@@ -1,6 +1,6 @@
 # Feature: qni bloch inline
 
-qni-cli のユーザとして
+qni-cli の利用者として
 対応端末で画像ファイルを開かずにブロッホ球を確認できるように
 qni bloch --inline で Kitty graphics protocol による表示を使いたい。
 

--- a/features/cli/bloch/inline.feature.md
+++ b/features/cli/bloch/inline.feature.md
@@ -1,17 +1,17 @@
 # Feature: qni bloch inline
 
 qni-cli のユーザとして
-対応 terminal で画像ファイルを開かずにブロッホ球を確認できるように
-qni bloch --inline で Kitty graphics protocol 表示を使いたい。
+対応端末で画像ファイルを開かずにブロッホ球を確認できるように
+qni bloch --inline で Kitty graphics protocol による表示を使いたい。
 
-## Scenario: qni bloch --inline は 1 qubit 回路で成功する
+## Scenario: qni bloch --inline は 1 量子ビット回路で成功する
 
 - Given "qni add H --qubit 0 --step 0" を実行
 - Given 環境変数 "QNI_TEST_FORCE_INLINE" を "1" に設定する
 - When "qni bloch --inline" を TTY で実行
 - Then コマンドは成功
 
-## Scenario: qni bloch --inline は 1 qubit 回路のブロッホ球を Kitty graphics protocol で表示する
+## Scenario: qni bloch --inline は 1 量子ビット回路のブロッホ球を Kitty graphics protocol によって表示する
 
 - Given "qni add H --qubit 0 --step 0" を実行
 - Given 環境変数 "QNI_TEST_FORCE_INLINE" を "1" に設定する
@@ -25,7 +25,7 @@ qni bloch --inline で Kitty graphics protocol 表示を使いたい。
 - When "qni bloch --inline --animate" を TTY で実行
 - Then コマンドは成功
 
-## Scenario: qni bloch --inline --animate は回転ゲートのブロッホ球を inline animation で表示する
+## Scenario: qni bloch --inline --animate は回転ゲートのブロッホ球をインラインアニメーションで表示する
 
 - Given "qni add Ry --angle π/2 --qubit 0 --step 0" を実行
 - Given 環境変数 "QNI_TEST_FORCE_INLINE" を "1" に設定する


### PR DESCRIPTION
## 概要

- `features/cli/bloch/inline.feature.md` の説明文とシナリオ見出しに残っていた不自然な英日混在表現を自然な日本語へ修正しました。
- `Given` / `When` / `Then` のステップ文、コマンド例、期待値は変更していません。

## Linear

- YAS-333

## 検証

- `git diff --check`
- one-`Then` 確認用 `awk` コマンドで 4 シナリオすべて `1` を確認
- `bundle exec rake check`
