### PR TITLE
SignFlip 課題仕様の Task 表記を整える

### DIFF
--- a/features/katas/basic_gates/sign_flip.feature.md
+++ b/features/katas/basic_gates/sign_flip.feature.md
@@ -1,5 +1,5 @@
-# Feature: Quantum Katas BasicGates Task 1.3 SignFlip
-  Task 1.3 SignFlip: |+⟩ を |-⟩ に、|-⟩ を |+⟩ に変える
+# Feature: Quantum Katas BasicGates 課題 1.3 SignFlip
+  課題 1.3 SignFlip: |+⟩ を |-⟩ に、|-⟩ を |+⟩ に変える
 
   入力:
   1 量子ビットの状態 |ψ⟩ = α|0⟩ + β|1⟩


### PR DESCRIPTION
## 概要

- YAS-391
- `features/katas/basic_gates/sign_flip.feature.md` の見出しに残っていた普通名詞の `Task` を `課題` に変更しました。
- Gherkin キーワード、ステップ文、期待値、コマンド例は変更していません。

## 検証

- [x] `git diff --check`
- [x] `bundle exec rake check`

## 補足

- `Feature` / `Scenario` は Gherkin の構造語として原文を維持しています。
- `Quantum Katas` / `BasicGates` / `SignFlip` は名称として原文を維持しています。
