### PR TITLE
PhaseFlip 仕様書のルー語を直す

### DIFF
--- a/features/katas/basic_gates/phase_flip.feature.md
+++ b/features/katas/basic_gates/phase_flip.feature.md
@@ -1,5 +1,5 @@
-# Feature: Quantum Katas BasicGates Task 1.5 PhaseFlip
-  Task 1.5 PhaseFlip: |1⟩ 成分にだけ位相 i を掛ける
+# Feature: Quantum Katas BasicGates 課題 1.5 PhaseFlip
+  課題 1.5 PhaseFlip: |1⟩ 成分にだけ位相 i を掛ける
 
   入力:
   1 量子ビットの状態 |ψ⟩ = α|0⟩ + β|1⟩


### PR DESCRIPTION
## 概要

- `features/katas/basic_gates/phase_flip.feature.md` の冒頭にある通常名詞 `Task` を `課題` に置き換えました。
- `Feature` / `Scenario`、`Quantum Katas` / `BasicGates` / `PhaseFlip`、既存ステップ文、回路図、期待値は維持しています。

## Linear

- YAS-390

## 検証

- `git diff --check`
- `bundle exec rake check`
