### PR TITLE
state-vector PNG 仕様の文体を直す

### DIFF
--- a/features/cli/export/state_vector_png.feature.md
+++ b/features/cli/export/state_vector_png.feature.md
@@ -29,8 +29,8 @@ qni export --state-vector --png を使いたい。
 - When "qni export --state-vector --png --output state.png" を実行
 - Then "circuit.png" と "state.png" は異なるファイル内容である
 
-## Scenario: qni export --state-vector --png は 3 qubit 回路の状態ベクトル画像を書き出す
+## Scenario: qni export --state-vector --png は 3 量子ビット回路の状態ベクトル画像を書き出す
 
-- Given 空の 3 qubit 回路がある
+- Given 空の 3 量子ビット回路がある
 - When "qni export --state-vector --png --output state.png" を実行
 - Then "state.png" は PNG 画像である

--- a/features/cli/export/state_vector_png.feature.md
+++ b/features/cli/export/state_vector_png.feature.md
@@ -1,6 +1,6 @@
 # Feature: qni export state-vector PNG
 
-qni-cli のユーザとして
+qni-cli の利用者として
 回路の最終状態を数式画像として保存できるように
 qni export --state-vector --png を使いたい。
 


### PR DESCRIPTION
## 概要

- YAS-348
- `features/cli/export/state_vector_png.feature.md` の導入文を `qni-cli の利用者として` に変更しました。
- `3 qubit 回路` 表現を `3 量子ビット回路` に変更しました。
- CLI 引数、Gherkin キーワード、期待値、コマンド例は変更していません。

## 検証

- `git diff --check`
- `bundle exec rake check`

## 補足

- `bundle exec cucumber features/cli/export/state_vector_png.feature.md` は、このリポジトリでは `bundler: command not found: cucumber` となったため、全体チェック内の `npm run cucumber` で対象を含むフィーチャを確認しています。
