### PR TITLE
variable ヘルプ仕様の文体を整える

### DIFF
--- a/features/cli/variable/help.feature.md
+++ b/features/cli/variable/help.feature.md
@@ -1,7 +1,7 @@
-# Feature: qni variable ヘルプ
+# Feature: qni variable のヘルプ表示
 
-qni-cli のユーザーとして
-記号角度変数の管理方法を知るために
+qni-cli のユーザとして
+角度変数の管理方法を知るために
 qni variable のヘルプを見たい
 
 ## Scenario: qni variable は成功する
@@ -9,7 +9,7 @@ qni variable のヘルプを見たい
 - When "qni variable" を実行
 - Then コマンドは成功
 
-## Scenario: qni variable は variable サブコマンドの使い方を表示
+## Scenario: qni variable は qni variable の使い方を表示
 
 - When "qni variable" を実行
 - Then 標準出力:
@@ -41,7 +41,7 @@ qni variable のヘルプを見たい
 - When "qni variable --help" を実行
 - Then コマンドは成功
 
-## Scenario: qni variable --help は variable サブコマンドの使い方を表示
+## Scenario: qni variable --help は qni variable の使い方を表示
 
 - When "qni variable --help" を実行
 - Then 標準出力:

--- a/features/cli/variable/help.feature.md
+++ b/features/cli/variable/help.feature.md
@@ -1,15 +1,15 @@
-# Feature: qni variable help
+# Feature: qni variable ヘルプ
 
-qni-cli のユーザとして
-symbolic angle variable の管理方法を知るために
-qni variable の help を見たい
+qni-cli のユーザーとして
+記号角度変数の管理方法を知るために
+qni variable のヘルプを見たい
 
 ## Scenario: qni variable は成功する
 
 - When "qni variable" を実行
 - Then コマンドは成功
 
-## Scenario: qni variable は variable コマンドの使い方を表示
+## Scenario: qni variable は variable サブコマンドの使い方を表示
 
 - When "qni variable" を実行
 - Then 標準出力:
@@ -41,7 +41,7 @@ qni variable の help を見たい
 - When "qni variable --help" を実行
 - Then コマンドは成功
 
-## Scenario: qni variable --help は variable コマンドの使い方を表示
+## Scenario: qni variable --help は variable サブコマンドの使い方を表示
 
 - When "qni variable --help" を実行
 - Then 標準出力:

--- a/features/cli/variable/help.feature.md
+++ b/features/cli/variable/help.feature.md
@@ -9,7 +9,7 @@ qni variable のヘルプを見たい
 - When "qni variable" を実行
 - Then コマンドは成功
 
-## Scenario: qni variable は qni variable の使い方を表示
+## Scenario: qni variable は variable コマンドの使い方を表示
 
 - When "qni variable" を実行
 - Then 標準出力:
@@ -41,7 +41,7 @@ qni variable のヘルプを見たい
 - When "qni variable --help" を実行
 - Then コマンドは成功
 
-## Scenario: qni variable --help は qni variable の使い方を表示
+## Scenario: qni variable --help は variable コマンドの使い方を表示
 
 - When "qni variable --help" を実行
 - Then 標準出力:


### PR DESCRIPTION
## 概要

- `features/cli/variable/help.feature.md` の見出しと本文で、不自然に英語の普通名詞が混ざっていた箇所を自然な日本語に修正しました。
- 既存の help feature 群との表記統一に合わせ、`ユーザ`、`角度変数`、`variable コマンドの使い方を表示` は維持しました。
- CLI 出力例、コマンド、Gherkin キーワード、既存ステップ文は検証値を変えないため維持しました。

## Linear

- YAS-371

## 検証

- `git diff --check`
- `npm run build && npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress "features/cli/variable/help.feature.md"`
- `bundle exec rake check`
- GitHub Actions `test` 2 件 pass
