### PR TITLE
variable list 機能仕様の文体を整える

### DIFF
--- a/features/cli/variable/list.feature.md
+++ b/features/cli/variable/list.feature.md
@@ -1,6 +1,6 @@
 # Feature: qni variable list
 
-qni-cli のユーザとして
+qni-cli の利用者として
 保存済みの角度変数を確認するために
 qni variable list で変数を一覧表示したい
 


### PR DESCRIPTION
## 概要

- YAS-372 の対象である `features/cli/variable/list.feature.md` の文体を見直しました。
- `qni-cli のユーザとして` を `qni-cli の利用者として` に直し、不自然な英日混在を避けました。
- Gherkin キーワード、ステップ文、コマンド例、期待値は変更していません。

## 検証

- `git diff --check`
- `bundle exec rake check`

## Linear

- YAS-372
