### PR TITLE
state 短縮表記の機能ファイルの文体を整える

### DIFF
--- a/features/cli/state/shorthand.feature.md
+++ b/features/cli/state/shorthand.feature.md
@@ -1,7 +1,7 @@
 # Feature: qni state 短縮表記
 
 qni-cli の利用者として
-よく使う 1 量子ビットの初期状態を短い表記で保存するために
+よく使う 1 量子ビットの初期状態を短縮表記で保存するために
 qni state set の短縮表記を使いたい
 
 ## Scenario: qni state set は |+> の保存に成功する

--- a/features/cli/state/shorthand.feature.md
+++ b/features/cli/state/shorthand.feature.md
@@ -1,15 +1,15 @@
-# Feature: qni state shorthand
+# Feature: qni state 短縮表記
 
-qni-cli のユーザとして
-よく使う 1 qubit 初期状態を短い表記で保存するために
-qni state set の shorthand を使いたい
+qni-cli の利用者として
+よく使う 1 量子ビットの初期状態を短い表記で保存するために
+qni state set の短縮表記を使いたい
 
 ## Scenario: qni state set は |+> の保存に成功する
 
 - When "qni state set \"|+>\"" を実行
 - Then コマンドは成功
 
-## Scenario: qni state show は |+> を shorthand のまま表示する
+## Scenario: qni state show は |+> を短縮表記のまま表示する
 
 - Given "qni state set \"|+>\"" を実行
 - When "qni state show" を実行
@@ -24,7 +24,7 @@ qni state set の shorthand を使いたい
 - When "qni state set \"|->\"" を実行
 - Then コマンドは成功
 
-## Scenario: qni state show は |-> を shorthand のまま表示する
+## Scenario: qni state show は |-> を短縮表記のまま表示する
 
 - Given "qni state set \"|->\"" を実行
 - When "qni state show" を実行
@@ -39,7 +39,7 @@ qni state set の shorthand を使いたい
 - When "qni state set \"|+i>\"" を実行
 - Then コマンドは成功
 
-## Scenario: qni state show は |+i> を shorthand のまま表示する
+## Scenario: qni state show は |+i> を短縮表記のまま表示する
 
 - Given "qni state set \"|+i>\"" を実行
 - When "qni state show" を実行
@@ -54,7 +54,7 @@ qni state set の shorthand を使いたい
 - When "qni state set \"|-i>\"" を実行
 - Then コマンドは成功
 
-## Scenario: qni state show は |-i> を shorthand のまま表示する
+## Scenario: qni state show は |-i> を短縮表記のまま表示する
 
 - Given "qni state set \"|-i>\"" を実行
 - When "qni state show" を実行


### PR DESCRIPTION
## 概要

YAS-366

- `features/cli/state/shorthand.feature.md` の不自然な英日混在を自然な日本語に修正しました。
- `qni state set`、`qni state show`、Gherkin キーワード、コマンド例、期待値は変更していません。
- PR レビュー指摘に従い、導入文の用語も「短縮表記」に統一しました。

## 検証

- `npm run build && npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress features/cli/state/shorthand.feature.md`
- `git diff --check`
- `bundle exec rake check`
