### PR TITLE
TypeScript process compatibility 仕様の文体を整える

### DIFF
--- a/features/cli/typescript_process_compatibility.feature.md
+++ b/features/cli/typescript_process_compatibility.feature.md
@@ -1,25 +1,25 @@
-# Feature: TypeScript process compatibility helper
+# Feature: TypeScript プロセス互換性ヘルパー
 
 qni-cli のメンテナとして
-TypeScript dispatcher から Ruby fallback を安全に呼び出せるようにするために
-process compatibility helper の契約を明確にしたい
+TypeScript の実行振り分けから Ruby fallback を安全に呼び出せるようにするために
+プロセス互換性ヘルパーの契約を明確にしたい
 
-## Scenario: helper module が存在する
+## Scenario: ヘルパーモジュールが存在する
 
 - Then リポジトリファイル "src/process/process_compatibility.ts" は存在する
 
-## Scenario: TypeScript test script が定義されている
+## Scenario: TypeScript テストスクリプトが定義されている
 
 - Then リポジトリファイル "package.json" は "\"test:ts\"" を含む
 
-## Scenario: full check は TypeScript tests を実行する
+## Scenario: 全体チェックは TypeScript テストを実行する
 
 - Then リポジトリファイル "Rakefile" は "npm run test:ts" を含む
 
-## Scenario: TypeScript symbolic helper boundary が存在する
+## Scenario: TypeScript のシンボリックヘルパー境界が存在する
 
 - Then リポジトリファイル "src/symbolic_state_renderer.ts" は存在する
 
-## Scenario: TypeScript run command は symbolic helper boundary を使う
+## Scenario: TypeScript の run コマンドはシンボリックヘルパー境界を使う
 
 - Then リポジトリファイル "src/commands/run_command.ts" は "renderSymbolicStateVector" を含む

--- a/features/cli/typescript_process_compatibility.feature.md
+++ b/features/cli/typescript_process_compatibility.feature.md
@@ -1,25 +1,25 @@
-# Feature: TypeScript process compatibility helper
+# Feature: TypeScript プロセス互換性ヘルパー
 
 qni-cli のメンテナとして
 TypeScript dispatcher から Ruby fallback を安全に呼び出せるようにするために
-process compatibility helper の契約を明確にしたい
+プロセス互換性ヘルパーの契約を明確にしたい
 
-## Scenario: helper module が存在する
+## Scenario: ヘルパーモジュールが存在する
 
 - Then リポジトリファイル "src/process/process_compatibility.ts" は存在する
 
-## Scenario: TypeScript test script が定義されている
+## Scenario: TypeScript テストスクリプトが定義されている
 
 - Then リポジトリファイル "package.json" は "\"test:ts\"" を含む
 
-## Scenario: full check は TypeScript tests を実行する
+## Scenario: 全体チェックは TypeScript テストを実行する
 
 - Then リポジトリファイル "Rakefile" は "npm run test:ts" を含む
 
-## Scenario: TypeScript symbolic helper boundary が存在する
+## Scenario: TypeScript のシンボリックヘルパー境界が存在する
 
 - Then リポジトリファイル "src/symbolic_state_renderer.ts" は存在する
 
-## Scenario: TypeScript run command は symbolic helper boundary を使う
+## Scenario: TypeScript の run コマンドはシンボリックヘルパー境界を使う
 
 - Then リポジトリファイル "src/commands/run_command.ts" は "renderSymbolicStateVector" を含む


### PR DESCRIPTION
## 概要

- `features/cli/typescript_process_compatibility.feature.md` の説明文とシナリオ名に残っていた英語の普通名詞を自然な日本語へ修正しました。
- `Feature`、`Scenario`、`Then`、ファイルパス、`npm run test:ts`、`renderSymbolicStateVector` など、原文維持が必要な語は変更していません。
- `dispatcher` は `src/dispatcher` や `createDispatcher` と対応する既存コード用語として原文維持対象にしています。
- Linear: YAS-368

## 検証

- `git diff --check`
- `bundle exec rake check`

## 補足

- ステップ本文と検証対象の文字列は変更していないため、仕様の意味、期待値、コマンド例は維持されています。
