### PR TITLE
qni expect 仕様書の文体を整える

### DIFF
--- a/features/cli/expect/command.feature.md
+++ b/features/cli/expect/command.feature.md
@@ -1,6 +1,6 @@
 # Feature: qni expect コマンド
 
-qni-cli のユーザとして、Pauli 文字列の期待値を確認するために、
+qni-cli の利用者として、Pauli 文字列の期待値を確認するために、
 `qni expect` を実行したい。
 
 ## Scenario: qni expect コマンドは成功
@@ -44,7 +44,7 @@ qni-cli のユーザとして、Pauli 文字列の期待値を確認するため
   XX=1.0
   ```
 
-## Scenario: qni expect は 3 qubit の Pauli 文字列の期待値を標準出力に表示
+## Scenario: qni expect は 3 量子ビットの Pauli 文字列の期待値を標準出力に表示
 
 - Given "qni add H --qubit 0 --step 0" を実行
 - And "qni add X --control 0 --qubit 1 --step 1" を実行
@@ -58,7 +58,7 @@ qni-cli のユーザとして、Pauli 文字列の期待値を確認するため
   XXX=1.0
   ```
 
-## Scenario: qni expect は変数 angle を解決して期待値を表示
+## Scenario: qni expect は角度変数を解決して期待値を表示
 
 - Given "qni add H --qubit 0 --step 0" を実行
 - And "qni add X --control 0 --qubit 1 --step 1" を実行


### PR DESCRIPTION
## 概要

- `features/cli/expect/command.feature.md` の日本語本文に残っていた不自然な英語混在を自然な日本語に修正しました。
- コマンド例、期待値、Gherkin キーワード、既存ステップ文は変更していません。

## Linear

- YAS-340: https://linear.app/yasuhito/issue/YAS-340/featurescliexpectcommandfeaturemd-のルー語をレビューして直す

## 検証

- `git diff --check`
- `bundle exec rake check`

## 補足

- `Feature` / `Scenario` / `Given` / `When` / `Then`、`Pauli`、`Bell`、コマンド文字列は仕様上の語として維持しています。
