### PR TITLE
Bell 状態仕様の文体を整える

### DIFF
--- a/features/cli/state/bell.feature.md
+++ b/features/cli/state/bell.feature.md
@@ -2,14 +2,14 @@
 
 qni-cli のユーザとして
 Bell 基底の初期状態を保存・確認するために
-qni state set の Bell shorthand を使いたい
+qni state set の Bell 短縮表記を使いたい
 
 ## Scenario: qni state set は |Φ+> の保存に成功する
 
 - When "qni state set \"|Φ+>\"" を実行
 - Then コマンドは成功
 
-## Scenario: qni state show は |Φ+> を shorthand のまま表示する
+## Scenario: qni state show は |Φ+> を短縮表記のまま表示する
 
 - Given "qni state set \"|Φ+>\"" を実行
 - When "qni state show" を実行
@@ -19,7 +19,7 @@ qni state set の Bell shorthand を使いたい
   |Φ+>
   ```
 
-## Scenario: qni state set は |Φ+> を qubits 2 の circuit.json として保存する
+## Scenario: qni state set は |Φ+> を 2 量子ビットの circuit.json として保存する
 
 - When "qni state set \"|Φ+>\"" を実行
 - Then "circuit.json" の内容:
@@ -50,7 +50,7 @@ qni state set の Bell shorthand を使いたい
 - When "qni state set \"|Φ->\"" を実行
 - Then コマンドは成功
 
-## Scenario: qni state show は |Φ-> を shorthand のまま表示する
+## Scenario: qni state show は |Φ-> を短縮表記のまま表示する
 
 - Given "qni state set \"|Φ->\"" を実行
 - When "qni state show" を実行
@@ -65,7 +65,7 @@ qni state set の Bell shorthand を使いたい
 - When "qni state set \"|Ψ+>\"" を実行
 - Then コマンドは成功
 
-## Scenario: qni state show は |Ψ+> を shorthand のまま表示する
+## Scenario: qni state show は |Ψ+> を短縮表記のまま表示する
 
 - Given "qni state set \"|Ψ+>\"" を実行
 - When "qni state show" を実行
@@ -80,7 +80,7 @@ qni state set の Bell shorthand を使いたい
 - When "qni state set \"|Ψ->\"" を実行
 - Then コマンドは成功
 
-## Scenario: qni state show は |Ψ-> を shorthand のまま表示する
+## Scenario: qni state show は |Ψ-> を短縮表記のまま表示する
 
 - Given "qni state set \"|Ψ->\"" を実行
 - When "qni state show" を実行

--- a/features/cli/state/bell.feature.md
+++ b/features/cli/state/bell.feature.md
@@ -1,6 +1,6 @@
 # Feature: qni state Bell
 
-qni-cli のユーザとして
+qni-cli の利用者として
 Bell 基底の初期状態を保存・確認するために
 qni state set の Bell 短縮表記を使いたい
 


### PR DESCRIPTION
## 概要

- `features/cli/state/bell.feature.md` の本文に残っていた `shorthand`、`qubits 2`、`ユーザ` の表現を自然な日本語に修正しました。
- `Feature:` / `Scenario:` / `Given` / `When` / `Then`、コマンド例、期待値、JSON キーは原文を維持しています。
- GitHub Actions の滞留回復のため、内容変更のない空 commit を追加しています。最終的な意図ある差分は文体修正のみです。

## 検証

- `git diff --check`
- `bundle exec rake check`
- `origin/main` merge 後の `git diff --check`
- `origin/main` merge 後の `bundle exec rake check`

## Linear

- YAS-362
