### PR TITLE
性能比較ハーネス仕様の文体を整える

### DIFF
--- a/features/cli/performance_comparison_harness.feature.md
+++ b/features/cli/performance_comparison_harness.feature.md
@@ -1,29 +1,29 @@
-# Feature: Ruby / TypeScript performance comparison harness
+# Feature: Ruby / TypeScript 性能比較ハーネス
 
-Ruby から TypeScript へ command migration を進める前に、
-同じ input と command で wall-clock / memory regression を比較できる
-ローカル保存可能な harness が必要である。
+Ruby から TypeScript へのコマンド移行を進める前に、
+同じ入力とコマンドで経過時間やメモリ使用量の悪化を比較できる
+ローカルに保存可能な性能比較ハーネスが必要である。
 
-## Scenario: performance comparison harness script が存在する
+## Scenario: 性能比較ハーネススクリプトが存在する
 
 - Then リポジトリファイル "scripts/compare_ruby_typescript_performance.js" は存在する
 
-## Scenario: representative large-circuit workload が存在する
+## Scenario: 大規模回路の代表的な処理負荷が存在する
 
 - Then リポジトリファイル "test/fixtures/performance/large_add_h_workload.json" は存在する
 
-## Scenario: harness は JSON artifact を出力する
+## Scenario: 性能比較ハーネスは JSON 形式の成果物を出力する
 
 - Then リポジトリファイル "src/performance/comparison_harness.ts" は "writePerformanceComparison" を含む
 
-## Scenario: harness は warm-up と repeat を扱う
+## Scenario: 性能比較ハーネスはウォームアップと繰り返し実行を扱う
 
 - Then リポジトリファイル "src/performance/comparison_harness.ts" は "warmUp" を含む
 
-## Scenario: harness は 20% threshold を扱う
+## Scenario: 性能比較ハーネスは 20% のしきい値を扱う
 
 - Then リポジトリファイル "src/performance/comparison_harness.ts" は "thresholdRatio" を含む
 
-## Scenario: harness は TypeScript 測定で Ruby override を引き継がない
+## Scenario: 性能比較ハーネスは TypeScript 測定で Ruby override を引き継がない
 
 - Then リポジトリファイル "src/performance/comparison_harness.ts" は "withoutRubyOverrideEnvironment" を含む


### PR DESCRIPTION
## 概要

- `features/cli/performance_comparison_harness.feature.md` の英日混在表現を自然な日本語へ整えました。
- Gherkin キーワード、ファイルパス、コード識別子、コマンド例は維持しています。

## 対応課題

- YAS-353

## 検証

- [x] `git diff --check`
- [x] `bundle exec rake check`

## 補足

- `.github/pull_request_template.md` は存在しないため、この本文を明示指定しています。
