### PR TITLE
benchmark run の出力解析の端を補強する

### DIFF
--- a/src/commands/benchmark_command.ts
+++ b/src/commands/benchmark_command.ts
@@ -206,12 +206,16 @@ function parseComplexAmplitude(text: string): ComplexAmplitude {
 
 function lastSignIndex(value: string): number {
   for (let index = value.length - 1; index > 0; index -= 1) {
-    if (value[index] === '+' || value[index] === '-') {
+    if ((value[index] === '+' || value[index] === '-') && !exponentSign(value, index)) {
       return index;
     }
   }
 
   return -1;
+}
+
+function exponentSign(value: string, index: number): boolean {
+  return value[index - 1] === 'e' || value[index - 1] === 'E';
 }
 
 function basisIndex(basis: string, vectorLength: number): number {
@@ -252,7 +256,7 @@ function captureCommandRun(callback: () => number): QniCommandResult {
     encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
     callback?: (error?: Error | null) => void
   ): boolean => {
-    stdout += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk.toString();
+    stdout += streamChunkText(chunk);
     if (typeof encodingOrCallback === 'function') {
       encodingOrCallback();
     }
@@ -267,7 +271,7 @@ function captureCommandRun(callback: () => number): QniCommandResult {
     encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
     callback?: BufferEncoding | ((error?: Error | null) => void)
   ): boolean => {
-    stderr += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk.toString();
+    stderr += streamChunkText(chunk);
     if (typeof encodingOrCallback === 'function') {
       encodingOrCallback();
     }
@@ -287,6 +291,10 @@ function captureCommandRun(callback: () => number): QniCommandResult {
     process.stdout.write = originalStdoutWrite;
     process.stderr.write = originalStderrWrite;
   }
+}
+
+export function streamChunkText(chunk: string | Uint8Array): string {
+  return typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
 }
 
 function loadBenchmarkTask(taskPath: string): BenchmarkTask {

--- a/test/typescript/benchmark_command.test.ts
+++ b/test/typescript/benchmark_command.test.ts
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import { streamChunkText } from '../../src/commands/benchmark_command';
+import { createDispatcher } from '../../src/dispatcher';
+
+interface CapturedRun {
+  readonly exitStatus: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}
+
+async function withTempDir<T>(callback: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'qni-cli-benchmark-'));
+
+  try {
+    return await callback(dir);
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+}
+
+function captureDispatcherRun(cwd: string, argv: string[]): CapturedRun {
+  let stdout = '';
+  let stderr = '';
+  const originalStdoutWrite = process.stdout.write;
+  const originalStderrWrite = process.stderr.write;
+
+  process.stdout.write = ((
+    chunk: string | Uint8Array,
+    encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+    callback?: (error?: Error | null) => void
+  ): boolean => {
+    stdout += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    if (typeof encodingOrCallback === 'function') {
+      encodingOrCallback();
+    }
+    if (callback) {
+      callback();
+    }
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = ((
+    chunk: string | Uint8Array,
+    encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+    callback?: BufferEncoding | ((error?: Error | null) => void)
+  ): boolean => {
+    stderr += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    if (typeof encodingOrCallback === 'function') {
+      encodingOrCallback();
+    }
+    if (typeof callback === 'function') {
+      callback();
+    }
+    return true;
+  }) as typeof process.stderr.write;
+
+  try {
+    const dispatcher = createDispatcher({
+      cwd,
+      env: { PATH: '' },
+      projectRoot: process.cwd()
+    });
+
+    return {
+      exitStatus: dispatcher.run(argv),
+      stderr,
+      stdout
+    };
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+}
+
+describe('benchmark command TypeScript route', () => {
+  it('decodes Uint8Array stream chunks as UTF-8 text', () => {
+    assert.equal(streamChunkText(new Uint8Array([97, 98])), 'ab');
+  });
+
+  it('parses scientific notation in imaginary amplitudes during run checks', async () => {
+    await withTempDir(async (dir) => {
+      await writeFile(path.join(dir, 'task.md'), [
+        '---',
+        'id: numeric/small-rx',
+        'title: SmallRx',
+        'source: test',
+        'difficulty: smoke',
+        'allowed_commands:',
+        '  - qni add',
+        'checks:',
+        '  tolerance: 1e-18',
+        '  items:',
+        '    - type: run',
+        '      expected:',
+        '        - basis: "|0>"',
+        '          amplitude:',
+        '            real: 1',
+        '            imaginary: 0',
+        '        - basis: "|1>"',
+        '          amplitude:',
+        '            real: 0',
+        '            imaginary: -1.5707963267948965e-15',
+        '---',
+        '',
+        'Apply a tiny Rx rotation.'
+      ].join('\n'));
+      await writeFile(
+        path.join(dir, 'submission.qni'),
+        'qni add Rx --angle pi/1000000000000000 --qubit 0 --step 0\n'
+      );
+
+      const result = captureDispatcherRun(dir, ['benchmark', 'run', 'task.md', 'submission.qni']);
+
+      assert.equal(result.exitStatus, 0, result.stderr);
+      assert.equal(result.stdout, 'PASS SmallRx\nchecks: 1\n');
+      assert.equal(result.stderr, '');
+    });
+  });
+});


### PR DESCRIPTION
## 概要

- #259 の Copilot コメントを確認し、`Uint8Array` の出力チャンクを UTF-8 として取り込むよう修正
- #259 の CodeRabbit コメントを確認し、虚数成分の指数表記 `e-...` を実部/虚部の区切りと誤認しないよう修正
- 回帰テストを追加

## 補足

Copilot の `catch` で終了コード `3` を返す指摘については、`qni benchmark run` の PRD で `実行エラー = 3` が定義されているため変更していません。

## 検証

- `bundle exec rake check`
