### PR TITLE
run ヘルプ仕様の文体を整える

### DIFF
--- a/features/cli/run/help.feature.md
+++ b/features/cli/run/help.feature.md
@@ -1,8 +1,8 @@
-# Feature: qni run help
+# Feature: qni run ヘルプ
 
 qni-cli のユーザとして
-状態ベクトル表示の option を迷わず選べるように
-qni run の help で利用できる option を確認したい。
+状態ベクトル表示のオプションを迷わず選べるように
+qni run のヘルプで利用できるオプションを確認したい。
 
 ## Scenario: qni run --help は成功する
 

--- a/features/cli/run/help.feature.md
+++ b/features/cli/run/help.feature.md
@@ -1,6 +1,6 @@
-# Feature: qni run ヘルプ
+# Feature: qni run のヘルプ表示
 
-qni-cli のユーザとして
+qni-cli の利用者として
 状態ベクトル表示のオプションを迷わず選べるように
 qni run のヘルプで利用できるオプションを確認したい。
 


### PR DESCRIPTION
## 概要

- `features/cli/run/help.feature.md` の `Feature` 見出しと導入文を自然な日本語へ整えました。
- 本文に残っていた `help` / `option` と、PR 指摘の `ユーザ` 表記を見直しました。
- 期待される標準出力、コマンド例、既存ステップ文は変更していません。

## Linear

- YAS-358

## 検証

- `git diff --check`
- `bundle exec rake check`
