### PR TITLE
StateFlip を qni benchmark run で合格判定できるようにする

### DIFF
--- a/benchmarks/quantum-katas/basic-gates/state-flip.md
+++ b/benchmarks/quantum-katas/basic-gates/state-flip.md
@@ -1,0 +1,21 @@
+---
+id: basic-gates/state-flip
+title: StateFlip
+source: Microsoft Quantum Katas / BasicGates
+difficulty: smoke
+allowed_commands:
+  - qni add
+checks:
+  tolerance: 1e-9
+  items:
+    - type: run
+      expected:
+        - basis: "|1>"
+          amplitude:
+            real: 1
+            imaginary: 0
+---
+
+1量子ビットを `|0>` から `|1>` に反転する量子回路を、`qni` コマンド列として作成してください。
+
+提出物は `.qni` 形式で、1行に1つずつ完全な `qni` コマンドを書いてください。

--- a/benchmarks/solutions/quantum-katas/basic-gates/state-flip.qni
+++ b/benchmarks/solutions/quantum-katas/basic-gates/state-flip.qni
@@ -1,0 +1,1 @@
+qni add X --qubit 0 --step 0

--- a/features/cli/benchmark_run.feature.md
+++ b/features/cli/benchmark_run.feature.md
@@ -1,0 +1,25 @@
+# Feature: qni benchmark run
+
+qni-cli の利用者として
+課題ファイルと `.qni` 提出物を同じ条件で評価するために
+qni benchmark run で最小の合格判定を実行したい。
+
+## Scenario: StateFlip 標準解は合格する
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/solutions/quantum-katas/basic-gates/state-flip.qni" を実行
+- Then コマンドは成功
+
+## Scenario: StateFlip 標準解の合格が表示される
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/solutions/quantum-katas/basic-gates/state-flip.qni" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  PASS StateFlip
+  ```
+
+## Scenario: StateFlip 評価は作業ディレクトリに circuit.json を残さない
+
+- Given "circuit.json" は存在しない
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/solutions/quantum-katas/basic-gates/state-flip.qni" を実行
+- Then "circuit.json" は存在しない

--- a/src/commands/benchmark_command.ts
+++ b/src/commands/benchmark_command.ts
@@ -1,0 +1,472 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path = require('node:path');
+
+import type { CommandHandler, CommandHandlerContext } from '../dispatcher';
+import { runAddCommand } from './add_command';
+import { runRunCommand } from './run_command';
+
+interface BenchmarkTask {
+  readonly checks: BenchmarkChecks;
+  readonly id: string;
+  readonly title: string;
+}
+
+interface BenchmarkChecks {
+  readonly items: readonly RunCheck[];
+  readonly tolerance: number;
+}
+
+interface RunCheck {
+  readonly expected: readonly ExpectedAmplitude[];
+  readonly type: 'run';
+}
+
+interface ExpectedAmplitude {
+  readonly amplitude: ComplexAmplitude;
+  readonly basis: string;
+}
+
+interface ComplexAmplitude {
+  readonly imaginary: number;
+  readonly real: number;
+}
+
+interface QniCommandResult {
+  readonly exitStatus: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}
+
+interface BenchmarkResult {
+  readonly checkCount: number;
+  readonly status: 'passed' | 'failed';
+}
+
+class BenchmarkError extends Error {}
+
+const QNI_COMMAND_HANDLERS = new Map<string, CommandHandler>([
+  ['add', runAddCommand],
+  ['run', runRunCommand]
+]);
+const USAGE = 'Usage: qni benchmark run <task-file> <submission-file>\n';
+const ZERO_AMPLITUDE: ComplexAmplitude = { imaginary: 0, real: 0 };
+
+export function runBenchmarkCommand(argv: string[], context: CommandHandlerContext): number {
+  const request = parseBenchmarkRequest(argv);
+
+  if (!request) {
+    process.stderr.write(USAGE);
+    return 3;
+  }
+
+  try {
+    const taskPath = resolveInputPath(request.taskFile, context);
+    const submissionPath = resolveInputPath(request.submissionFile, context);
+    const task = loadBenchmarkTask(taskPath);
+    const result = evaluateBenchmark({
+      context,
+      submissionPath,
+      task
+    });
+
+    writeHumanResult(task, result);
+    return result.status === 'passed' ? 0 : 1;
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    return 3;
+  }
+}
+
+function parseBenchmarkRequest(argv: readonly string[]): { submissionFile: string; taskFile: string } | undefined {
+  if (argv.length !== 4 || argv[0] !== 'benchmark' || argv[1] !== 'run') {
+    return undefined;
+  }
+
+  return {
+    submissionFile: argv[3] ?? '',
+    taskFile: argv[2] ?? ''
+  };
+}
+
+function evaluateBenchmark(options: {
+  readonly context: CommandHandlerContext;
+  readonly submissionPath: string;
+  readonly task: BenchmarkTask;
+}): BenchmarkResult {
+  const workDir = mkdtempSync(path.join(tmpdir(), 'qni-benchmark-'));
+
+  try {
+    runSubmission(options.submissionPath, workDir, options.context);
+    const checksPassed = options.task.checks.items.every((check) => runCheckPassed(check, options.task, workDir, options.context));
+
+    return {
+      checkCount: options.task.checks.items.length,
+      status: checksPassed ? 'passed' : 'failed'
+    };
+  } finally {
+    rmSync(workDir, { force: true, recursive: true });
+  }
+}
+
+function runSubmission(submissionPath: string, workDir: string, context: CommandHandlerContext): void {
+  for (const command of qniCommandsInSubmission(submissionPath)) {
+    const result = runQni(command.argv, workDir, context);
+
+    if (result.exitStatus !== 0) {
+      throw new BenchmarkError([
+        `submission command failed at line ${command.lineNumber}: ${command.source}`,
+        result.stderr.trimEnd()
+      ].filter(Boolean).join('\n'));
+    }
+  }
+}
+
+function qniCommandsInSubmission(submissionPath: string): { argv: string[]; lineNumber: number; source: string }[] {
+  return readFileSync(submissionPath, 'utf8')
+    .split(/\r?\n/u)
+    .map((line, index) => ({ lineNumber: index + 1, source: line.trim() }))
+    .filter((line) => line.source.length > 0)
+    .map((line) => {
+      const argv = splitCommandLine(line.source);
+
+      if (argv[0] !== 'qni') {
+        throw new BenchmarkError(`submission command must start with qni at line ${line.lineNumber}: ${line.source}`);
+      }
+
+      return {
+        argv: argv.slice(1),
+        lineNumber: line.lineNumber,
+        source: line.source
+      };
+    });
+}
+
+function runCheckPassed(
+  check: RunCheck,
+  task: BenchmarkTask,
+  workDir: string,
+  context: CommandHandlerContext
+): boolean {
+  const result = runQni(['run'], workDir, context);
+
+  if (result.exitStatus !== 0) {
+    throw new BenchmarkError(`run check failed to execute for ${task.id}: ${result.stderr.trimEnd()}`);
+  }
+
+  return stateVectorMatches(parseStateVector(result.stdout), check.expected, task.checks.tolerance);
+}
+
+function stateVectorMatches(
+  actual: readonly ComplexAmplitude[],
+  expectedAmplitudes: readonly ExpectedAmplitude[],
+  tolerance: number
+): boolean {
+  const expected = Array.from({ length: actual.length }, () => ZERO_AMPLITUDE);
+
+  for (const item of expectedAmplitudes) {
+    expected[basisIndex(item.basis, actual.length)] = item.amplitude;
+  }
+
+  return actual.every((amplitude, index) => amplitudesClose(amplitude, expected[index] ?? ZERO_AMPLITUDE, tolerance));
+}
+
+function amplitudesClose(actual: ComplexAmplitude, expected: ComplexAmplitude, tolerance: number): boolean {
+  return Math.abs(actual.real - expected.real) <= tolerance &&
+    Math.abs(actual.imaginary - expected.imaginary) <= tolerance;
+}
+
+function parseStateVector(stdout: string): ComplexAmplitude[] {
+  const text = stdout.trim();
+
+  if (text.length === 0) {
+    throw new BenchmarkError('qni run produced empty state vector output');
+  }
+
+  return text.split(',').map(parseComplexAmplitude);
+}
+
+function parseComplexAmplitude(text: string): ComplexAmplitude {
+  if (!text.endsWith('i')) {
+    return { imaginary: 0, real: parseNumber(text) };
+  }
+
+  const body = text.slice(0, -1);
+  const splitIndex = lastSignIndex(body);
+
+  if (splitIndex === -1) {
+    return { imaginary: parseNumber(body), real: 0 };
+  }
+
+  return {
+    imaginary: parseNumber(body.slice(splitIndex)),
+    real: parseNumber(body.slice(0, splitIndex))
+  };
+}
+
+function lastSignIndex(value: string): number {
+  for (let index = value.length - 1; index > 0; index -= 1) {
+    if (value[index] === '+' || value[index] === '-') {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+function basisIndex(basis: string, vectorLength: number): number {
+  const match = /^\|(?<bits>[01]+)>$/u.exec(basis);
+
+  if (!match?.groups) {
+    throw new BenchmarkError(`unsupported basis label: ${basis}`);
+  }
+
+  const index = Number.parseInt(match.groups.bits, 2);
+
+  if (index >= vectorLength) {
+    throw new BenchmarkError(`basis label is outside the state vector: ${basis}`);
+  }
+
+  return index;
+}
+
+function runQni(argv: readonly string[], cwd: string, context: CommandHandlerContext): QniCommandResult {
+  const command = argv[0] ?? '';
+  const handler = QNI_COMMAND_HANDLERS.get(command);
+
+  if (!handler) {
+    throw new BenchmarkError(`unsupported qni command in benchmark runner: qni ${argv.join(' ')}`);
+  }
+
+  return captureCommandRun(() => handler([...argv], { ...context, cwd }));
+}
+
+function captureCommandRun(callback: () => number): QniCommandResult {
+  let stdout = '';
+  let stderr = '';
+  const originalStdoutWrite = process.stdout.write;
+  const originalStderrWrite = process.stderr.write;
+
+  process.stdout.write = ((
+    chunk: string | Uint8Array,
+    encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+    callback?: (error?: Error | null) => void
+  ): boolean => {
+    stdout += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk.toString();
+    if (typeof encodingOrCallback === 'function') {
+      encodingOrCallback();
+    }
+    if (callback) {
+      callback();
+    }
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = ((
+    chunk: string | Uint8Array,
+    encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+    callback?: BufferEncoding | ((error?: Error | null) => void)
+  ): boolean => {
+    stderr += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk.toString();
+    if (typeof encodingOrCallback === 'function') {
+      encodingOrCallback();
+    }
+    if (typeof callback === 'function') {
+      callback();
+    }
+    return true;
+  }) as typeof process.stderr.write;
+
+  try {
+    return {
+      exitStatus: callback(),
+      stderr,
+      stdout
+    };
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+}
+
+function loadBenchmarkTask(taskPath: string): BenchmarkTask {
+  const frontmatter = frontmatterOf(readFileSync(taskPath, 'utf8'));
+
+  return {
+    checks: parseChecks(frontmatter),
+    id: scalarValue(frontmatter, 'id'),
+    title: scalarValue(frontmatter, 'title')
+  };
+}
+
+function frontmatterOf(markdown: string): string {
+  const match = /^---\r?\n(?<frontmatter>[\s\S]*?)\r?\n---(?:\r?\n|$)/u.exec(markdown);
+
+  if (!match?.groups) {
+    throw new BenchmarkError('benchmark task file must start with YAML frontmatter');
+  }
+
+  return match.groups.frontmatter;
+}
+
+function parseChecks(frontmatter: string): BenchmarkChecks {
+  return {
+    items: parseRunChecks(frontmatter),
+    tolerance: checksTolerance(frontmatter)
+  };
+}
+
+function checksTolerance(frontmatter: string): number {
+  const match = /^\s+tolerance:\s*(?<value>\S+)\s*$/mu.exec(frontmatter);
+
+  if (!match?.groups) {
+    throw new BenchmarkError('checks.tolerance is required');
+  }
+
+  return parseNumber(match.groups.value);
+}
+
+function parseRunChecks(frontmatter: string): RunCheck[] {
+  if (!/^\s+-\s+type:\s*run\s*$/mu.test(frontmatter)) {
+    throw new BenchmarkError('at least one run check is required');
+  }
+
+  return [{ expected: parseExpectedAmplitudes(frontmatter), type: 'run' }];
+}
+
+function parseExpectedAmplitudes(frontmatter: string): ExpectedAmplitude[] {
+  const matches = [...frontmatter.matchAll(
+    /^\s+-\s+basis:\s*(?<basis>.+?)\s*\r?\n\s+amplitude:\s*\r?\n\s+real:\s*(?<real>\S+)\s*\r?\n\s+imaginary:\s*(?<imaginary>\S+)\s*$/gmu
+  )];
+
+  if (matches.length === 0) {
+    throw new BenchmarkError('run check expected amplitudes are required');
+  }
+
+  return matches.map((match) => {
+    const groups = match.groups ?? {};
+
+    return {
+      amplitude: {
+        imaginary: parseNumber(groups.imaginary ?? ''),
+        real: parseNumber(groups.real ?? '')
+      },
+      basis: unquote(groups.basis ?? '')
+    };
+  });
+}
+
+function scalarValue(frontmatter: string, key: string): string {
+  const match = new RegExp(`^${key}:\\s*(?<value>.+?)\\s*$`, 'mu').exec(frontmatter);
+
+  if (!match?.groups) {
+    throw new BenchmarkError(`${key} is required`);
+  }
+
+  return unquote(match.groups.value);
+}
+
+function parseNumber(value: string): number {
+  const result = Number(value);
+
+  if (Number.isNaN(result)) {
+    throw new BenchmarkError(`invalid number: ${value}`);
+  }
+
+  return result;
+}
+
+function unquote(value: string): string {
+  const trimmed = value.trim();
+
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1);
+  }
+
+  return trimmed;
+}
+
+function resolveInputPath(filePath: string, context: CommandHandlerContext): string {
+  if (path.isAbsolute(filePath)) {
+    return filePath;
+  }
+
+  const cwdPath = path.resolve(context.cwd, filePath);
+
+  if (existsSync(cwdPath)) {
+    return cwdPath;
+  }
+
+  return path.resolve(context.projectRoot, filePath);
+}
+
+function splitCommandLine(command: string): string[] {
+  const words: string[] = [];
+  let current = '';
+  let quote: string | undefined;
+  let escaping = false;
+  let tokenStarted = false;
+
+  for (const char of command) {
+    if (escaping) {
+      current += char;
+      escaping = false;
+      tokenStarted = true;
+      continue;
+    }
+
+    if (char === '\\' && quote !== "'") {
+      escaping = true;
+      continue;
+    }
+
+    if (quote) {
+      if (char === quote) {
+        quote = undefined;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      tokenStarted = true;
+      continue;
+    }
+
+    if (/\s/u.test(char)) {
+      if (tokenStarted) {
+        words.push(current);
+        current = '';
+        tokenStarted = false;
+      }
+      continue;
+    }
+
+    current += char;
+    tokenStarted = true;
+  }
+
+  if (escaping) {
+    current += '\\';
+    tokenStarted = true;
+  }
+
+  if (quote) {
+    throw new BenchmarkError(`unterminated quote in command: ${command}`);
+  }
+
+  if (tokenStarted) {
+    words.push(current);
+  }
+
+  return words;
+}
+
+function writeHumanResult(task: BenchmarkTask, result: BenchmarkResult): void {
+  const label = result.status === 'passed' ? 'PASS' : 'FAIL';
+
+  process.stdout.write(`${label} ${task.title}\n`);
+  process.stdout.write(`checks: ${result.checkCount}\n`);
+}

--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -3,6 +3,7 @@ import {
   runRubyFallbackSync
 } from './process/process_compatibility';
 import { runAddCommand } from './commands/add_command';
+import { runBenchmarkCommand } from './commands/benchmark_command';
 import { runExportCommand } from './commands/export_command';
 import { runGateCommand } from './commands/gate_command';
 import { runExpectCommand } from './commands/expect_command';
@@ -34,6 +35,7 @@ interface CommandRoute {
 
 const TYPESCRIPT_ROUTES = new Map<string, CommandHandler>([
   ['add', runAddCommand],
+  ['benchmark', runBenchmarkCommand],
   ['export', runExportCommand],
   ['expect', runExpectCommand],
   ['gate', runGateCommand],


### PR DESCRIPTION
## 概要

- StateFlip のベンチマーク課題ファイルと標準解 `.qni` を追加
- `qni benchmark run <task-file> <submission-file>` の最小縦断を TypeScript に追加
- frontmatter 読み取り、提出コマンド実行、一時ディレクトリ実行、`qni run` による状態ベクトル検証、人間向け合格出力を実装

Closes #251

## 検証

- `bundle exec rake check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `benchmark run` コマンドで、課題ファイルと提出ファイルを指定してベンチマークを実行できるようになりました。
  * 新しい量子ベンチマーク「StateFlip」が追加され、`|0>` を `|1>` に反転する提出例も利用できます。
* **Bug Fixes**
  * ベンチマーク実行後に一時ファイルが作業ディレクトリへ残らないようになりました。
  * 実行結果に応じて `PASS/FAIL` と終了ステータスが返るようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->