### PR TITLE
circle notation PNG 機能ファイルの文体を直す

### DIFF
--- a/features/cli/export/circle_notation_png.feature.md
+++ b/features/cli/export/circle_notation_png.feature.md
@@ -1,40 +1,40 @@
 # Feature: qni export circle-notation PNG
 
-qni-cli のユーザとして
+qni-cli の利用者として
 計算基底の振幅と位相を図で確認できるように
 qni export --circle-notation --png を使いたい。
 
-## Scenario: qni export --circle-notation --png は 1 qubit 状態で成功する
+## Scenario: qni export --circle-notation --png は 1 量子ビット状態で成功する
 
 - Given "qni state set |+>" を実行
 - When "qni export --circle-notation --png --output circles.png" を実行
 - Then コマンドは成功
 
-## Scenario: qni export --circle-notation --png は 1 qubit 状態の PNG を書き出す
+## Scenario: qni export --circle-notation --png は 1 量子ビット状態の PNG を書き出す
 
 - Given "qni state set |+>" を実行
 - When "qni export --circle-notation --png --output circles.png" を実行
 - Then "circles.png" は PNG 画像である
 
-## Scenario: qni export --circle-notation --png は 1 qubit 状態の透過 PNG を書き出す
+## Scenario: qni export --circle-notation --png は 1 量子ビット状態の透過 PNG を書き出す
 
 - Given "qni state set |+>" を実行
 - When "qni export --circle-notation --png --output circles.png" を実行
 - Then "circles.png" は透過 PNG 画像である
 
-## Scenario: qni export --circle-notation --png は 2 qubit Bell 状態で成功する
+## Scenario: qni export --circle-notation --png は 2 量子ビット Bell 状態で成功する
 
 - Given "qni state set |Φ+>" を実行
 - When "qni export --circle-notation --png --output circles.png" を実行
 - Then コマンドは成功
 
-## Scenario: qni export --circle-notation --png は 2 qubit Bell 状態の PNG を書き出す
+## Scenario: qni export --circle-notation --png は 2 量子ビット Bell 状態の PNG を書き出す
 
 - Given "qni state set |Φ+>" を実行
 - When "qni export --circle-notation --png --output circles.png" を実行
 - Then "circles.png" は PNG 画像である
 
-## Scenario: qni export --circle-notation --png は 2 qubit Bell 状態の透過 PNG を書き出す
+## Scenario: qni export --circle-notation --png は 2 量子ビット Bell 状態の透過 PNG を書き出す
 
 - Given "qni state set |Φ+>" を実行
 - When "qni export --circle-notation --png --output circles.png" を実行
@@ -44,37 +44,37 @@ qni export --circle-notation --png を使いたい。
 
 - Given "qni state set '0.1|0> + 0.99498743710662|1>'" を実行
 - When "qni export --circle-notation --png --light --output circles.png" を実行
-- Then circle notation renderer では振幅 0.1 の位相針の長さは外円の半径に等しい
+- Then circle notation の描画処理では振幅 0.1 の位相針の長さは外円の半径に等しい
 
 ## Scenario: qni export --circle-notation は外円の輪郭線を内側へ食い込ませない
 
 - Given "qni state set '0.1|0> + 0.99498743710662|1>'" を実行
 - When "qni export --circle-notation --png --light --output circles.png" を実行
-- Then circle notation renderer では外円の輪郭線は内側へ食い込まない
+- Then circle notation の描画処理では外円の輪郭線は内側へ食い込まない
 
 ## Scenario: qni export --circle-notation は正の実数振幅の位相針を上向きに描く
 
 - Given "qni state set '|+>'" を実行
 - When "qni export --circle-notation --png --light --output circles.png" を実行
-- Then circle notation renderer では正の実数振幅の位相針は上を向く
+- Then circle notation の描画処理では正の実数振幅の位相針は上を向く
 
 ## Scenario: qni export --circle-notation は正の虚数振幅の位相針を左向きに描く
 
 - Given "qni state set '|+>'" を実行
 - When "qni export --circle-notation --png --light --output circles.png" を実行
-- Then circle notation renderer では正の虚数振幅の位相針は左を向く
+- Then circle notation の描画処理では正の虚数振幅の位相針は左を向く
 
 ## Scenario: qni export --circle-notation は振幅が 0 のとき位相針を描かない
 
-- Given 空の 1 qubit 回路がある
+- Given 空の 1 量子ビット回路がある
 - When "qni export --circle-notation --png --light --output circles.png" を実行
-- Then circle notation renderer では振幅 0 のとき位相針は描画されない
+- Then circle notation の描画処理では振幅 0 のとき位相針は描画されない
 
 ## Scenario: qni export --circle-notation は振幅が 0 のとき中心ドットを描かない
 
-- Given 空の 1 qubit 回路がある
+- Given 空の 1 量子ビット回路がある
 - When "qni export --circle-notation --png --light --output circles.png" を実行
