### PR TITLE
variable エラー仕様の文体を整える

### DIFF
--- a/features/cli/variable/errors.feature.md
+++ b/features/cli/variable/errors.feature.md
@@ -1,7 +1,7 @@
-# Feature: qni variable errors
+# Feature: qni variable のエラー
 
 qni-cli のユーザとして
-variable コマンドの入力エラーを理解するために
+qni variable の入力エラーを理解するために
 qni variable のエラーを確認したい
 
 ## Scenario: qni variable set は circuit.json がないと失敗する

--- a/features/cli/variable/errors.feature.md
+++ b/features/cli/variable/errors.feature.md
@@ -1,7 +1,7 @@
-# Feature: qni variable errors
+# Feature: qni variable のエラー
 
-qni-cli のユーザとして
-variable コマンドの入力エラーを理解するために
+qni-cli のユーザーとして
+qni variable の入力エラーを理解するために
 qni variable のエラーを確認したい
 
 ## Scenario: qni variable set は circuit.json がないと失敗する


### PR DESCRIPTION
## 概要

- `features/cli/variable/errors.feature.md` の見出しと冒頭文を自然な日本語に調整しました。
- `qni variable`、`circuit.json`、Gherkin ステップ、コマンド例、期待エラー文字列は維持しました。

## 確認

- [x] `git diff --check`
- [x] `bundle exec rake check`

## Linear

- YAS-370
