### PR TITLE
qni clear 仕様の文体を整える

### DIFF
--- a/features/cli/clear/command.feature.md
+++ b/features/cli/clear/command.feature.md
@@ -1,6 +1,6 @@
 # Feature: qni clear コマンド
 
-qni-cli のユーザとして
+qni-cli の利用者として
 回路を最初から作り直せるようにするために
 qni clear を実行したい
 

--- a/features/cli/clear/command.feature.md
+++ b/features/cli/clear/command.feature.md
@@ -1,6 +1,6 @@
-# Feature: qni clear command
+# Feature: qni clear コマンド
 
-qni-cli のユーザとして
+qni-cli の利用者として
 回路を最初から作り直せるようにするために
 qni clear を実行したい
 

--- a/features/cli/clear/command.feature.md
+++ b/features/cli/clear/command.feature.md
@@ -1,6 +1,6 @@
 # Feature: qni clear コマンド
 
-qni-cli の利用者として
+qni-cli のユーザとして
 回路を最初から作り直せるようにするために
 qni clear を実行したい
 


### PR DESCRIPTION
## 概要

- `features/cli/clear/command.feature.md` の見出しで `command` を `コマンド` に変更しました。
- PR コメントの指摘を受け、導入文の `qni-cli のユーザとして` を `qni-cli の利用者として` に変更しました。
- Gherkin キーワード、コマンド例、CLI 引数、期待値は変更していません。

## Linear

- YAS-337

## 検証

- `git diff --check`
- `bundle exec rake check`