-- Then circle notation renderer では振幅 0 のとき中心ドットも描画されない
+- Then circle notation の描画処理では振幅 0 のとき中心ドットも描画されない
 
 ## Scenario: qni export --circle-notation --png は state-vector PNG と異なる画像を書き出す
 

--- a/features/cli/export/circle_notation_png.feature.md
+++ b/features/cli/export/circle_notation_png.feature.md
@@ -4,37 +4,37 @@ qni-cli のユーザとして
 計算基底の振幅と位相を図で確認できるように
 qni export --circle-notation --png を使いたい。
 
-## Scenario: qni export --circle-notation --png は 1 qubit 状態で成功する
+## Scenario: qni export --circle-notation --png は 1 量子ビット状態で成功する
 
 - Given "qni state set |+>" を実行
 - When "qni export --circle-notation --png --output circles.png" を実行
 - Then コマンドは成功
 
-## Scenario: qni export --circle-notation --png は 1 qubit 状態の PNG を書き出す
+## Scenario: qni export --circle-notation --png は 1 量子ビット状態の PNG を書き出す
 
 - Given "qni state set |+>" を実行
 - When "qni export --circle-notation --png --output circles.png" を実行
 - Then "circles.png" は PNG 画像である
 
-## Scenario: qni export --circle-notation --png は 1 qubit 状態の透過 PNG を書き出す
+## Scenario: qni export --circle-notation --png は 1 量子ビット状態の透過 PNG を書き出す
 
 - Given "qni state set |+>" を実行
 - When "qni export --circle-notation --png --output circles.png" を実行
 - Then "circles.png" は透過 PNG 画像である
 
-## Scenario: qni export --circle-notation --png は 2 qubit Bell 状態で成功する
+## Scenario: qni export --circle-notation --png は 2 量子ビット Bell 状態で成功する
 
 - Given "qni state set |Φ+>" を実行
 - When "qni export --circle-notation --png --output circles.png" を実行
 - Then コマンドは成功
 
-## Scenario: qni export --circle-notation --png は 2 qubit Bell 状態の PNG を書き出す
+## Scenario: qni export --circle-notation --png は 2 量子ビット Bell 状態の PNG を書き出す
 
 - Given "qni state set |Φ+>" を実行
 - When "qni export --circle-notation --png --output circles.png" を実行
 - Then "circles.png" は PNG 画像である
 
-## Scenario: qni export --circle-notation --png は 2 qubit Bell 状態の透過 PNG を書き出す
+## Scenario: qni export --circle-notation --png は 2 量子ビット Bell 状態の透過 PNG を書き出す
 
 - Given "qni state set |Φ+>" を実行
 - When "qni export --circle-notation --png --output circles.png" を実行
@@ -44,37 +44,37 @@ qni export --circle-notation --png を使いたい。
 
 - Given "qni state set '0.1|0> + 0.99498743710662|1>'" を実行
 - When "qni export --circle-notation --png --light --output circles.png" を実行
-- Then circle notation renderer では振幅 0.1 の位相針の長さは外円の半径に等しい
+- Then circle notation の描画処理では振幅 0.1 の位相針の長さは外円の半径に等しい
 
 ## Scenario: qni export --circle-notation は外円の輪郭線を内側へ食い込ませない
 
 - Given "qni state set '0.1|0> + 0.99498743710662|1>'" を実行
 - When "qni export --circle-notation --png --light --output circles.png" を実行
-- Then circle notation renderer では外円の輪郭線は内側へ食い込まない
+- Then circle notation の描画処理では外円の輪郭線は内側へ食い込まない
 
 ## Scenario: qni export --circle-notation は正の実数振幅の位相針を上向きに描く
 
 - Given "qni state set '|+>'" を実行
 - When "qni export --circle-notation --png --light --output circles.png" を実行
-- Then circle notation renderer では正の実数振幅の位相針は上を向く
+- Then circle notation の描画処理では正の実数振幅の位相針は上を向く
 
 ## Scenario: qni export --circle-notation は正の虚数振幅の位相針を左向きに描く
 
 - Given "qni state set '|+>'" を実行
 - When "qni export --circle-notation --png --light --output circles.png" を実行
-- Then circle notation renderer では正の虚数振幅の位相針は左を向く
+- Then circle notation の描画処理では正の虚数振幅の位相針は左を向く
 
 ## Scenario: qni export --circle-notation は振幅が 0 のとき位相針を描かない
 
-- Given 空の 1 qubit 回路がある
+- Given 空の 1 量子ビット回路がある
 - When "qni export --circle-notation --png --light --output circles.png" を実行
-- Then circle notation renderer では振幅 0 のとき位相針は描画されない
+- Then circle notation の描画処理では振幅 0 のとき位相針は描画されない
 
 ## Scenario: qni export --circle-notation は振幅が 0 のとき中心ドットを描かない
 
-- Given 空の 1 qubit 回路がある
+- Given 空の 1 量子ビット回路がある
 - When "qni export --circle-notation --png --light --output circles.png" を実行
