### PR TITLE
state set 仕様書の文体を整える

### DIFF
--- a/features/cli/state/set.feature.md
+++ b/features/cli/state/set.feature.md
@@ -1,6 +1,6 @@
 # Feature: qni state set
 
-qni-cli のユーザとして
+qni-cli の利用者として
 任意の初期状態ベクトルを保存するために
 qni state set を使いたい
 


### PR DESCRIPTION
## 概要

- `features/cli/state/set.feature.md` の本文にある普通名詞寄りの `ユーザ` を `利用者` に変更しました。
- Gherkin キーワード、コマンド例、JSON キー、期待値、エラーメッセージは仕様上の原文として維持しました。

## 検証

- `git diff --check`
- `bundle exec rake check`

## Linear

- YAS-365
