### PR TITLE
qni expect ヘルプ仕様の文体を整える

### DIFF
--- a/features/cli/expect/help.feature.md
+++ b/features/cli/expect/help.feature.md
@@ -1,6 +1,6 @@
 # Feature: expect コマンドのヘルプ表示
 
-qni-cli のユーザとして、Pauli string の期待値計算方法を確認するために、
+qni-cli の利用者として、Pauli 文字列の期待値計算方法を確認するために、
 `qni expect` の使い方をヘルプで見たい。
 
 ## Scenario: qni expect は成功する


### PR DESCRIPTION
## 概要

- `features/cli/expect/help.feature.md` の本文冒頭にある不自然な英日混在を自然な日本語に修正しました。
- ヘルプ出力の期待値本文、コマンド例、シナリオ構造は変更していません。

## Linear

- YAS-341

## 検証

- `git diff --check`
- `bundle exec rake check`
