### PR TITLE
制御付きゲート仕様書の文体を整える

### DIFF
--- a/features/cli/view/controlled_gates.feature.md
+++ b/features/cli/view/controlled_gates.feature.md
@@ -1,7 +1,7 @@
-# Feature: qni view の controlled gate 表示
+# Feature: qni view の制御付きゲート表示
 
 qni-cli のユーザとして、制御付き量子回路を確認するために、
-qni view で control と target の接続が分かるアスキーアート表示を見たい。
+qni view で制御点と対象ゲートの接続が分かるアスキーアート表示を見たい。
 
 ## Scenario: qni view は CNOT ゲートを表示
 
@@ -16,7 +16,7 @@ qni view で control と target の接続が分かるアスキーアート表示
       └───┘
   ```
 
-## Scenario: qni view は control 付き √X ゲートを表示
+## Scenario: qni view は制御付き √X ゲートを表示
 
 - Given "qni add √X --control 0 --qubit 1 --step 0" を実行
 - When "qni view" を実行
@@ -29,7 +29,7 @@ qni view で control と target の接続が分かるアスキーアート表示
       └───┘
   ```
 
-## Scenario: qni view は control 付き T† ゲートを表示
+## Scenario: qni view は制御付き T† ゲートを表示
 
 - Given "qni add T† --control 0 --qubit 1 --step 0" を実行
 - When "qni view" を実行
@@ -42,7 +42,7 @@ qni view で control と target の接続が分かるアスキーアート表示
       └───┘
   ```
 
-## Scenario: qni view は control 付き Rz ゲートを表示
+## Scenario: qni view は制御付き Rz ゲートを表示
 
 - Given "qni add Rz --angle π/2 --control 0 --qubit 1 --step 0" を実行
 - When "qni view" を実行


### PR DESCRIPTION
## 概要

- `features/cli/view/controlled_gates.feature.md` の日本語本文に混ざっていた `controlled gate`、`control`、`target`、`control 付き` を自然な日本語に変更しました。
- `Given` / `When` / `Then`、CLI 引数、コマンド例、期待される回路図は変更していません。

## 対応課題

- YAS-376

## 検証

- `git diff --check`
- `bundle exec rake check`
