### PR TITLE
qni view のヘルプ文書を整える

### DIFF
--- a/features/cli/view/help.feature.md
+++ b/features/cli/view/help.feature.md
@@ -1,8 +1,8 @@
-# Feature: qni view help
+# Feature: qni view のヘルプ
 
 qni-cli のユーザとして
 回路表示コマンドの使い方を迷わず確認できるように
-qni view の help を表示したい。
+qni view のヘルプを表示したい。
 
 ## Scenario: qni view --help は成功する
 


### PR DESCRIPTION
## 概要

- `features/cli/view/help.feature.md` の日本語文脈に混ざっていた `help` を `ヘルプ` に修正しました。
- CLI 出力例、コマンド文字列、Gherkin キーワード、ステップ文は期待値・識別子として維持しました。

## Linear

- YAS-378

## 検証

- [x] `git diff --check`
- [x] `bundle exec rake check`
