### PR TITLE
state show の利用者表記を直す

### DIFF
--- a/features/cli/state/show.feature.md
+++ b/features/cli/state/show.feature.md
@@ -1,6 +1,6 @@
 # Feature: qni state show
 
-qni-cli のユーザとして
+qni-cli の利用者として
 現在の初期状態ベクトルを確認するために
 qni state show を使いたい
 


### PR DESCRIPTION
## 概要

- `features/cli/state/show.feature.md` の本文で「ユーザ」を「利用者」に変更しました。
- `Feature:` / `Scenario:` / `Given` / `When` / `Then`、`qni state show`、期待値、コマンド例は構文や識別子として原文を保ちました。

## 検証

- `git diff --check`
- `npm run build && npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress features/cli/state/show.feature.md`
- `bundle exec rake check`

## Linear

- YAS-367
