### PR TITLE
ESM 互換性確認手順を補強する

### DIFF
--- a/docs/superpowers/specs/2026-05-06-esm-migration-decision.md
+++ b/docs/superpowers/specs/2026-05-06-esm-migration-decision.md
@@ -11,7 +11,7 @@ qni-cli の TypeScript 移行は `package.json` の `type: commonjs` を維持�
 現時点の判断は CommonJS 維持とする。理由は次のとおり。
 
 - npm CLI としての消費形態がまだ十分に固定されていない。
-- Ruby fallback を含む移行期間中であり、subprocess の境界をできるだけ安定させる必要がある。
+- Ruby fallback を含む移行期間中であり、子プロセス境界をできるだけ安定させる必要がある。
 - ESM に切り替える直接の必要性がまだない。
 - `require` 互換性を壊すリスクより、現状の CommonJS 継続で得られる運用上の安定性が大きい。
 
@@ -22,10 +22,10 @@ ESM 実装課題は現時点では作成しない。下記の移行開始条件�
 ESM 移行を開始できるのは、次の条件がそろったときに限る。
 
 - qni-cli が主に npm CLI として消費され、CommonJS ライブラリとしての `require` 利用を維持する必要がないと判断できる。
-- 対象 Node.js LTS が明示され、その範囲で ESM の npm bin 実行と subprocess 境界に不安定要素がない。
-- `qni` npm bin contract を direct `node` execution と installed package execution の両方で検証できる。
-- Ruby fallback が残る場合でも、ESM の entrypoint から Ruby fallback へ cwd、argv、env、stdio、終了ステータスをそのまま渡せる。
-- Cucumber と TypeScript unit tests の両方で、CommonJS 維持時と同じ CLI 振る舞いを検証できる。
+- 対象 Node.js LTS が明示され、その範囲で ESM の npm bin 実行と子プロセス境界に不安定要素がない。
+- `qni` npm bin の契約を直接 `node` 実行とインストール済みパッケージでの実行の両方で検証できる。
+- Ruby fallback が残る場合でも、ESM のエントリーポイントから Ruby fallback へ cwd、argv、env、stdio、終了ステータスをそのまま渡せる。
+- Cucumber と TypeScript の単体テストの両方で、CommonJS 維持時と同じ CLI 振る舞いを検証できる。
 - ESM-only 依存関係の採用、Node.js エコシステムとの整合、または配布形態の単純化など、移行コストを上回る具体的な利点がある。
 
 ## CommonJS 継続の利点とリスク
@@ -55,31 +55,69 @@ ESM 移行を開始できるのは、次の条件がそろったときに限る�
 
 - `require` 互換性が壊れる可能性がある。
 - `__dirname`、`__filename`、JSON 読み込み、拡張子付き import など、CommonJS 前提の実装差分が出る。
-- npm bin の shebang、実行権限、Windows shim、subprocess 委譲の不具合が、モジュール形式変更と同時に表面化する可能性がある。
-- Ruby fallback が残っている間は、ESM entrypoint と Ruby subprocess 境界の両方を検証する必要がある。
+- npm bin の shebang、実行権限、Windows shim、子プロセス委譲の不具合が、モジュール形式変更と同時に表面化する可能性がある。
+- Ruby fallback が残っている間は、ESM エントリーポイントと Ruby 子プロセス境界の両方を検証する必要がある。
 
 ## 互換性方針
 
-npm bin contract は `qni` コマンド名、shebang、引数、終了ステータス、標準出力、標準エラー、作業ディレクトリ、環境変数の引き継ぎを対象にする。
+npm bin の契約は `qni` コマンド名、shebang、引数、終了ステータス、標準出力、標準エラー、作業ディレクトリ、環境変数の引き継ぎを対象にする。
 
 ESM へ移行する場合も、利用者から見える契約は次のように維持する。
 
 - `qni` という bin 名を変えない。
