### PR TITLE
TypeScript コマンドのエラー分類を整理する

### DIFF
--- a/features/cli/typescript_command_error_taxonomy.feature.md
+++ b/features/cli/typescript_command_error_taxonomy.feature.md
@@ -1,20 +1,20 @@
-# Feature: TypeScript command error taxonomy
+# Feature: TypeScript コマンドのエラー分類
 
 qni-cli のメンテナとして
-TypeScript command route の CLI validation error と circuit file domain error を分けるために
+TypeScript コマンド経路の CLI 検証エラーと回路ファイルのドメインエラーを分けるために
 ユーザー向けエラー互換性を保ったまま責務境界を明確にしたい
 
-## Scenario: CLI validation error class が存在する
+## Scenario: CLI 検証エラー用のクラスが存在する
 
 - Then リポジトリファイル "src/commands/command_error.ts" は "export class CommandError extends Error" を含む
 
-## Scenario: gate command validation error は失敗する
+## Scenario: gate コマンドの検証エラーは失敗する
 
 - Given 空の 1 qubit 回路がある
 - When "qni gate --qubit 1.0 --step 0" を実行
 - Then コマンドは失敗
 
-## Scenario: gate command validation error は stderr 互換性を保つ
+## Scenario: gate コマンドの検証エラーは標準エラー互換性を保つ
 
 - Given 空の 1 qubit 回路がある
 - When "qni gate --qubit 1.0 --step 0" を実行
@@ -24,12 +24,12 @@ TypeScript command route の CLI validation error と circuit file domain error 
   qubit must be an integer
   ```
 
-## Scenario: state command validation error は失敗する
+## Scenario: state コマンドの検証エラーは失敗する
 
 - When "qni state set \"\"" を実行
 - Then コマンドは失敗
 
-## Scenario: state command validation error は stderr 互換性を保つ
+## Scenario: state コマンドの検証エラーは標準エラー互換性を保つ
 
 - When "qni state set \"\"" を実行
 - Then 標準エラー:
@@ -38,12 +38,66 @@ TypeScript command route の CLI validation error と circuit file domain error 
   initial state expression is required
   ```
 
-## Scenario: variable command validation error は失敗する
+## Scenario: variable コマンドの検証エラーは失敗する
 
 - When "qni variable set theta" を実行
 - Then コマンドは失敗
 
-## Scenario: variable command validation error は stderr 互換性を保つ
+## Scenario: variable コマンドの検証エラーは標準エラー互換性を保つ
+
+- When "qni variable set theta" を実行
+- Then 標準エラー:
+
+  ```text
+  wrong number of arguments
+  ```
+
+## Scenario: gate コマンドの検証エラーは回路ファイルのドメインエラーより先に表示される
+
+- Given 次の circuit.json がある:
+
+  ```json
+  {
+    "qubits": 1,
+    "cols": "bad"
+  }
+  ```
+
+- When "qni gate --qubit 1.0 --step 0" を実行
+- Then 標準エラー:
+
+  ```text
+  qubit must be an integer
+  ```
+
+## Scenario: state コマンドの検証エラーは回路ファイルのドメインエラーより先に表示される
+
+- Given 次の circuit.json がある:
+
+  ```json
+  {
+    "qubits": 1,
+    "cols": "bad"
+  }
+  ```
+
+- When "qni state set \"\"" を実行
+- Then 標準エラー:
+
+  ```text
+  initial state expression is required
+  ```
+
+## Scenario: variable コマンドの検証エラーは回路ファイルのドメインエラーより先に表示される
+
+- Given 次の circuit.json がある:
+
+  ```json
+  {
+    "qubits": 1,
+    "cols": "bad"
+  }
+  ```
 
 - When "qni variable set theta" を実行
 - Then 標準エラー:

--- a/src/commands/command_error.ts
+++ b/src/commands/command_error.ts
@@ -1,6 +1,19 @@
+/**
+ * TypeScript コマンド経路が責務を持つ CLI 引数とサブコマンドの検証エラー。
+ * ./circuit.json のドメインエラーは引き続き CircuitFileError が責務を持つ。
+ */
 export class CommandError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'CommandError';
   }
+}
+
+export function reportCommandRouteError(error: unknown): number {
+  process.stderr.write(`${errorMessage(error)}\n`);
+  return 1;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/src/commands/gate_command.ts
+++ b/src/commands/gate_command.ts
@@ -1,6 +1,6 @@
 import { currentCircuitFile } from '../circuit_file';
 import type { CommandHandlerContext } from '../dispatcher';
-import { CommandError } from './command_error';
+import { CommandError, reportCommandRouteError } from './command_error';
 
 const HELP_TEXT = `Usage:
   qni gate --qubit=N --step=N
@@ -33,8 +33,7 @@ export function runGateCommand(argv: string[], context: CommandHandlerContext): 
     process.stdout.write(`${currentCircuitFile(context.cwd).slotText(options.step, options.qubit)}\n`);
     return 0;
   } catch (error) {
-    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-    return 1;
+    return reportCommandRouteError(error);
   }
 }
 

--- a/src/commands/state_command.ts
+++ b/src/commands/state_command.ts
@@ -1,6 +1,6 @@
 import { currentCircuitFile } from '../circuit_file';
 import type { CommandHandlerContext } from '../dispatcher';
-import { CommandError } from './command_error';
+import { CommandError, reportCommandRouteError } from './command_error';
 
 const HELP_TEXT = `Usage:
   qni state set "alpha|0> + beta|1>"
@@ -44,8 +44,7 @@ export function runStateCommand(argv: string[], context: CommandHandlerContext):
 
     return 0;
   } catch (error) {
-    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-    return 1;
+    return reportCommandRouteError(error);
   }
 }
 

--- a/src/commands/variable_command.ts
+++ b/src/commands/variable_command.ts
@@ -1,6 +1,6 @@
 import { currentCircuitFile } from '../circuit_file';
 import type { CommandHandlerContext } from '../dispatcher';
-import { CommandError } from './command_error';
+import { CommandError, reportCommandRouteError } from './command_error';
 
 const HELP_TEXT = `Usage:
   qni variable set NAME ANGLE
@@ -47,8 +47,7 @@ export function runVariableCommand(argv: string[], context: CommandHandlerContex
 
     return 0;
   } catch (error) {
-    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-    return 1;
+    return reportCommandRouteError(error);
   }
 }
 


### PR DESCRIPTION
## 概要
- CLI 検証エラー用の `CommandError` の責務を明記
- `gate` / `state` / `variable` のエラー出力処理を共通化
- 回路ファイルのドメインエラーより CLI 検証エラーが先に表示される回帰シナリオを追加

## 検証
- `bundle exec rake check`

Closes #86