### PR TITLE
variable set 仕様の文体を整える

### DIFF
--- a/features/cli/variable/set.feature.md
+++ b/features/cli/variable/set.feature.md
@@ -1,6 +1,6 @@
 # Feature: qni variable set
 
-qni-cli のユーザとして
+qni-cli の利用者として
 角度変数を使って回路を再利用するために
 qni variable set で変数を保存したい
 


### PR DESCRIPTION
## 概要

- `features/cli/variable/set.feature.md` の本文で `ユーザ` を `利用者` に直しました。
- Gherkin キーワード、ステップ、コマンド例、期待 JSON は変更していません。

## Linear

- YAS-373

## 検証

- `git diff --check`
- `bundle exec rake check`

## 備考

- `Feature` / `Scenario` / `Given` / `When` / `Then`、`qni variable set`、`circuit.json` は構文、コマンド、ファイル名として原文を維持しています。
