### PR TITLE
qni export ヘルプ仕様の文体を整える

### DIFF
--- a/features/cli/export/help.feature.md
+++ b/features/cli/export/help.feature.md
@@ -1,15 +1,15 @@
-# Feature: qni export help
+# Feature: qni export のヘルプ
 
-qni-cli のユーザとして
+qni-cli のユーザーとして
 出力形式ごとの使い方を迷わず選べるように
-qni export の help で利用できる export mode と option を確認したい。
+qni export のヘルプで利用できる出力形式とオプションを確認したい。
 
 ## Scenario: qni export --help は export コマンドの使い方を表示
 
 - When "qni export --help" を実行
 - Then コマンドは成功
 
-## Scenario: qni export --help は export mode と option を表示
+## Scenario: qni export --help は出力形式とオプションを表示
 
 - When "qni export --help" を実行
 - Then 標準出力:
@@ -65,7 +65,7 @@ qni export の help で利用できる export mode と option を確認したい
 - When "qni export" を実行
 - Then コマンドは成功
 
-## Scenario: qni export は export mode と option を表示
+## Scenario: qni export は出力形式とオプションを表示
 
 - When "qni export" を実行
 - Then 標準出力:

--- a/features/cli/export/help.feature.md
+++ b/features/cli/export/help.feature.md
@@ -1,6 +1,6 @@
-# Feature: qni export のヘルプ
+# Feature: qni export のヘルプ表示
 
-qni-cli のユーザーとして
+qni-cli のユーザとして
 出力形式ごとの使い方を迷わず選べるように
 qni export のヘルプで利用できる出力形式とオプションを確認したい。
 

--- a/features/cli/export/help.feature.md
+++ b/features/cli/export/help.feature.md
@@ -1,6 +1,6 @@
 # Feature: qni export のヘルプ表示
 
-qni-cli のユーザとして
+qni-cli の利用者として
 出力形式ごとの使い方を迷わず選べるように
 qni export のヘルプで利用できる出力形式とオプションを確認したい。
 


### PR DESCRIPTION
## 概要

- `features/cli/export/help.feature.md` の日本語本文に混ざっていた `help` / `export mode` / `option` を自然な日本語へ修正しました。
- 導入文の `qni-cli のユーザとして` を `qni-cli の利用者として` に直し、レビュー指摘に対応しました。
- `qni export` の期待出力、コマンド例、Gherkin ステップ本文は変更していません。

## Linear

- YAS-345

## 検証

- `git diff --check`
- `bundle exec rake check`
