### PR TITLE
minus_state の文体を整える

### DIFF
--- a/features/katas/superposition/minus_state.feature.md
+++ b/features/katas/superposition/minus_state.feature.md
@@ -1,5 +1,5 @@
 # Feature: Quantum Katas Superposition Task 1.2 MinusState
-  Task 1.2 MinusState: |0⟩ を |-⟩ に変える
+  課題 1.2 MinusState: |0⟩ を |-⟩ に変える
 
   入力:
   1 量子ビットの状態 |0⟩
@@ -7,7 +7,7 @@
   目標:
   状態を |-⟩ = (|0⟩ - |1⟩) / sqrt(2) に変える
 
-  この task では、X ゲートで |1⟩ を作ってから
+  この課題では、X ゲートで |1⟩ を作ってから
   Hadamard ゲート H をかけることで |-⟩ が得られることを確かめる。
 
 ## Scenario: X のあとに H を適用すると |0> は計算基底で負の重ね合わせになる

--- a/features/katas/superposition/minus_state.feature.md
+++ b/features/katas/superposition/minus_state.feature.md
@@ -1,5 +1,5 @@
 # Feature: Quantum Katas Superposition Task 1.2 MinusState
-  課題 1.2 MinusState: |0⟩ を |-⟩ に変える
+  Task 1.2 MinusState: |0⟩ を |-⟩ に変える
 
   入力:
   1 量子ビットの状態 |0⟩


### PR DESCRIPTION
## 概要

- Linear: YAS-399
- `features/katas/superposition/minus_state.feature.md` の日本語本文に残っていた `この task では` を `この課題では` に置き換えました。
- `Task 1.2 MinusState`、`Feature`、`Scenario`、`Given`、`When`、`Then`、ゲート名、数式表記は識別子・Gherkin キーワード・技術表記として維持しています。

## 検証

- [x] `git diff --check`
- [x] `bundle exec rake check`
- [x] 最新 `origin/main` 取り込み後に `git diff --check && bundle exec rake check`
- [x] PR コメント対応後に `git diff --check && bundle exec rake check`