-- Then circle notation renderer では振幅 0 のとき中心ドットも描画されない
+- Then circle notation の描画処理では振幅 0 のとき中心ドットも描画されない
 
 ## Scenario: qni export --circle-notation --png は state-vector PNG と異なる画像を書き出す
 

--- a/features/cli/export/circle_notation_png.feature.md
+++ b/features/cli/export/circle_notation_png.feature.md
@@ -1,6 +1,6 @@
 # Feature: qni export circle-notation PNG
 
-qni-cli の利用者として
+qni-cli のユーザとして
 計算基底の振幅と位相を図で確認できるように
 qni export --circle-notation --png を使いたい。
 

--- a/features/cli/export/circle_notation_png.feature.md
+++ b/features/cli/export/circle_notation_png.feature.md
@@ -1,6 +1,6 @@
 # Feature: qni export circle-notation PNG
 
-qni-cli のユーザとして
+qni-cli の利用者として
 計算基底の振幅と位相を図で確認できるように
 qni export --circle-notation --png を使いたい。
 

--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -682,7 +682,7 @@ print(json.dumps(module.label_metrics()))
   return pythonJson(script, [helperPath]);
 }
 
-Given('空の 1 qubit 回路がある', function () {
+Given(/^空の 1 (?:qubit |量子ビット)回路がある$/, function () {
   writeCircuitJson(this.scenarioDir, {
     qubits: 1,
     cols: [[1]]
@@ -1033,7 +1033,7 @@ Then('{string} と {string} は異なるファイル内容である', function (
   assert.notDeepEqual(fs.readFileSync(actualLhsPath), fs.readFileSync(actualRhsPath));
 });
 
-Then('circle notation renderer では振幅 {float} の位相針の長さは外円の半径に等しい', function (real) {
+Then(/^(?:circle notation renderer では|circle notation の描画処理では)振幅 (\d+(?:\.\d+)?) の位相針の長さは外円の半径に等しい$/, function (real) {
   const metrics = circleNotationPhaseMetrics(real, 0.0);
   const actual = metrics.needle_length;
   const expected = metrics.outer_radius;
@@ -1048,7 +1048,7 @@ Then('circle notation renderer では振幅 {float} の位相針の長さは外�
   );
 });
 
-Then('circle notation renderer では外円の輪郭線は内側へ食い込まない', function () {
+Then(/^(?:circle notation renderer では|circle notation の描画処理では)外円の輪郭線は内側へ食い込まない$/, function () {
   const metrics = circleNotationOutlineMetrics();
   const actual = metrics.outline_inner_edge;
   const expected = metrics.intended_radius;
@@ -1063,7 +1063,7 @@ Then('circle notation renderer では外円の輪郭線は内側へ食い込ま�
   );
 });
 
-Then('circle notation renderer では正の実数振幅の位相針は上を向く', function () {
+Then(/^(?:circle notation renderer では|circle notation の描画処理では)正の実数振幅の位相針は上を向く$/, function () {
   const metrics = circleNotationPhaseMetrics(1.0, 0.0);
 
   assert.ok(
@@ -1075,7 +1075,7 @@ Then('circle notation renderer では正の実数振幅の位相針は上を向�
   );
 });
 
-Then('circle notation renderer では正の虚数振幅の位相針は左を向く', function () {
+Then(/^(?:circle notation renderer では|circle notation の描画処理では)正の虚数振幅の位相針は左を向く$/, function () {
   const metrics = circleNotationPhaseMetrics(0.0, 1.0);
 
   assert.ok(
@@ -1087,13 +1087,13 @@ Then('circle notation renderer では正の虚数振幅の位相針は左を向�
   );
 });
 
-Then('circle notation renderer では振幅 0 のとき位相針は描画されない', function () {
+Then(/^(?:circle notation renderer では|circle notation の描画処理では)振幅 0 のとき位相針は描画されない$/, function () {
   const metrics = circleNotationPhaseMetrics(0.0, 0.0);
 
   assert.equal(metrics.phase_visible, false);
 });
 
-Then('circle notation renderer では振幅 0 のとき中心ドットも描画されない', function () {
+Then(/^(?:circle notation renderer では|circle notation の描画処理では)振幅 0 のとき中心ドットも描画されない$/, function () {
   const metrics = circleNotationPhaseMetrics(0.0, 0.0);
 
   assert.equal(metrics.center_dot_visible, false);


### PR DESCRIPTION
## 概要

- `features/cli/export/circle_notation_png.feature.md` の英日混在表現を自然な日本語に修正しました。
- 修正したステップ文が既存のステップ定義と対応するよう、関連する Cucumber ステップ定義を正規表現化しました。

## 対応課題

- YAS-343

## 検証

- `git diff --check`
- `npm run build && ./node_modules/.bin/cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress features/cli/export/circle_notation_png.feature.md`
- `bundle exec rake check`
