### PR TITLE
state ヘルプ仕様の文体を整える

### DIFF
--- a/features/cli/state/help.feature.md
+++ b/features/cli/state/help.feature.md
@@ -1,8 +1,8 @@
-# Feature: qni state help
+# Feature: qni state のヘルプ
 
-qni-cli のユーザとして
+qni-cli の利用者として
 初期状態ベクトルの管理方法を知るために
-qni state の help を見たい
+qni state のヘルプを見たい
 
 ## Scenario: qni state は成功する
 

--- a/features/cli/state/help.feature.md
+++ b/features/cli/state/help.feature.md
@@ -1,4 +1,4 @@
-# Feature: qni state のヘルプ
+# Feature: qni state のヘルプ表示
 
 qni-cli の利用者として
 初期状態ベクトルの管理方法を知るために


### PR DESCRIPTION
## 概要

- `features/cli/state/help.feature.md` の日本語本文に残っていた `help` を `ヘルプ` に直しました。
- Feature 見出しを `qni state のヘルプ表示` にし、既存仕様書の傾向に合わせました。
- `qni-cli のユーザ` を `qni-cli の利用者` に直し、文体を自然な日本語に寄せました。
- CLI の期待出力、コマンド例、Gherkin ステップ文は変更していません。

## Linear

- YAS-364

## 検証

- `git diff --check`
- `bundle exec rake check`
