### PR TITLE
初期状態仕様の文体を整える

### DIFF
--- a/features/cli/run/initial_states.feature.md
+++ b/features/cli/run/initial_states.feature.md
@@ -1,6 +1,6 @@
 # Feature: qni run の初期状態
 
-qni-cli のユーザとして
+qni-cli の利用者として
 qni state set で指定した初期状態から数値実行するために
 qni run が変数解決済みの初期状態を使うことを確認したい。
 

--- a/features/cli/run/initial_states.feature.md
+++ b/features/cli/run/initial_states.feature.md
@@ -1,4 +1,4 @@
-# Feature: qni run initial states
+# Feature: qni run の初期状態
 
 qni-cli のユーザとして
 qni state set で指定した初期状態から数値実行するために
@@ -18,7 +18,7 @@ qni run が変数解決済みの初期状態を使うことを確認したい。
   0.8,0.6
   ```
 
-## Scenario: qni run は短い initial_state を |0> suffix qubits で拡張して数値実行する
+## Scenario: qni run は短い initial_state を後続の |0> 量子ビットで拡張して数値実行する
 
 - Given 次の circuit.json がある:
 


### PR DESCRIPTION
## 概要

- `features/cli/run/initial_states.feature.md` の見出しと導入文に残っていた不自然な英語混在を自然な日本語へ修正しました。
- `Feature` / `Scenario` / `Given` / `When` / `Then`、コマンド例、JSON キー、期待値は変更していません。

## Linear

- YAS-359

## 検証

- [x] `git diff --check origin/main...HEAD`
- [x] `bundle exec rake check`
