### PR TITLE
basis_change.feature.md の文体を整える

### DIFF
--- a/features/katas/basic_gates/basis_change.feature.md
+++ b/features/katas/basic_gates/basis_change.feature.md
@@ -1,5 +1,6 @@
-# Feature: Quantum Katas BasicGates Task 1.2 BasisChange
-  Task 1.2 BasisChange: |0⟩ を |+⟩ に、|1⟩ を |-⟩ に変える
+# Feature: Quantum Katas BasicGates 課題 1.2 BasisChange
+
+  課題 1.2 BasisChange: |0⟩ を |+⟩ に、|1⟩ を |-⟩ に変える
 
   入力:
   1 量子ビットの状態 |ψ⟩ = α|0⟩ + β|1⟩

--- a/features/katas/basic_gates/basis_change.feature.md
+++ b/features/katas/basic_gates/basis_change.feature.md
@@ -1,5 +1,5 @@
-# Feature: Quantum Katas BasicGates Task 1.2 BasisChange
-  Task 1.2 BasisChange: |0⟩ を |+⟩ に、|1⟩ を |-⟩ に変える
+# Feature: Quantum Katas BasicGates 課題 1.2 BasisChange
+  課題 1.2 BasisChange: |0⟩ を |+⟩ に、|1⟩ を |-⟩ に変える
 
   入力:
   1 量子ビットの状態 |ψ⟩ = α|0⟩ + β|1⟩


### PR DESCRIPTION
## 概要

- `features/katas/basic_gates/basis_change.feature.md` の課題名まわりで、普通名詞として混在していた `Task` を `課題` に変更しました。
- `Feature` / `Scenario` / `Given` / `When` / `Then` は Gherkin キーワードとして、`Quantum Katas` / `BasicGates` / `BasisChange` は課題名・識別子として維持しました。
- 見出し直後に空行を追加し、Markdown 見出しの体裁も整えました。

## Linear

- YAS-384
- 横展開は範囲外のため、関連 Backlog 課題として YAS-519 を作成しました。

## 検証

- `git diff --check origin/main...HEAD`
- `bundle exec rake check`
