### PR TITLE
BellStateChange3 の課題表記を整える

### DIFF
--- a/features/katas/basic_gates/bell_state_change_3.feature.md
+++ b/features/katas/basic_gates/bell_state_change_3.feature.md
@@ -1,5 +1,5 @@
-# Feature: Quantum Katas BasicGates Task 1.10 BellStateChange3
-  Task 1.10 BellStateChange3: |Φ⁺⟩ を |Ψ⁻⟩ に変える
+# Feature: Quantum Katas BasicGates 課題 1.10 BellStateChange3
+  課題 1.10 BellStateChange3: |Φ⁺⟩ を |Ψ⁻⟩ に変える
 
   入力:
   2 量子ビットの Bell 状態 |ψ⟩ = α|Φ⁺⟩ + β|Ψ⁻⟩

--- a/features/katas/basic_gates/bell_state_change_3.feature.md
+++ b/features/katas/basic_gates/bell_state_change_3.feature.md
@@ -1,4 +1,4 @@
-# Feature: Quantum Katas BasicGates 課題 1.10 BellStateChange3
+# Feature: Quantum Katas BasicGates Task 1.10 BellStateChange3
   課題 1.10 BellStateChange3: |Φ⁺⟩ を |Ψ⁻⟩ に変える
 
   入力:


### PR DESCRIPTION
## 概要

- `features/katas/basic_gates/bell_state_change_3.feature.md` の課題説明で、本文中の `Task` を `課題` に変更しました。
- `Feature` / `Scenario` などの Gherkin 見出しキーワード、状態ベクトル、回路例、期待値は変更していません。

## Linear

- YAS-387

## 検証

- [x] `git diff --check`
- [x] `bundle exec rake check`
