### PR TITLE
ブロッホ PNG 仕様の文体を整える

### DIFF
--- a/features/cli/bloch/png.feature.md
+++ b/features/cli/bloch/png.feature.md
@@ -1,7 +1,7 @@
 # Feature: qni bloch PNG
 
 qni-cli のユーザとして
-1 qubit の状態を画像として確認するために
+1 量子ビットの状態を画像として確認するために
 qni bloch --png でブロッホ球 PNG を書き出したい。
 
 ## Scenario: qni bloch --png は成功する

--- a/features/cli/bloch/png.feature.md
+++ b/features/cli/bloch/png.feature.md
@@ -1,6 +1,6 @@
 # Feature: qni bloch PNG
 
-qni-cli のユーザとして
+qni-cli の利用者として
 1 量子ビットの状態を画像として確認するために
 qni bloch --png でブロッホ球 PNG を書き出したい。
 


### PR DESCRIPTION
## 概要

- `features/cli/bloch/png.feature.md` の本文に残っていた `qni-cli のユーザとして` を `qni-cli の利用者として` に変更しました。
- 既存対応の `1 qubit` から `1 量子ビット` への変更も含め、導入文のルー語を自然な日本語に整えました。
- Gherkin キーワード、既存ステップ文、CLI 表記、期待値は変更していません。

## Linear

- YAS-335

## 検証

- `git diff --check`
- `bundle exec rake check`
