### PR TITLE
GHZ 状態仕様の文体を整える

### DIFF
--- a/features/katas/superposition/ghz_state.feature.md
+++ b/features/katas/superposition/ghz_state.feature.md
@@ -1,5 +1,5 @@
 # Feature: Quantum Katas Superposition Task 1.8 GHZ_State
-  Task 1.8 GHZ_State: N qubit の GHZ 状態を作る
+  Task 1.8 GHZ_State: N 量子ビットの GHZ 状態を作る
 
   入力:
   N 量子ビットの状態 |0...0⟩
@@ -7,8 +7,8 @@
   目標:
   状態を (|0...0⟩ + |1...1⟩) / sqrt(2) に変える
 
-  この task では、最初の qubit を H で重ね合わせにし、
-  その値を残りの qubit に順に CNOT で伝えると、
+  この課題では、最初の量子ビットを H で重ね合わせにし、
+  その値を残りの量子ビットに順に CNOT で伝えると、
   GHZ 状態が作れることを小さい N から確かめる。
 
 ## Scenario: N = 1 のとき GHZ 状態は計算基底の重ね合わせになる
@@ -80,7 +80,7 @@
   ```
 
 ## Scenario: N = 3 のとき GHZ 状態は |000> と |111> の重ね合わせになる
-- Given 空の 3 qubit 回路がある
+- Given 空の 3 量子ビット回路がある
 - When 次の回路を適用:
   ```
       ┌───┐          


### PR DESCRIPTION
Linear: YAS-398

## 概要
- `features/katas/superposition/ghz_state.feature.md` の `task` / `qubit` 混在表現を自然な日本語に直しました。

## 変更内容
- `N qubit` を `N 量子ビット` に変更しました。
- `この task` を `この課題` に変更しました。
- 既存ステップ定義に対応している `空の 3 量子ビット回路がある` 表記に変更しました。

## 検証
- `git diff --check`
- `npm run build && npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress features/katas/superposition/ghz_state.feature.md`
- `bundle exec rake check`

## 備考
- 仕様、期待値、コマンド例、Gherkin キーワードは変更していません。
