### PR TITLE
QNI_USE_RUBY運用ドキュメントの文体を整える

### DIFF
--- a/features/docs/qni_use_ruby_operational_documentation.feature.md
+++ b/features/docs/qni_use_ruby_operational_documentation.feature.md
@@ -1,7 +1,7 @@
-# Feature: QNI_USE_RUBY operational documentation
+# Feature: QNI_USE_RUBY 運用ドキュメント
 
 qni-cli の保守者として
-TypeScript 段階移行中の緊急 rollback と release difference analysis を安全に行うために
+TypeScript 段階移行中の緊急ロールバックとリリース差分分析を安全に行うために
 Ruby 実装を強制する環境変数の使い方とリスクを README で確認したい
 
 ## Scenario: README は QNI_USE_RUBY の目的を説明する
@@ -16,14 +16,14 @@ Ruby 実装を強制する環境変数の使い方とリスクを README で確�
 
 - Then リポジトリファイル "README.md" は "QNI_USE_RUBY=1 qni run --symbolic" を含む
 
-## Scenario: README は repository-local の利用例を示す
+## Scenario: README はリポジトリ内での利用例を示す
 
 - Then リポジトリファイル "README.md" は "QNI_USE_RUBY=1 bundle exec bin/qni run --symbolic" を含む
 
-## Scenario: README は compatibility lane の注意を説明する
+## Scenario: README は互換性レーンの注意を説明する
 
 - Then リポジトリファイル "README.md" は "The TypeScript compatibility lane in CI must fail fast if `QNI_USE_RUBY` is set." を含む
 
-## Scenario: README は Ruby fallback removal まで文書を残す方針を説明する
+## Scenario: README は Ruby fallback を削除するまで文書を残す方針を説明する
 
 - Then リポジトリファイル "README.md" は "Keep this section until the final Ruby fallback removal issue deletes the dispatcher fallback and Ruby runtime dependency." を含む


### PR DESCRIPTION
## 概要

- `features/docs/qni_use_ruby_operational_documentation.feature.md` の不自然な英日混在表現を自然な日本語に修正しました。
- README の期待文字列、`QNI_USE_RUBY`、`Ruby fallback`、コマンド例、Gherkin キーワードは原文のまま維持しました。

## 検証

- `git diff --check`
- `bundle exec rake check`

Linear: YAS-382
