### PR TITLE
state clear 仕様書の文体を整える

### DIFF
--- a/features/cli/state/clear.feature.md
+++ b/features/cli/state/clear.feature.md
@@ -1,6 +1,6 @@
 # Feature: qni state clear
 
-qni-cli のユーザとして
+qni-cli の利用者として
 明示的な初期状態設定を削除するために
 qni state clear を使いたい
 
@@ -10,7 +10,7 @@ qni state clear を使いたい
 - When "qni state clear" を実行
 - Then コマンドは成功
 
-## Scenario: qni state clear は initial_state を circuit.json から削除する
+## Scenario: qni state clear は circuit.json から initial_state を削除する
 
 - Given "qni state set \"alpha|0> + beta|1>\"" を実行
 - When "qni state clear" を実行
@@ -27,7 +27,7 @@ qni state clear を使いたい
   }
   ```
 
-## Scenario: QNI_USE_RUBY=1 の qni state clear は initial_state を circuit.json から削除する
+## Scenario: QNI_USE_RUBY=1 の qni state clear は circuit.json から initial_state を削除する
 
 - Given 環境変数 "QNI_USE_RUBY" を "1" に設定する
 - Given "qni state set \"alpha|0> + beta|1>\"" を実行


### PR DESCRIPTION
## 概要

- `features/cli/state/clear.feature.md` の本文で `ユーザ` を `利用者` に直しました。
- `initial_state` と `circuit.json` は識別子・ファイル名として維持しつつ、シナリオ名の語順を自然にしました。
- Gherkin ステップ、コマンド例、期待 JSON は変更していません。

## Linear

- YAS-363

## 検証

- `git diff --check`
- `bundle exec rake check`
