### PR TITLE
課題仕様書の英日混在表現を整える

### DIFF
--- a/features/katas/superposition/all_basis_vectors_with_phases_two_qubits.feature.md
+++ b/features/katas/superposition/all_basis_vectors_with_phases_two_qubits.feature.md
@@ -1,5 +1,5 @@
 # Feature: Quantum Katas Superposition Task 1.5 AllBasisVectorsWithPhases_TwoQubits
-  課題 1.5 AllBasisVectorsWithPhases_TwoQubits: |00⟩ を位相付きの一様重ね合わせに変える
+  Task 1.5 AllBasisVectorsWithPhases_TwoQubits: |00⟩ を位相付きの一様重ね合わせに変える
 
   入力:
   2 量子ビットの状態 |00⟩

--- a/features/katas/superposition/all_basis_vectors_with_phases_two_qubits.feature.md
+++ b/features/katas/superposition/all_basis_vectors_with_phases_two_qubits.feature.md
@@ -1,5 +1,5 @@
 # Feature: Quantum Katas Superposition Task 1.5 AllBasisVectorsWithPhases_TwoQubits
-  Task 1.5 AllBasisVectorsWithPhases_TwoQubits: |00⟩ を位相付きの一様重ね合わせに変える
+  課題 1.5 AllBasisVectorsWithPhases_TwoQubits: |00⟩ を位相付きの一様重ね合わせに変える
 
   入力:
   2 量子ビットの状態 |00⟩
@@ -7,9 +7,9 @@
   目標:
   状態を (|00⟩ + i|01⟩ - |10⟩ - i|11⟩) / 2 に変える
 
-  この task では、求める状態が
+  この課題では、求める状態が
   |−⟩ ⊗ |+i⟩ の積状態として分解できることを使い、
-  2 つの qubit に独立に位相を与えて目的の重ね合わせを作ることを確かめる。
+  2 つの量子ビットに独立に位相を与えて目的の重ね合わせを作ることを確かめる。
 
 ## Scenario: q0 に H と Z、q1 に H と S を適用すると位相付きの一様重ね合わせになる
 - Given 初期状態ベクトルは:


### PR DESCRIPTION
## 概要

- `features/katas/superposition/all_basis_vectors_with_phases_two_qubits.feature.md` の日本語本文に残っていた英語の普通名詞を自然な日本語へ置き換えました。
- `Task` 形式の課題名、`Feature` / `Scenario` / `Given` / `When` / `Then`、識別子、状態表記、期待値は変更していません。
- ディレクトリ全体の用語統一は範囲外として `YAS-524` に分けました。

## Linear

- YAS-394

## 検証

- `git diff --check`
- `bundle exec rake check`
