### PR TITLE
workspace_noise.feature.md の文体を整える

### DIFF
--- a/features/repository/workspace_noise.feature.md
+++ b/features/repository/workspace_noise.feature.md
@@ -1,12 +1,12 @@
-# Feature: Workspace noise
+# Feature: ワークスペースのノイズ
 
-qni-cli の Symphony workspace 利用者として
+qni-cli の Symphony ワークスペース利用者として
 作業に関係ない生成ファイルで git status が埋まらないようにしたい
 
-## Scenario: `.codex/` は ignore される
+## Scenario: `.codex/` は無視される
 
 - Then リポジトリファイル ".gitignore" は ".codex/" を含む
 
-## Scenario: `excalidraw.log` は ignore される
+## Scenario: `excalidraw.log` は無視される
 
 - Then リポジトリファイル ".gitignore" は "excalidraw.log" を含む


### PR DESCRIPTION
## 概要

- `features/repository/workspace_noise.feature.md` の見出しと本文から、不自然な英日混在表現を取り除きました。
- `Feature` / `Scenario` / `Then`、`.gitignore`、`.codex/`、`excalidraw.log`、`git status` など、識別子・コマンド・ファイル名にあたる表記は維持しました。

## Linear

- YAS-511

## 検証

- `git diff --check`
- `bundle exec rake check`
