### PR TITLE
phase_change のタスク表記を整える

### DIFF
--- a/features/katas/basic_gates/phase_change.feature.md
+++ b/features/katas/basic_gates/phase_change.feature.md
@@ -1,5 +1,5 @@
 # Feature: Quantum Katas BasicGates Task 1.6 PhaseChange
-  Task 1.6 PhaseChange: |1⟩ 成分に一般角の位相を掛ける
+  タスク 1.6 PhaseChange: |1⟩ 成分に一般角の位相を掛ける
 
   入力:
   角度 θ

--- a/features/katas/basic_gates/phase_change.feature.md
+++ b/features/katas/basic_gates/phase_change.feature.md
@@ -1,5 +1,5 @@
-# Feature: Quantum Katas BasicGates Task 1.6 PhaseChange
-  Task 1.6 PhaseChange: |1⟩ 成分に一般角の位相を掛ける
+# Feature: Quantum Katas BasicGates タスク 1.6 PhaseChange
+  タスク 1.6 PhaseChange: |1⟩ 成分に一般角の位相を掛ける
 
   入力:
   角度 θ

--- a/features/katas/basic_gates/phase_change.feature.md
+++ b/features/katas/basic_gates/phase_change.feature.md
@@ -1,4 +1,5 @@
 # Feature: Quantum Katas BasicGates タスク 1.6 PhaseChange
+
   タスク 1.6 PhaseChange: |1⟩ 成分に一般角の位相を掛ける
 
   入力:


### PR DESCRIPTION
## 概要

- `features/katas/basic_gates/phase_change.feature.md` の見出しと本文にある `Task` を `タスク` に変更しました。
- `Feature:` / `Scenario:` などの Gherkin 由来の構造見出し、`PhaseChange` の課題識別子、ステップ文、期待値、コマンド例は変更していません。
- トップ見出し直後に空行を入れ、Markdown 見出しとしての整形も保っています。

## Linear

- YAS-389: https://linear.app/yasuhito/issue/YAS-389/featureskatasbasic-gatesphase-changefeaturemd-のルー語をレビューして直す

## 検証

- `git diff --check`
- `bundle exec rake check`
