### PR TITLE
qni clear ヘルプ仕様の文体を整える

### DIFF
--- a/features/cli/clear/help.feature.md
+++ b/features/cli/clear/help.feature.md
@@ -1,8 +1,8 @@
-# Feature: qni clear help
+# Feature: qni clear のヘルプ表示
 
 qni-cli のユーザとして
 clear コマンドの使い方を知るために
-qni clear の help を見たい
+qni clear のヘルプを見たい
 
 ## Scenario: qni clear --help は成功する
 

--- a/features/cli/clear/help.feature.md
+++ b/features/cli/clear/help.feature.md
@@ -1,6 +1,6 @@
 # Feature: qni clear のヘルプ表示
 
-qni-cli のユーザとして
+qni-cli の利用者として
 clear コマンドの使い方を知るために
 qni clear のヘルプを見たい
 


### PR DESCRIPTION
## 概要

- Linear: YAS-338
- `features/cli/clear/help.feature.md` の表題と本文で、不自然に混ざっていた普通名詞 `help` を自然な日本語の「ヘルプ」に変更しました。
- 導入文の `qni-cli のユーザとして` を `qni-cli の利用者として` に変更しました。
- Gherkin キーワード、既存ステップ文、期待出力、コマンド例は変更していません。

## 検証

- [x] `git diff --check`
- [x] `bundle exec rake check`
