### PR TITLE
PNG 書き出しを TypeScript 経路へ移行する

### DIFF
--- a/features/cli/export/captions.feature.md
+++ b/features/cli/export/captions.feature.md
@@ -55,3 +55,15 @@ qni export のキャプションオプションを使いたい。
 - Given "qni add X --control 0 --qubit 1 --step 0" を実行
 - When "qni export --png --light --caption 'CNOT before cut' --output circuit.png" を実行
 - Then "circuit.png" は PNG 画像である
+
+## Scenario: qni export --png --caption は透過 PNG を書き出す
+
+- Given "qni add X --control 0 --qubit 1 --step 0" を実行
+- When "qni export --png --light --caption 'CNOT before cut' --output circuit.png" を実行
+- Then "circuit.png" は透過 PNG 画像である
+
+## Scenario: qni export --png --caption --no-transparent は不透過 PNG を書き出す
+
+- Given "qni add X --control 0 --qubit 1 --step 0" を実行
+- When "qni export --png --light --caption 'CNOT before cut' --no-transparent --output circuit.png" を実行
+- Then "circuit.png" は不透過 PNG 画像である

--- a/features/cli/export/png.feature.md
+++ b/features/cli/export/png.feature.md
@@ -40,6 +40,17 @@ qni export --png で通常の回路図を PNG 形式で書き出したい。
 - When "qni export --png --output circuit.png" を実行
 - Then "circuit.png" の画像サイズは 64x64 である
 
+## Scenario: qni export --png は列なし回路を最小幅で書き出す
+
+- Given 次の circuit.json がある:
+
+  ```json
+  { "qubits": 1, "cols": [] }
+  ```
+
+- When "qni export --png --output circuit.png" を実行
+- Then "circuit.png" の画像サイズは 192x64 である
+
 ## Scenario: qni export --png は 2x2 回路を 128x128 で書き出す
 
 - Given "qni add H --qubit 0 --step 0" を実行

--- a/features/cli/export/png.feature.md
+++ b/features/cli/export/png.feature.md
@@ -46,3 +46,21 @@ qni export --png で通常の回路図を PNG 形式で書き出したい。
 - Given "qni add H --qubit 1 --step 1" を実行
 - When "qni export --png --output circuit.png" を実行
 - Then "circuit.png" の画像サイズは 128x128 である
+
+## Scenario: qni export --png は pdflatex 未導入環境で失敗する
+
+- Given "qni add H --qubit 0 --step 0" を実行
+- Given 環境変数 "PATH" を "" に設定する
+- When "qni export --png --output circuit.png" を実行
+- Then コマンドは失敗
+
+## Scenario: qni export --png は pdflatex 未導入環境で互換エラーを表示する
+
+- Given "qni add H --qubit 0 --step 0" を実行
+- Given 環境変数 "PATH" を "" に設定する
+- When "qni export --png --output circuit.png" を実行
+- Then 標準エラー:
+
+  ```text
+  pdflatex is required for qni export --png
+  ```

