### PR TITLE
qni run --symbolic 仕様の文体を整える

### DIFF
--- a/features/cli/run/symbolic.feature.md
+++ b/features/cli/run/symbolic.feature.md
@@ -1,7 +1,7 @@
-# Feature: qni run symbolic output
+# Feature: qni run symbolic の出力
 
-qni-cli のユーザとして
-ket 形式や named basis で状態を読めるように
+qni-cli の利用者として
+ket 形式や名前付き基底で状態を読めるように
 qni run --symbolic と --basis の表示を確認したい。
 
 
@@ -132,7 +132,7 @@ qni run --symbolic と --basis の表示を確認したい。
   cos(alpha)|0> + sin(alpha)|1>
   ```
 
-## Scenario: qni run --symbolic は具体的な π 角度も exact に表示
+## Scenario: qni run --symbolic は具体的な π 角度も厳密値として表示
 
 - Given "qni add Ry --angle π/2 --qubit 0 --step 0" を実行
 - When "qni run --symbolic" を実行
@@ -142,7 +142,7 @@ qni run --symbolic と --basis の表示を確認したい。
   sqrt(2)/2|0> + sqrt(2)/2|1>
   ```
 
-## Scenario: qni run --symbolic は 2 qubit の空回路を ket 形式で表示
+## Scenario: qni run --symbolic は 2 量子ビットの空回路を ket 形式で表示
 
 - Given 空の 2 qubit 回路がある
 - When "qni run --symbolic" を実行
@@ -152,7 +152,7 @@ qni run --symbolic と --basis の表示を確認したい。
   |00>
   ```
 
-## Scenario: qni run --symbolic は同じ step に 2 qubit の独立した H がある回路を ket 形式で表示
+## Scenario: qni run --symbolic は同じステップに 2 量子ビットの独立した H がある回路を ket 形式で表示
 
 - Given 次の回路図がある:
 
@@ -170,13 +170,13 @@ qni run --symbolic と --basis の表示を確認したい。
   1/2|00> + 1/2|01> + 1/2|10> + 1/2|11>
   ```
 
-## Scenario: qni run --symbolic は 3 qubit 回路を計算基底で表示 は成功
+## Scenario: qni run --symbolic は 3 量子ビット回路を計算基底で表示 は成功
 
 - Given 空の 3 qubit 回路がある
 - When "qni run --symbolic" を実行
 - Then コマンドは成功
 
-## Scenario: qni run --symbolic は 3 qubit 回路を計算基底で表示
+## Scenario: qni run --symbolic は 3 量子ビット回路を計算基底で表示
 
 - Given 空の 3 qubit 回路がある
 - When "qni run --symbolic" を実行

--- a/features/cli/run/symbolic.feature.md
+++ b/features/cli/run/symbolic.feature.md
@@ -1,4 +1,4 @@
-# Feature: qni run symbolic の出力
+# Feature: qni run --symbolic の出力
 
 qni-cli の利用者として
 ket 形式や名前付き基底で状態を読めるように
@@ -18,7 +18,7 @@ qni run --symbolic と --basis の表示を確認したい。
 
 ## Scenario: qni run --symbolic は Bell 状態の |Φ⁻⟩ を表示
 
-- Given 空の 2 qubit 回路がある
+- Given 空の 2 量子ビット回路がある
 - And "qni add H --qubit 0 --step 0" を実行
 - And "qni add X --control 0 --qubit 1 --step 1" を実行
 - And "qni add Z --qubit 0 --step 2" を実行
@@ -144,7 +144,7 @@ qni run --symbolic と --basis の表示を確認したい。
 
 ## Scenario: qni run --symbolic は 2 量子ビットの空回路を ket 形式で表示
 
-- Given 空の 2 qubit 回路がある
+- Given 空の 2 量子ビット回路がある
 - When "qni run --symbolic" を実行
 - Then 標準出力:
 
@@ -172,13 +172,13 @@ qni run --symbolic と --basis の表示を確認したい。
 
 ## Scenario: qni run --symbolic は 3 量子ビット回路を計算基底で表示 は成功
 
-- Given 空の 3 qubit 回路がある
+- Given 空の 3 量子ビット回路がある
 - When "qni run --symbolic" を実行
 - Then コマンドは成功
 
 ## Scenario: qni run --symbolic は 3 量子ビット回路を計算基底で表示
 
-- Given 空の 3 qubit 回路がある
+- Given 空の 3 量子ビット回路がある
 - When "qni run --symbolic" を実行
 - Then 標準出力:
 

--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -689,7 +689,7 @@ Given(/^空の 1 (?:qubit |量子ビット)回路がある$/, function () {
   });
 });
 
-Given('空の 2 qubit 回路がある', function () {
+Given(/^空の 2 (?:qubit |量子ビット)回路がある$/, function () {
   writeCircuitJson(this.scenarioDir, {
     qubits: 2,
     cols: [[1, 1]]


### PR DESCRIPTION
## 概要

`features/cli/run/symbolic.feature.md` の日本語文体を見直し、ルー語と見なせる表現を自然な日本語へ修正しました。

## 変更内容

- `qni run --symbolic` の feature 見出しで CLI 引数を明示。
- `ユーザ`、`named basis`、`exact`、`step`、`qubit` など、本文やシナリオ名で不自然に混ざっていた普通名詞を自然な日本語へ修正。
- 対象 feature の `空の 2 量子ビット回路がある` ステップを受け付けるよう、2 量子ビット回路のステップ定義を後方互換で調整。
- コマンド例、出力例、Gherkin キーワード、CLI 引数、`ket` など原文維持すべき表記は維持。

## 検証

- `git diff --check`
- `bundle exec rake check`

## Linear

- YAS-360
