### PR TITLE
2 量子ビットゲート仕様の文体を整える

### DIFF
--- a/features/cli/run/two_qubit_gates.feature.md
+++ b/features/cli/run/two_qubit_gates.feature.md
@@ -1,6 +1,6 @@
 # Feature: qni run の 2 量子ビットゲート
 
-qni-cli のユーザとして
+qni-cli の利用者として
 2 量子ビットゲートの数値状態ベクトルを確認するために
 qni run が SWAP と CNOT の結果を表示することを検証したい。
 

--- a/features/cli/run/two_qubit_gates.feature.md
+++ b/features/cli/run/two_qubit_gates.feature.md
@@ -1,13 +1,13 @@
-# Feature: qni run two qubit gates
+# Feature: qni run の 2 量子ビットゲート
 
 qni-cli のユーザとして
-2 qubit gate の数値状態ベクトルを確認するために
+2 量子ビットゲートの数値状態ベクトルを確認するために
 qni run が SWAP と CNOT の結果を表示することを検証したい。
 
 
 ## Scenario: qni run は SWAP を |00> に適用した状態ベクトルを標準出力に表示
 
-- Given 空の 2 qubit 回路がある
+- Given 空の 2 量子ビット回路がある
 - And "qni add SWAP --qubit 0,1 --step 0" を実行
 - When "qni run" を実行
 - Then 標準出力:
@@ -18,7 +18,7 @@ qni run が SWAP と CNOT の結果を表示することを検証したい。
 
 ## Scenario: qni run は SWAP を |01> に適用した状態ベクトルを標準出力に表示
 
-- Given 2 qubit の初期状態が "|01>" である
+- Given 2 量子ビットの初期状態が "|01>" である
 - And "qni add SWAP --qubit 0,1 --step 1" を実行
 - When "qni run" を実行
 - Then 標準出力:
@@ -29,7 +29,7 @@ qni run が SWAP と CNOT の結果を表示することを検証したい。
 
 ## Scenario: qni run は SWAP を |10> に適用した状態ベクトルを標準出力に表示
 
-- Given 2 qubit の初期状態が "|10>" である
+- Given 2 量子ビットの初期状態が "|10>" である
 - And "qni add SWAP --qubit 0,1 --step 1" を実行
 - When "qni run" を実行
 - Then 標準出力:
@@ -40,7 +40,7 @@ qni run が SWAP と CNOT の結果を表示することを検証したい。
 
 ## Scenario: qni run は SWAP を |11> に適用した状態ベクトルを標準出力に表示
 
-- Given 2 qubit の初期状態が "|11>" である
+- Given 2 量子ビットの初期状態が "|11>" である
 - And "qni add SWAP --qubit 0,1 --step 1" を実行
 - When "qni run" を実行
 - Then 標準出力:
@@ -51,7 +51,7 @@ qni run が SWAP と CNOT の結果を表示することを検証したい。
 
 ## Scenario: qni run は CNOT を |00> に適用した状態ベクトルを標準出力に表示
 
-- Given 空の 2 qubit 回路がある
+- Given 空の 2 量子ビット回路がある
 - And "qni add X --control 0 --qubit 1 --step 0" を実行
 - When "qni run" を実行
 - Then 標準出力:
@@ -62,7 +62,7 @@ qni run が SWAP と CNOT の結果を表示することを検証したい。
 
 ## Scenario: qni run は CNOT を |01> に適用した状態ベクトルを標準出力に表示
 
-- Given 2 qubit の初期状態が "|01>" である
+- Given 2 量子ビットの初期状態が "|01>" である
 - And "qni add X --control 0 --qubit 1 --step 1" を実行
 - When "qni run" を実行
 - Then 標準出力:
@@ -73,7 +73,7 @@ qni run が SWAP と CNOT の結果を表示することを検証したい。
 
 ## Scenario: qni run は CNOT を |10> に適用した状態ベクトルを標準出力に表示
 
-- Given 2 qubit の初期状態が "|10>" である
+- Given 2 量子ビットの初期状態が "|10>" である
 - And "qni add X --control 0 --qubit 1 --step 1" を実行
 - When "qni run" を実行
 - Then 標準出力:
@@ -84,7 +84,7 @@ qni run が SWAP と CNOT の結果を表示することを検証したい。
 
 ## Scenario: qni run は CNOT を |11> に適用した状態ベクトルを標準出力に表示
 
-- Given 2 qubit の初期状態が "|11>" である
+- Given 2 量子ビットの初期状態が "|11>" である
 - And "qni add X --control 0 --qubit 1 --step 2" を実行
 - When "qni run" を実行
 - Then 標準出力:

--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -689,14 +689,14 @@ Given(/^空の 1 (?:qubit |量子ビット)回路がある$/, function () {
   });
 });
 
-Given('空の 2 qubit 回路がある', function () {
+Given(/^空の 2 (?:qubit |量子ビット)回路がある$/, function () {
   writeCircuitJson(this.scenarioDir, {
     qubits: 2,
     cols: [[1, 1]]
   });
 });
 
-Given('2 qubit の初期状態が {string} である', function (state) {
+Given(/^2 (?:qubit |量子ビット)の初期状態が "([^"]*)" である$/, function (state) {
   writeCircuitJson(this.scenarioDir, {
     qubits: 2,
     cols: twoQubitInitialCols(state)


### PR DESCRIPTION
## 概要

- `features/cli/run/two_qubit_gates.feature.md` の `2 qubit gate` / `2 qubit` / `qni-cli のユーザとして` 表記を自然な日本語に整えました。
- 対象 feature のステップを `2 量子ビット` 表記へ更新しました。
- 既存 feature の `2 qubit` 表記も通るよう、対応ステップ定義は両方の表記を受ける形にしました。

## 検証

- `git diff --check`
- `bundle exec rake check`

## Linear

- YAS-361