-- `qni ...`、`node dist/bin/qni.js ...`、installed package の `node_modules/.bin/qni ...` で同じ入力に同じ結果を返す。
+- `qni ...`、`node dist/bin/qni.js ...`、インストール済みパッケージの `node_modules/.bin/qni ...` で同じ入力に同じ結果を返す。
 - Ruby fallback が残るコマンドでは、CommonJS 維持時と同じ cwd、argv、env、stdio、終了ステータスを Ruby 側へ渡す。
-- `QNI_USE_RUBY=1` は、ESM entrypoint でも Ruby fallback 強制として働く。
-- ESM 移行の pull request では `package.json` の `type` 変更、生成された `dist`、Cucumber 実行経路、TypeScript unit tests を同じ差分で確認する。
+- `QNI_USE_RUBY=1` は、ESM エントリーポイントでも Ruby fallback 強制として働く。
+- ESM 移行のプルリクエストでは `package.json` の `type` 変更、生成された `dist`、Cucumber 実行経路、TypeScript の単体テストを同じ差分で確認する。
+
+## 互換性確認手順
+
+ESM へ移行するプルリクエストでは、`package.json` の `type` を変更する前に CommonJS の現状で次の確認を実行し、ESM 切り替え後にも同じ確認を実行する。終了ステータス、標準出力、標準エラー、生成される `circuit.json` に差分が出た場合は、npm bin の契約の破壊として扱う。
+
+```bash
+repo="$(pwd)"
+workdir="$(mktemp -d)"
+npm run build
+
+(
+  cd "$workdir"
+  node "$repo/dist/bin/qni.js" add H --qubit 0 --step 0
+  node "$repo/dist/bin/qni.js" view
+  QNI_USE_RUBY=1 node "$repo/dist/bin/qni.js" view
+)
+```
+
+インストール済みパッケージでの実行は、同じ生成物を `npm pack` で tarball にし、一時プロジェクトへインストールして確認する。
+
+```bash
+repo="$(pwd)"
+workdir="$(mktemp -d)"
+npm run build
+npm pack --pack-destination "$workdir"
+
+mkdir "$workdir/consumer"
+(
+  cd "$workdir/consumer"
+  npm init -y >/dev/null
+  npm install "$workdir"/qni-cli-*.tgz
+  ./node_modules/.bin/qni add H --qubit 0 --step 0
+  ./node_modules/.bin/qni view
+  QNI_USE_RUBY=1 ./node_modules/.bin/qni view
+)
+```
+
+この手順は代表的なスモークテストであり、ESM 移行課題では Cucumber と TypeScript の単体テストに同等の確認を追加する。
 
 ## 試験方針
 
 ESM 移行課題を作る場合は、実装前に次の試験を受け入れ条件へ入れる。
 
-- direct `node` execution は `node dist/bin/qni.js ...` を使い、npm shim を通さない実行形を確認する。
-- installed package execution は `npm pack` で作った tarball を一時プロジェクトに入れ、`node_modules/.bin/qni ...` から確認する。
-- npm bin contract は、少なくとも help、TypeScript-backed command、Ruby fallback command、`QNI_USE_RUBY=1` の経路で確認する。
-- Cucumber の既存機能は、通常の repository-local 実行に加えて installed package 実行で代表シナリオを通す。
-- TypeScript unit tests は、direct `node` execution と installed package execution の argv 正規化、env 引き継ぎ、終了ステータス、stdio 転送を確認する。
-- 変更後の fresh full check として `bundle exec rake check` を通す。
+- 直接 `node` 実行は `node dist/bin/qni.js ...` を使い、npm shim を通さない実行形を確認する。
+- インストール済みパッケージでの実行は `npm pack` で作った tarball を一時プロジェクトに入れ、`node_modules/.bin/qni ...` から確認する。
+- npm bin の契約は、少なくともヘルプ表示、TypeScript 実装コマンド、Ruby fallback コマンド、`QNI_USE_RUBY=1` の経路で確認する。
+- Cucumber の既存機能は、通常のリポジトリ内実行に加えてインストール済みパッケージでの実行で代表シナリオを通す。
+- TypeScript の単体テストは、直接 `node` 実行とインストール済みパッケージでの実行の argv 正規化、env 引き継ぎ、終了ステータス、stdio 転送を確認する。
+- 変更後の最新の全体チェックとして `bundle exec rake check` を通す。
 
 ## ESM 実装課題を作る条件
 
