### PR TITLE
export エラー仕様のルー語を直す

### DIFF
--- a/features/cli/export/errors.feature.md
+++ b/features/cli/export/errors.feature.md
@@ -1,7 +1,7 @@
-# Feature: qni export errors
+# Feature: qni export のエラー
 
 qni-cli のユーザとして
-誤った option 組み合わせをすぐ直せるように
+誤ったオプションの組み合わせをすぐ直せるように
 qni export が明確なエラーを返してほしい。
 
 ## Scenario: qni export --caption-position に不正な値を指定すると失敗する
@@ -44,7 +44,7 @@ qni export が明確なエラーを返してほしい。
   choose at most one of --state-vector or --circle-notation
   ```
 
-## Scenario: qni export --circle-notation --png は 3 qubit 回路では失敗する
+## Scenario: qni export --circle-notation --png は 3 量子ビット回路では失敗する
 
 - Given 空の 3 qubit 回路がある
 - When "qni export --circle-notation --png --output circles.png" を実行

--- a/features/cli/export/errors.feature.md
+++ b/features/cli/export/errors.feature.md
@@ -1,6 +1,6 @@
 # Feature: qni export のエラー
 
-qni-cli のユーザとして
+qni-cli の利用者として
 誤ったオプションの組み合わせをすぐ直せるように
 qni export が明確なエラーを返してほしい。
 
@@ -46,7 +46,7 @@ qni export が明確なエラーを返してほしい。
 
 ## Scenario: qni export --circle-notation --png は 3 量子ビット回路では失敗する
 
-- Given 空の 3 qubit 回路がある
+- Given 空の 3 量子ビット回路がある
 - When "qni export --circle-notation --png --output circles.png" を実行
 - Then コマンドは失敗して標準エラー:
 

--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -707,7 +707,7 @@ Given('初期状態ベクトルは:', function (docString) {
   writeInitialStateVector(this.scenarioDir, docStringContent(docString));
 });
 
-Given('空の 3 qubit 回路がある', function () {
+Given(/^空の 3 (?:qubit 回路|量子ビット回路)がある$/, function () {
   writeCircuitJson(this.scenarioDir, {
     qubits: 3,
     cols: [[1, 1, 1]]


### PR DESCRIPTION
## 概要

- `features/cli/export/errors.feature.md` の Feature 見出し、導入文、本文、シナリオ見出し、`Given` 文のルー語を自然な日本語に修正しました。
- `Given 空の 3 量子ビット回路がある` が通るように、既存の 3 量子ビット用ステップ定義で旧表記 `qubit` と新表記 `量子ビット` の両方を受けるようにしました。
- コマンド例、期待エラーメッセージ、Gherkin キーワード、仕様上の意味は変更していません。

## Linear

- YAS-344

## 検証

- `npm run build && npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress features/cli/export/errors.feature.md`
- `git diff --check`
- `bundle exec rake check`
