### PR TITLE
state_flip.feature.md の文体を整える

### DIFF
--- a/features/katas/basic_gates/state_flip.feature.md
+++ b/features/katas/basic_gates/state_flip.feature.md
@@ -1,5 +1,5 @@
-# Feature: Quantum Katas BasicGates Task 1.1 StateFlip
-  Task 1.1 StateFlip: |0⟩ を |1⟩ に、|1⟩ を |0⟩ に反転する
+# Feature: Quantum Katas BasicGates タスク 1.1 StateFlip
+  タスク 1.1 StateFlip: |0⟩ を |1⟩ に、|1⟩ を |0⟩ に反転する
 
   入力:
   1 量子ビットの状態 |ψ⟩ = α|0⟩ + β|1⟩


### PR DESCRIPTION
## 概要

- `features/katas/basic_gates/state_flip.feature.md` の先頭説明にある `Task` 表記を、日本語本文に合わせて `タスク` に変更しました。
- `Feature`、`Scenario`、`Given` / `When` / `Then`、ステップ文、回路図、状態式、期待値は変更していません。

## Linear

- YAS-392

## 検証

- [x] `git diff --check`
- [x] `bundle exec rake check`
