### PR TITLE
export PNG 機能仕様の文体を整える

### DIFF
--- a/features/cli/export/png.feature.md
+++ b/features/cli/export/png.feature.md
@@ -16,19 +16,19 @@ qni export --png で通常の回路図を PNG 形式で書き出したい。
 - When "qni export --png --light --output circuit.png" を実行
 - Then 標準出力は空
 
-## Scenario: qni export --png --light は PNG 画像ファイルを書き出す
+## Scenario: qni export --png --light は PNG を書き出す
 
 - Given "qni add H --qubit 0 --step 0" を実行
 - When "qni export --png --light --output circuit.png" を実行
 - Then "circuit.png" は PNG 画像である
 
-## Scenario: qni export --png は透過 PNG 画像ファイルを書き出す
+## Scenario: qni export --png は透過 PNG を書き出す
 
 - Given "qni add H --qubit 0 --step 0" を実行
 - When "qni export --png --output circuit.png" を実行
 - Then "circuit.png" は透過 PNG 画像である
 
-## Scenario: qni export --png --no-transparent は不透過 PNG 画像ファイルを書き出す
+## Scenario: qni export --png --no-transparent は不透過 PNG を書き出す
 
 - Given "qni add H --qubit 0 --step 0" を実行
 - When "qni export --png --light --no-transparent --output circuit.png" を実行

--- a/features/cli/export/png.feature.md
+++ b/features/cli/export/png.feature.md
@@ -1,8 +1,8 @@
 # Feature: qni export PNG
 
-qni-cli のユーザとして
+qni-cli の利用者として
 回路図を画像として保存できるように
-qni export --png で通常回路 PNG を書き出したい。
+qni export --png で通常の回路図を PNG 形式で書き出したい。
 
 ## Scenario: qni export --png --light は成功する
 
@@ -16,19 +16,19 @@ qni export --png で通常回路 PNG を書き出したい。
 - When "qni export --png --light --output circuit.png" を実行
 - Then 標準出力は空
 
-## Scenario: qni export --png --light は PNG ファイルを書き出す
+## Scenario: qni export --png --light は PNG 画像ファイルを書き出す
 
 - Given "qni add H --qubit 0 --step 0" を実行
 - When "qni export --png --light --output circuit.png" を実行
 - Then "circuit.png" は PNG 画像である
 
-## Scenario: qni export --png は透過 PNG ファイルを書き出す
+## Scenario: qni export --png は透過 PNG 画像ファイルを書き出す
 
 - Given "qni add H --qubit 0 --step 0" を実行
 - When "qni export --png --output circuit.png" を実行
 - Then "circuit.png" は透過 PNG 画像である
 
-## Scenario: qni export --png --no-transparent は不透過 PNG ファイルを書き出す
+## Scenario: qni export --png --no-transparent は不透過 PNG 画像ファイルを書き出す
 
 - Given "qni add H --qubit 0 --step 0" を実行
 - When "qni export --png --light --no-transparent --output circuit.png" を実行


### PR DESCRIPTION
## 概要

- YAS-347
- `features/cli/export/png.feature.md` の導入文とシナリオ見出しの文体を自然な日本語へ修正しました。
- Gherkin キーワード、ステップ文、コマンド例、期待値は変更していません。

## 確認

- `git diff --check`
- `bundle exec rake check`

## 補足

- `origin/main` の `b1dfd5c` を競合なしでマージ済みです。
