### PR TITLE
TTY 装飾表示仕様の文体を整える

### DIFF
--- a/features/cli/view/tty_styles.feature.md
+++ b/features/cli/view/tty_styles.feature.md
@@ -1,7 +1,7 @@
 # Feature: qni view の TTY 装飾表示
 
 qni-cli のユーザとして、端末上で読みやすく回路を確認するために、
-qni view の TTY 出力で gate ラベルの修飾子を控えめに表示してほしい。
+qni view の TTY 出力でゲートのラベルの修飾子を控えめに表示してほしい。
 
 ## Scenario: qni view は TTY で T† ゲートを表示できる
 
@@ -9,11 +9,11 @@ qni view の TTY 出力で gate ラベルの修飾子を控えめに表示して
 - When "qni view" を TTY で実行
 - Then コマンドは成功
 
-## Scenario: qni view は TTY では T† の修飾子を dim 表示する
+## Scenario: qni view は TTY では T† の修飾子を淡色表示する
 
 - Given "qni add T† --qubit 0 --step 0" を実行
 - When "qni view" を TTY で実行
-- Then 標準出力に dim 修飾付きラベル "T†" を含む
+- Then 標準出力に淡色修飾付きラベル "T†" を含む
 
 ## Scenario: qni view は TTY で Ry ゲートを表示できる
 
@@ -21,9 +21,8 @@ qni view の TTY 出力で gate ラベルの修飾子を控えめに表示して
 - When "qni view" を TTY で実行
 - Then コマンドは成功
 
-## Scenario: qni view は TTY では Ry の修飾子を dim 表示する
+## Scenario: qni view は TTY では Ry の修飾子を淡色表示する
 
 - Given "qni add Ry --angle π/2 --qubit 0 --step 0" を実行
 - When "qni view" を TTY で実行
-- Then 標準出力に dim 修飾付きラベル "Ry" を含む
-
+- Then 標準出力に淡色修飾付きラベル "Ry" を含む

--- a/features/cli/view/tty_styles.feature.md
+++ b/features/cli/view/tty_styles.feature.md
@@ -1,7 +1,7 @@
 # Feature: qni view の TTY 装飾表示
 
-qni-cli のユーザとして、端末上で読みやすく回路を確認するために、
-qni view の TTY 出力で gate ラベルの修飾子を控えめに表示してほしい。
+qni-cli の利用者として、端末上で読みやすく回路を確認するために、
+qni view の TTY 出力でゲートのラベルの修飾子を控えめに表示してほしい。
 
 ## Scenario: qni view は TTY で T† ゲートを表示できる
 
@@ -9,7 +9,7 @@ qni view の TTY 出力で gate ラベルの修飾子を控えめに表示して
 - When "qni view" を TTY で実行
 - Then コマンドは成功
 
-## Scenario: qni view は TTY では T† の修飾子を dim 表示する
+## Scenario: qni view は TTY では T† の修飾子を淡色表示する
 
 - Given "qni add T† --qubit 0 --step 0" を実行
 - When "qni view" を TTY で実行
@@ -21,9 +21,8 @@ qni view の TTY 出力で gate ラベルの修飾子を控えめに表示して
 - When "qni view" を TTY で実行
 - Then コマンドは成功
 
-## Scenario: qni view は TTY では Ry の修飾子を dim 表示する
+## Scenario: qni view は TTY では Ry の修飾子を淡色表示する
 
 - Given "qni add Ry --angle π/2 --qubit 0 --step 0" を実行
 - When "qni view" を TTY で実行
 - Then 標準出力に dim 修飾付きラベル "Ry" を含む
-

--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -937,7 +937,7 @@ Then('リポジトリファイル {string} は {string} を含む', function (fi
   );
 });
 
-Then('標準出力に dim 修飾付きラベル {string} を含む', function (label) {
+Then('標準出力に淡色修飾付きラベル {string} を含む', function (label) {
   const chars = [...label];
 
   assert.ok(chars.length >= 2, `label must have at least 2 characters: ${label}`);


### PR DESCRIPTION
## 概要

- Linear: YAS-381
- `features/cli/view/tty_styles.feature.md` の日本語本文、シナリオ名、検証ステップ文を見直しました。
- `features/step_definitions/cli_steps.js` の対応ステップ定義名も、仕様書側の表現に合わせて日本語化しました。
- 仕様、期待値、コマンド例、検証ロジックは変更していません。

## 検証

- [x] `git diff --check`
- [x] `bundle exec rake check`