@@ -89,4 +127,4 @@ ESM 移行課題を作る場合は、実装前に次の試験を受け入れ条�
 - qni-cli の自然な機能拡張に ESM-only 依存関係が必要になる。
 - npm CLI としての配布確認が安定し、CommonJS ライブラリ互換を維持しない判断ができる。
 
-課題を作るときは、互換性方針と試験方針を受け入れ条件へ写し、`package.json` を変更する前に direct `node` execution と installed package execution の失敗が再現できる試験を追加する。
+課題を作るときは、互換性方針と試験方針を受け入れ条件へ写し、`package.json` を変更する前に直接 `node` 実行とインストール済みパッケージでの実行の失敗が再現できる試験を追加する。

--- a/features/docs/esm_migration_decision.feature.md
+++ b/features/docs/esm_migration_decision.feature.md
@@ -16,14 +16,18 @@ CommonJS 維持と ESM 移行の判断基準をリポジトリ内の仕様で確
 
 - Then リポジトリファイル "docs/superpowers/specs/2026-05-06-esm-migration-decision.md" は "ESM 移行を開始できるのは、次の条件がそろったときに限る。" を含む
 
-## Scenario: 仕様書は npm bin contract の試験方針を示す
+## Scenario: 仕様書は npm bin の契約の試験方針を示す
 
-- Then リポジトリファイル "docs/superpowers/specs/2026-05-06-esm-migration-decision.md" は "npm bin contract は `qni` コマンド名、shebang、引数、終了ステータス、標準出力、標準エラー、作業ディレクトリ、環境変数の引き継ぎを対象にする。" を含む
+- Then リポジトリファイル "docs/superpowers/specs/2026-05-06-esm-migration-decision.md" は "npm bin の契約は `qni` コマンド名、shebang、引数、終了ステータス、標準出力、標準エラー、作業ディレクトリ、環境変数の引き継ぎを対象にする。" を含む
 
-## Scenario: 仕様書は direct node execution の確認方法を示す
+## Scenario: 仕様書は互換性確認手順を示す
 
-- Then リポジトリファイル "docs/superpowers/specs/2026-05-06-esm-migration-decision.md" は "direct `node` execution は `node dist/bin/qni.js ...` を使い、npm shim を通さない実行形を確認する。" を含む
+- Then リポジトリファイル "docs/superpowers/specs/2026-05-06-esm-migration-decision.md" は "## 互換性確認手順" を含む
 
-## Scenario: 仕様書は installed package execution の確認方法を示す
+## Scenario: 仕様書は直接 node 実行の確認方法を示す
 
-- Then リポジトリファイル "docs/superpowers/specs/2026-05-06-esm-migration-decision.md" は "installed package execution は `npm pack` で作った tarball を一時プロジェクトに入れ、`node_modules/.bin/qni ...` から確認する。" を含む
+- Then リポジトリファイル "docs/superpowers/specs/2026-05-06-esm-migration-decision.md" は "直接 `node` 実行は `node dist/bin/qni.js ...` を使い、npm shim を通さない実行形を確認する。" を含む
+
+## Scenario: 仕様書はインストール済みパッケージでの実行確認方法を示す
+
+- Then リポジトリファイル "docs/superpowers/specs/2026-05-06-esm-migration-decision.md" は "インストール済みパッケージでの実行は `npm pack` で作った tarball を一時プロジェクトに入れ、`node_modules/.bin/qni ...` から確認する。" を含む


### PR DESCRIPTION
## 概要
- ESM 移行判断仕様に互換性確認手順を追加
- 直接 `node` 実行とインストール済みパッケージでの実行確認を具体化
- Cucumber 仕様の文言を更新

## 検証
- `npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress "features/docs/esm_migration_decision.feature.md"`
- `npm run test:ts`
- `bundle exec rake check`

Closes #82