--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -114,7 +114,7 @@ function runNodeQniCommand(scenarioDir, command, extraEnv = {}) {
   }
 
   return new Promise((resolve, reject) => {
-    const child = spawn('node', [NODE_QNI_BIN, ...argv.slice(1)], {
+    const child = spawn(process.execPath, [NODE_QNI_BIN, ...argv.slice(1)], {
       cwd: scenarioDir,
       env: scenarioEnv(extraEnv)
     });
@@ -147,7 +147,7 @@ function runQniCommandInTty(scenarioDir, command, extraEnv = {}) {
     throw new Error(`command must start with qni: ${command}`);
   }
 
-  const ttyCommand = ['node', NODE_QNI_BIN, ...argv.slice(1)]
+  const ttyCommand = [process.execPath, NODE_QNI_BIN, ...argv.slice(1)]
     .map(shellQuote)
     .join(' ');
 

--- a/src/commands/export_command.ts
+++ b/src/commands/export_command.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { CircuitFileError, currentCircuitFile } from '../circuit_file';
 import type { CommandHandlerContext } from '../dispatcher';
 import { QCircuitLatex, validateCaptionOptions, type ExportTheme } from '../export/qcircuit_latex';
+import { circuitPngHeight, circuitPngWidth, PngExporter } from '../export/png_exporter';
 import { runRubyFallbackSync } from '../process/process_compatibility';
 
 const HELP_TEXT = `Usage:
@@ -64,6 +65,7 @@ interface ExportOptions {
   readonly output?: string;
   readonly png: boolean;
   readonly stateVector: boolean;
+  readonly transparent: boolean;
 }
 
 const BOOLEAN_OPTIONS = new Map<string, (options: MutableExportOptions) => void>([
@@ -82,14 +84,18 @@ const BOOLEAN_OPTIONS = new Map<string, (options: MutableExportOptions) => void>
   ['--light', (options) => {
     options.light = true;
   }],
-  ['--no-transparent', () => undefined],
+  ['--no-transparent', (options) => {
+    options.transparent = false;
+  }],
   ['--png', (options) => {
     options.png = true;
   }],
   ['--state-vector', (options) => {
     options.stateVector = true;
   }],
-  ['--transparent', () => undefined]
+  ['--transparent', (options) => {
+    options.transparent = true;
+  }]
 ]);
 
 const VALUE_OPTIONS = new Map<string, (options: MutableExportOptions, value: string) => void>([
@@ -131,13 +137,14 @@ export function runExportCommand(argv: string[], context: CommandHandlerContext)
   }
 
   try {
-    if (!typeScriptLatexSource(options)) {
+    if (!typeScriptRegularCircuitExport(options)) {
       return rubyFallback(argv, context);
     }
 
     validateOptions(options);
 
-    const latexSource = new QCircuitLatex(currentCircuitFile(context.cwd).load(), {
+    const circuit = currentCircuitFile(context.cwd).load();
+    const latexSource = new QCircuitLatex(circuit, {
       caption: options.caption,
       captionFormat: options.captionFormat,
       captionPosition: options.captionPosition,
@@ -145,7 +152,12 @@ export function runExportCommand(argv: string[], context: CommandHandlerContext)
       theme: theme(options)
     }).render();
 
-    writeLatexSource(latexSource, options, context.cwd);
+    if (options.png) {
+      writePng(latexSource, options, context, circuit.cols.length, circuit.qubits);
+    } else {
+      writeLatexSource(latexSource, options, context.cwd);
+    }
+
     return 0;
   } catch (error) {
     if (error instanceof CircuitFileError || error instanceof Error) {
@@ -171,7 +183,8 @@ function parseExportOptions(args: string[]): ExportOptions | undefined {
     latexSource: false,
     light: false,
     png: false,
-    stateVector: false
+    stateVector: false,
+    transparent: true
   };
 
   for (let index = 0; index < args.length; index += 1) {
@@ -276,8 +289,12 @@ function theme(options: ExportOptions): ExportTheme {
   return options.light ? 'light' : 'dark';
 }
 
-function typeScriptLatexSource(options: ExportOptions): boolean {
-  return options.latexSource && !options.png && !options.stateVector && !options.circleNotation;
+function typeScriptRegularCircuitExport(options: ExportOptions): boolean {
+  return (options.latexSource || regularCircuitPng(options)) && !options.stateVector && !options.circleNotation;
+}
+
+function regularCircuitPng(options: ExportOptions): boolean {
+  return options.png && !options.latexSource;
 }
 
 function writeLatexSource(latexSource: string, options: ExportOptions, cwd: string): void {
@@ -290,4 +307,28 @@ function writeLatexSource(latexSource: string, options: ExportOptions, cwd: stri
 
   mkdirSync(path.dirname(outputPath), { recursive: true });
   writeFileSync(outputPath, `${latexSource}\n`);
+}
+
+function writePng(
+  latexSource: string,
+  options: ExportOptions,
+  context: CommandHandlerContext,
+  columns: number,
+  qubits: number
+): void {
+  const outputPath = path.resolve(context.cwd, options.output ?? '');
+  const exporterOptions = captionPresent(options)
+    ? {}
+    : {
+        targetHeight: circuitPngHeight(qubits),
+        targetWidth: circuitPngWidth(columns)
+      };
+
+  new PngExporter(latexSource, {
+    cwd: context.cwd,
+    env: context.env,
+    outputPath,
+    transparent: options.transparent,
+    ...exporterOptions
+  }).export();
 }

--- a/src/commands/export_command.ts
+++ b/src/commands/export_command.ts
@@ -3,7 +3,12 @@ import path from 'node:path';
 
 import { CircuitFileError, currentCircuitFile } from '../circuit_file';
 import type { CommandHandlerContext } from '../dispatcher';
-import { QCircuitLatex, validateCaptionOptions, type ExportTheme } from '../export/qcircuit_latex';
+import {
+  QCircuitLatex,
+  qcircuitRenderedColumnCount,
+  validateCaptionOptions,
+  type ExportTheme
+} from '../export/qcircuit_latex';
 import { circuitPngHeight, circuitPngWidth, PngExporter } from '../export/png_exporter';
 import { runRubyFallbackSync } from '../process/process_compatibility';
 
@@ -153,7 +158,7 @@ export function runExportCommand(argv: string[], context: CommandHandlerContext)
     }).render();
 
     if (options.png) {
-      writePng(latexSource, options, context, circuit.cols.length, circuit.qubits);
+      writePng(latexSource, options, context, qcircuitRenderedColumnCount(circuit), circuit.qubits);
     } else {
       writeLatexSource(latexSource, options, context.cwd);
     }

--- a/src/export/png_exporter.ts
+++ b/src/export/png_exporter.ts
@@ -138,8 +138,12 @@ function commandErrorMessage(command: string, result: SpawnSyncReturns<Buffer>, 
     return missingMessage;
   }
 
-  const detail = [result.stdout, result.stderr]
-    .map((output) => output.toString('utf8').trim())
+  const detail = [
+    result.error?.message,
+    result.stdout?.toString('utf8'),
+    result.stderr?.toString('utf8')
+  ]
+    .map((output) => output?.trim() ?? '')
     .filter((output) => output.length > 0)
     .join('\n');
 

--- a/src/export/png_exporter.ts
+++ b/src/export/png_exporter.ts
@@ -1,0 +1,155 @@
+import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+
+const CELL_SIZE_PX = 64;
+
+export interface PngExportOptions {
+  readonly cwd: string;
+  readonly env: NodeJS.ProcessEnv;
+  readonly outputPath: string;
+  readonly targetHeight?: number;
+  readonly targetWidth?: number;
+  readonly transparent: boolean;
+}
+
+interface ArtifactPaths {
+  readonly pdf: string;
+  readonly png: string;
+  readonly pngBase: string;
+  readonly tex: string;
+}
+
+export function circuitPngHeight(qubits: number): number {
+  return qubits * CELL_SIZE_PX;
+}
+
+export function circuitPngWidth(columns: number): number {
+  return columns * CELL_SIZE_PX;
+}
+
+export class PngExporter {
+  private readonly cwd: string;
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly latexSource: string;
+  private readonly outputPath: string;
+  private readonly targetHeight?: number;
+  private readonly targetWidth?: number;
+  private readonly transparent: boolean;
+
+  constructor(latexSource: string, options: PngExportOptions) {
+    this.cwd = options.cwd;
+    this.env = options.env;
+    this.latexSource = latexSource;
+    this.outputPath = options.outputPath;
+    this.targetHeight = options.targetHeight;
+    this.targetWidth = options.targetWidth;
+    this.transparent = options.transparent;
+  }
+
+  export(): void {
+    mkdirSync(path.dirname(this.outputPath), { recursive: true });
+
+    const dir = mkdtempSync(path.join(tmpdir(), 'qni-export'));
+
+    try {
+      this.exportFrom(dir);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  }
+
+  private exportFrom(dir: string): void {
+    const paths = artifactPaths(dir);
+
+    writeFileSync(paths.tex, this.latexSource);
+    this.compilePdf(dir, paths.tex);
+    this.convertPdfToPng(paths.pdf, paths.pngBase);
+    cpSync(paths.png, this.outputPath);
+  }
+
+  private compilePdf(dir: string, texPath: string): void {
+    this.runCommand(
+      'pdflatex',
+      ['-interaction=nonstopmode', '-halt-on-error', '-output-directory', dir, texPath],
+      'pdflatex is required for qni export --png'
+    );
+  }
+
+  private convertPdfToPng(pdfPath: string, pngBasePath: string): void {
+    this.runCommand(
+      'pdftocairo',
+      [...this.pdfToPngBaseArgs(), ...this.pdfToPngSizeArgs(), pdfPath, pngBasePath],
+      'pdftocairo is required for qni export --png'
+    );
+  }
+
+  private pdfToPngBaseArgs(): string[] {
+    const args = ['-singlefile', '-png', '-q'];
+
+    if (this.transparent) {
+      args.push('-transp');
+    }
+
+    return args;
+  }
+
+  private pdfToPngSizeArgs(): string[] {
+    if (this.targetWidth === undefined || this.targetHeight === undefined) {
+      return [];
+    }
+
+    return ['-scale-to-x', String(this.targetWidth), '-scale-to-y', String(this.targetHeight)];
+  }
+
+  private runCommand(command: string, args: string[], missingMessage: string): void {
+    const result = spawnSync(command, args, {
+      cwd: this.cwd,
+      env: {
+        ...process.env,
+        ...this.env
+      }
+    });
+
+    if (result.error && nodeErrorCode(result.error) === 'ENOENT') {
+      throw new Error(missingMessage);
+    }
+
+    if (result.status !== 0) {
+      throw new Error(commandErrorMessage(command, result, missingMessage));
+    }
+  }
+}
+
+function artifactPaths(dir: string): ArtifactPaths {
+  const basePath = path.join(dir, 'circuit');
+
+  return {
+    pdf: `${basePath}.pdf`,
+    png: `${basePath}.png`,
+    pngBase: basePath,
+    tex: `${basePath}.tex`
+  };
+}
+
+function commandErrorMessage(command: string, result: SpawnSyncReturns<Buffer>, missingMessage: string): string {
+  if (result.status === 127) {
+    return missingMessage;
+  }
+
+  const detail = [result.stdout, result.stderr]
+    .map((output) => output.toString('utf8').trim())
+    .filter((output) => output.length > 0)
+    .join('\n');
+
+  if (detail.length === 0) {
+    return `${command} failed`;
+  }
+
+  return `${command} failed: ${detail}`;
+}
+
+function nodeErrorCode(error: Error): string | undefined {
+  return 'code' in error && typeof error.code === 'string' ? error.code : undefined;
+}

--- a/src/export/qcircuit_latex.ts
+++ b/src/export/qcircuit_latex.ts
@@ -64,6 +64,10 @@ export interface QCircuitLatexOptions extends QCircuitCaptionOptions {
   readonly theme: ExportTheme;
 }
 
+export function qcircuitRenderedColumnCount(circuit: Pick<CircuitData, 'cols'>): number {
+  return circuit.cols.length > 0 ? circuit.cols.length : EMPTY_CIRCUIT_MIN_COLUMNS;
+}
+
 class QCircuitCaption {
   static readonly DEFAULT_POSITION = 'bottom';
   static readonly DEFAULT_SIZE_PT = 12;
@@ -181,7 +185,7 @@ export class QCircuitLatex {
       return this.circuit.cols;
     }
 
-    return Array.from({ length: EMPTY_CIRCUIT_MIN_COLUMNS }, () =>
+    return Array.from({ length: qcircuitRenderedColumnCount(this.circuit) }, () =>
       Array.from({ length: this.circuit.qubits }, () => EMPTY_SLOT)
     );
   }

--- a/test/typescript/export_command.test.ts
+++ b/test/typescript/export_command.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, it } from 'node:test';
@@ -10,6 +11,12 @@ interface CapturedRun {
   readonly exitStatus: number;
   readonly stderr: string;
   readonly stdout: string;
+}
+
+interface PngStableProperties {
+  readonly height: number;
+  readonly transparent: boolean;
+  readonly width: number;
 }
 
 async function withTempDir<T>(callback: (dir: string) => Promise<T>): Promise<T> {
@@ -86,6 +93,66 @@ async function writeCircuit(dir: string, circuit: unknown): Promise<void> {
 
 async function rubyOracle(dir: string, argv: string[]): Promise<CapturedRun> {
   return captureDispatcherRun(dir, argv, { ...process.env, QNI_USE_RUBY: '1' });
+}
+
+async function rubyOracleWithEnv(dir: string, argv: string[], env: NodeJS.ProcessEnv): Promise<CapturedRun> {
+  return captureDispatcherRun(dir, argv, { ...process.env, ...env, QNI_USE_RUBY: '1' });
+}
+
+async function pngStableProperties(filePath: string): Promise<PngStableProperties> {
+  const png = await readFile(filePath);
+  const signature = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+  assert.deepEqual(png.subarray(0, 8), signature);
+  assert.equal(png.toString('ascii', 12, 16), 'IHDR');
+
+  return {
+    height: png.readUInt32BE(20),
+    transparent: pngColorTypeHasAlpha(png) || pngChunks(png).some((chunk) => chunk.type === 'tRNS'),
+    width: png.readUInt32BE(16)
+  };
+}
+
+function pngColorTypeHasAlpha(png: Buffer): boolean {
+  return png[25] === 4 || png[25] === 6;
+}
+
+function pngChunks(png: Buffer): Array<{ readonly type: string }> {
+  const chunks: Array<{ readonly type: string }> = [];
+  let offset = 8;
+
+  while (offset + 8 <= png.length) {
+    const length = png.readUInt32BE(offset);
+    const type = png.toString('ascii', offset + 4, offset + 8);
+    const dataEnd = offset + 8 + length;
+
+    assert.ok(dataEnd + 4 <= png.length, `expected complete PNG chunk ${type}`);
+    chunks.push({ type });
+    offset = dataEnd + 4;
+
+    if (type === 'IEND') {
+      break;
+    }
+  }
+
+  return chunks;
+}
+
+async function pathWithOnly(parentDir: string, commands: string[]): Promise<string> {
+  const dir = path.join(parentDir, `path-${commands.join('-')}`);
+
+  await rm(dir, { force: true, recursive: true });
+  await mkdir(dir, { recursive: true });
+
+  for (const command of commands) {
+    await symlink(commandPath(command), path.join(dir, command));
+  }
+
+  return dir;
+}
+
+function commandPath(command: string): string {
+  return execFileSync('bash', ['-lc', `command -v ${command}`], { encoding: 'utf8' }).trim();
 }
 
 describe('export command TypeScript route', () => {
@@ -212,14 +279,165 @@ describe('export command TypeScript route', () => {
     });
   });
 
-  it('keeps regular PNG export on Ruby fallback', async () => {
+  it('renders regular transparent PNG like the Ruby oracle through TypeScript subprocesses', async () => {
     await withTempDir(async (dir) => {
       await writeCircuit(dir, {
         qubits: 1,
         cols: [['H']]
       });
 
-      const result = captureDispatcherRun(dir, ['export', '--png', '--output', 'circuit.png'], { PATH: '' });
+      const argv = ['export', '--png', '--light', '--output', 'typescript.png'];
+      const oracleArgv = ['export', '--png', '--light', '--output', 'ruby.png'];
+      const result = captureDispatcherRun(dir, argv);
+      const oracle = await rubyOracle(dir, oracleArgv);
+      const typeScriptPng = await pngStableProperties(path.join(dir, 'typescript.png'));
+      const rubyPng = await pngStableProperties(path.join(dir, 'ruby.png'));
+
+      assert.equal(result.exitStatus, oracle.exitStatus);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, '');
+      assert.equal(oracle.stdout, '');
+      assert.equal(oracle.stderr, '');
+      assert.deepEqual(typeScriptPng, rubyPng);
+      assert.deepEqual(typeScriptPng, { height: 64, transparent: true, width: 64 });
+    });
+  });
+
+  it('renders regular opaque PNG like the Ruby oracle', async () => {
+    await withTempDir(async (dir) => {
+      await writeCircuit(dir, {
+        qubits: 1,
+        cols: [['H']]
+      });
+
+      const argv = ['export', '--png', '--light', '--no-transparent', '--output', 'typescript.png'];
+      const oracleArgv = ['export', '--png', '--light', '--no-transparent', '--output', 'ruby.png'];
+      const result = captureDispatcherRun(dir, argv);
+      const oracle = await rubyOracle(dir, oracleArgv);
+      const typeScriptPng = await pngStableProperties(path.join(dir, 'typescript.png'));
+      const rubyPng = await pngStableProperties(path.join(dir, 'ruby.png'));
+
+      assert.equal(result.exitStatus, oracle.exitStatus);
+      assert.equal(result.stdout, oracle.stdout);
+      assert.equal(result.stderr, oracle.stderr);
+      assert.deepEqual(typeScriptPng, rubyPng);
+      assert.deepEqual(typeScriptPng, { height: 64, transparent: false, width: 64 });
+    });
+  });
+
+  it('renders caption PNG like the Ruby oracle', async () => {
+    await withTempDir(async (dir) => {
+      await writeCircuit(dir, {
+        qubits: 2,
+        cols: [['•', 'X']]
+      });
+
+      const argv = [
+        'export',
+        '--png',
+        '--light',
+        '--caption',
+        'CNOT before cut',
+        '--caption-position',
+        'top',
+        '--output',
+        'typescript.png'
+      ];
+      const oracleArgv = [...argv.slice(0, -1), 'ruby.png'];
+      const result = captureDispatcherRun(dir, argv);
+      const oracle = await rubyOracle(dir, oracleArgv);
+      const typeScriptPng = await pngStableProperties(path.join(dir, 'typescript.png'));
+      const rubyPng = await pngStableProperties(path.join(dir, 'ruby.png'));
+
+      assert.equal(result.exitStatus, oracle.exitStatus);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, '');
+      assert.equal(oracle.stdout, '');
+      assert.equal(oracle.stderr, '');
+      assert.deepEqual(typeScriptPng, rubyPng);
+      assert.equal(typeScriptPng.transparent, true);
+    });
+  });
+
+  it('renders caption opaque PNG like the Ruby oracle', async () => {
+    await withTempDir(async (dir) => {
+      await writeCircuit(dir, {
+        qubits: 2,
+        cols: [['•', 'X']]
+      });
+
+      const argv = [
+        'export',
+        '--png',
+        '--light',
+        '--caption',
+        'CNOT before cut',
+        '--no-transparent',
+        '--output',
+        'typescript.png'
+      ];
+      const oracleArgv = [...argv.slice(0, -1), 'ruby.png'];
+      const result = captureDispatcherRun(dir, argv);
+      const oracle = await rubyOracle(dir, oracleArgv);
+      const typeScriptPng = await pngStableProperties(path.join(dir, 'typescript.png'));
+      const rubyPng = await pngStableProperties(path.join(dir, 'ruby.png'));
+
+      assert.equal(result.exitStatus, oracle.exitStatus);
+      assert.equal(result.stdout, oracle.stdout);
+      assert.equal(result.stderr, oracle.stderr);
+      assert.deepEqual(typeScriptPng, rubyPng);
+      assert.equal(typeScriptPng.transparent, false);
+    });
+  });
+
+  it('reports missing pdflatex like the Ruby oracle without invoking Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      await writeCircuit(dir, {
+        qubits: 1,
+        cols: [['H']]
+      });
+
+      const missingPdfLatexPath = await pathWithOnly(dir, ['bundle']);
+      const argv = ['export', '--png', '--output', 'circuit.png'];
+      const result = captureDispatcherRun(dir, argv, { PATH: missingPdfLatexPath });
+      const oracle = await rubyOracleWithEnv(dir, argv, { PATH: missingPdfLatexPath });
+
+      assert.equal(result.exitStatus, oracle.exitStatus);
+      assert.equal(result.stdout, oracle.stdout);
+      assert.equal(result.stderr, oracle.stderr);
+      assert.equal(result.stderr, 'pdflatex is required for qni export --png\n');
+    });
+  });
+
+  it('reports missing pdftocairo like the Ruby oracle', async () => {
+    await withTempDir(async (dir) => {
+      await writeCircuit(dir, {
+        qubits: 1,
+        cols: [['H']]
+      });
+
+      const missingPdfToCairoPath = await pathWithOnly(dir, ['bundle', 'pdflatex']);
+      const argv = ['export', '--png', '--output', 'circuit.png'];
+      const result = captureDispatcherRun(dir, argv, { PATH: missingPdfToCairoPath });
+      const oracle = await rubyOracleWithEnv(dir, argv, { PATH: missingPdfToCairoPath });
+
+      assert.equal(result.exitStatus, oracle.exitStatus);
+      assert.equal(result.stdout, oracle.stdout);
+      assert.equal(result.stderr, oracle.stderr);
+      assert.equal(result.stderr, 'pdftocairo is required for qni export --png\n');
+    });
+  });
+
+  it('keeps state-vector PNG export on Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      await writeCircuit(dir, {
+        qubits: 1,
+        cols: [['H']]
+      });
+
+      const result = captureDispatcherRun(dir, ['export', '--state-vector', '--png', '--output', 'state.png'], {
+        PATH: ''
+      });
 
       assert.equal(result.exitStatus, 127);
       assert.equal(result.stdout, '');

--- a/test/typescript/export_command.test.ts
+++ b/test/typescript/export_command.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, it } from 'node:test';
@@ -152,7 +152,7 @@ async function pathWithOnly(parentDir: string, commands: string[]): Promise<stri
 }
 
 function commandPath(command: string): string {
-  return execFileSync('bash', ['-lc', `command -v ${command}`], { encoding: 'utf8' }).trim();
+  return execFileSync('bash', ['-lc', 'command -v -- "$1"', 'bash', command], { encoding: 'utf8' }).trim();
 }
 
 describe('export command TypeScript route', () => {
@@ -423,6 +423,28 @@ describe('export command TypeScript route', () => {
       assert.equal(result.stdout, oracle.stdout);
       assert.equal(result.stderr, oracle.stderr);
       assert.equal(result.stderr, 'pdflatex is required for qni export --png\n');
+    });
+  });
+
+  it('reports pdflatex spawn errors with the underlying cause', async () => {
+    await withTempDir(async (dir) => {
+      await writeCircuit(dir, {
+        qubits: 1,
+        cols: [['H']]
+      });
+
+      const pathDir = path.join(dir, 'path-denied-pdflatex');
+      const pdfLatexPath = path.join(pathDir, 'pdflatex');
+
+      await mkdir(pathDir, { recursive: true });
+      await writeFile(pdfLatexPath, '#!/bin/sh\n');
+      await chmod(pdfLatexPath, 0o644);
+
+      const result = captureDispatcherRun(dir, ['export', '--png', '--output', 'circuit.png'], { PATH: pathDir });
+
+      assert.equal(result.exitStatus, 1);
+      assert.equal(result.stdout, '');
+      assert.match(result.stderr, /^pdflatex failed: .*EACCES\n$/u);
     });
   });
 

--- a/test/typescript/export_command.test.ts
+++ b/test/typescript/export_command.test.ts
@@ -445,6 +445,23 @@ describe('export command TypeScript route', () => {
     });
   });
 
+  it('keeps circle-notation PNG export on Ruby fallback', async () => {
+    await withTempDir(async (dir) => {
+      await writeCircuit(dir, {
+        qubits: 1,
+        cols: [['H']]
+      });
+
+      const result = captureDispatcherRun(dir, ['export', '--circle-notation', '--png', '--output', 'circles.png'], {
+        PATH: ''
+      });
+
+      assert.equal(result.exitStatus, 127);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, 'spawnSync bundle ENOENT\n');
+    });
+  });
+
   it('leaves value-like option ambiguity on Ruby fallback', async () => {
     await withTempDir(async (dir) => {
       await writeCircuit(dir, {
@@ -468,6 +485,24 @@ describe('export command TypeScript route', () => {
       });
 
       const result = captureDispatcherRun(dir, ['export', '--latex-source'], { PATH: '', QNI_USE_RUBY: '1' });
+
+      assert.equal(result.exitStatus, 127);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, 'spawnSync bundle ENOENT\n');
+    });
+  });
+
+  it('honors QNI_USE_RUBY for regular PNG export', async () => {
+    await withTempDir(async (dir) => {
+      await writeCircuit(dir, {
+        qubits: 1,
+        cols: [['H']]
+      });
+
+      const result = captureDispatcherRun(dir, ['export', '--png', '--output', 'circuit.png'], {
+        PATH: '',
+        QNI_USE_RUBY: '1'
+      });
 
       assert.equal(result.exitStatus, 127);
       assert.equal(result.stdout, '');

--- a/test/typescript/export_command.test.ts
+++ b/test/typescript/export_command.test.ts
@@ -325,6 +325,23 @@ describe('export command TypeScript route', () => {
     });
   });
 
+  it('sizes an empty regular PNG from the rendered qcircuit columns', async () => {
+    await withTempDir(async (dir) => {
+      await writeCircuit(dir, {
+        qubits: 1,
+        cols: []
+      });
+
+      const result = captureDispatcherRun(dir, ['export', '--png', '--light', '--output', 'empty.png']);
+      const typeScriptPng = await pngStableProperties(path.join(dir, 'empty.png'));
+
+      assert.equal(result.exitStatus, 0);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, '');
+      assert.deepEqual(typeScriptPng, { height: 64, transparent: true, width: 192 });
+    });
+  });
+
   it('renders caption PNG like the Ruby oracle', async () => {
     await withTempDir(async (dir) => {
       await writeCircuit(dir, {


### PR DESCRIPTION
## 概要

- regular circuit PNG と caption PNG を TypeScript route で処理し、LaTeX source 生成から `pdflatex` / `pdftocairo` subprocess 実行までを TypeScript 側の境界に移しました。
- Ruby oracle と TypeScript route の stdout / stderr / exit status / PNG stable properties を比較するテストを追加しました。
- `--state-vector --png` と `--circle-notation --png`、および `QNI_USE_RUBY=1` の Ruby fallback は維持しています。

## 検証

- [x] `npm run test:ts`
- [x] `npm run build && npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress features/cli/export/png.feature.md features/cli/export/captions.feature.md`
- [x] `bundle exec rake check`

## Linear

- YAS-257: https://linear.app/yasuhito/issue/YAS-257/export-png-workflows-を-typescript-subprocess-境界へ移行する


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * `qni export --png` で回路を PNG 形式で出力できるようになりました。
  * `--caption` や `--no-transparent` / `--transparent` に応じて、透過・不透過の PNG を切り替えられるようになりました。

* **バグ修正**
  * PNG 出力時に必要な外部ツールがない場合、分かりやすいエラーメッセージを表示するようになりました。
  * 実行環境によらず、コマンドの起動方法がより安定するよう改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->