### PR TITLE
実行エラーを error と終了コード 3 に分類する

### DIFF
--- a/benchmarks/error/quantum-katas/basic-gates/state-flip-qni-error.qni
+++ b/benchmarks/error/quantum-katas/basic-gates/state-flip-qni-error.qni
@@ -1,0 +1,1 @@
+qni add X --qubit nope --step 0

--- a/benchmarks/error/quantum-katas/basic-gates/state-flip-syntax-error.qni
+++ b/benchmarks/error/quantum-katas/basic-gates/state-flip-syntax-error.qni
@@ -1,0 +1,1 @@
+qni add X --qubit "0 --step 0

--- a/benchmarks/invalid/quantum-katas/basic-gates/state-flip-malformed-frontmatter.md
+++ b/benchmarks/invalid/quantum-katas/basic-gates/state-flip-malformed-frontmatter.md
@@ -1,0 +1,19 @@
+---
+id: basic-gates/state-flip-malformed-frontmatter
+title: "StateFlipMalformedFrontmatter
+source: test fixture
+difficulty: smoke
+allowed_commands:
+  - qni add
+checks:
+  tolerance: 1e-9
+  items:
+    - type: run
+      expected:
+        - basis: "|1>"
+          amplitude:
+            real: 1
+            imaginary: 0
+---
+
+YAML として壊れている不正な課題ファイルです。

--- a/benchmarks/invalid/quantum-katas/basic-gates/state-flip-missing-allowed-commands.md
+++ b/benchmarks/invalid/quantum-katas/basic-gates/state-flip-missing-allowed-commands.md
@@ -1,0 +1,17 @@
+---
+id: basic-gates/state-flip-missing-allowed-commands
+title: StateFlipMissingAllowedCommands
+source: test fixture
+difficulty: smoke
+checks:
+  tolerance: 1e-9
+  items:
+    - type: run
+      expected:
+        - basis: "|1>"
+          amplitude:
+            real: 1
+            imaginary: 0
+---
+
+`allowed_commands` が欠けている不正な課題ファイルです。

--- a/features/cli/benchmark_run.feature.md
+++ b/features/cli/benchmark_run.feature.md
@@ -145,6 +145,11 @@ qni benchmark run で最小の合格判定を実行したい。
   error: allowed_commands is required
   ```
 
+## Scenario: YAML として壊れた課題ファイルは終了コード 3 になる
+
+- When "qni benchmark run benchmarks/invalid/quantum-katas/basic-gates/state-flip-malformed-frontmatter.md benchmarks/solutions/quantum-katas/basic-gates/state-flip.qni" を実行
+- Then 終了コードは 3
+
 ## Scenario: 提出物の構文不備は終了コード 3 になる
 
 - When "qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/error/quantum-katas/basic-gates/state-flip-syntax-error.qni" を実行

--- a/features/cli/benchmark_run.feature.md
+++ b/features/cli/benchmark_run.feature.md
@@ -24,6 +24,24 @@ qni benchmark run で最小の合格判定を実行したい。
 - When "qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/solutions/quantum-katas/basic-gates/state-flip.qni" を実行
 - Then "circuit.json" は存在しない
 
+## Scenario: StateFlip 標準解の JSON は passed を含む
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/solutions/quantum-katas/basic-gates/state-flip.qni --json" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  "status": "passed"
+  ```
+
+## Scenario: StateFlip 標準解の JSON は終了コード 0 を含む
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/solutions/quantum-katas/basic-gates/state-flip.qni --json" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  "exitCode": 0
+  ```
+
 ## Scenario: PlusState 標準解は合格する
 
 - When "qni benchmark run benchmarks/quantum-katas/superposition/plus-state.md benchmarks/solutions/quantum-katas/superposition/plus-state.qni" を実行
@@ -57,6 +75,24 @@ qni benchmark run で最小の合格判定を実行したい。
   rejected: line 1: qni run
   ```
 
+## Scenario: StateFlip の不許可コマンドの JSON は disallowed を含む
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/disallowed/quantum-katas/basic-gates/state-flip-disallowed.qni --json" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  "status": "disallowed"
+  ```
+
+## Scenario: StateFlip の不許可コマンドの JSON は終了コード 2 を含む
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/disallowed/quantum-katas/basic-gates/state-flip-disallowed.qni --json" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  "exitCode": 2
+  ```
+
 ## Scenario: StateFlip 不正解サンプルは終了コード 1 で不合格になる
 
 - When "qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/incorrect/quantum-katas/basic-gates/state-flip-wrong.qni" を実行
@@ -74,4 +110,75 @@ qni benchmark run で最小の合格判定を実行したい。
   - run #1: state vector did not match expected amplitudes
     expected / actual mismatches:
     - |0>: expected 0, actual 0.7071067811865475
+  ```
+
+## Scenario: StateFlip 不正解サンプルの JSON は failed を含む
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/incorrect/quantum-katas/basic-gates/state-flip-wrong.qni --json" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  "status": "failed"
+  ```
+
+## Scenario: StateFlip 不正解サンプルの JSON は終了コード 1 を含む
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/incorrect/quantum-katas/basic-gates/state-flip-wrong.qni --json" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  "exitCode": 1
+  ```
+
+## Scenario: frontmatter 不備の課題ファイルは終了コード 3 になる
+
+- When "qni benchmark run benchmarks/invalid/quantum-katas/basic-gates/state-flip-missing-allowed-commands.md benchmarks/solutions/quantum-katas/basic-gates/state-flip.qni" を実行
+- Then 終了コードは 3
+
+## Scenario: frontmatter 不備の課題ファイルは error と表示される
+
+- When "qni benchmark run benchmarks/invalid/quantum-katas/basic-gates/state-flip-missing-allowed-commands.md benchmarks/solutions/quantum-katas/basic-gates/state-flip.qni" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  ERROR benchmark run
+  error: allowed_commands is required
+  ```
+
+## Scenario: 提出物の構文不備は終了コード 3 になる
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/error/quantum-katas/basic-gates/state-flip-syntax-error.qni" を実行
+- Then 終了コードは 3
+
+## Scenario: qni 実行失敗は終了コード 3 になる
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/error/quantum-katas/basic-gates/state-flip-qni-error.qni" を実行
+- Then 終了コードは 3
+
+## Scenario: qni 実行失敗は error と表示される
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/error/quantum-katas/basic-gates/state-flip-qni-error.qni" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  ERROR StateFlip
+  error: submission command failed at line 1: qni add X --qubit nope --step 0
+  ```
+
+## Scenario: qni 実行失敗の JSON は error を含む
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/error/quantum-katas/basic-gates/state-flip-qni-error.qni --json" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  "status": "error"
+  ```
+
+## Scenario: qni 実行失敗の JSON は終了コード 3 を含む
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/error/quantum-katas/basic-gates/state-flip-qni-error.qni --json" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  "exitCode": 3
   ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,9 @@
   "packages": {
     "": {
       "name": "qni-cli",
+      "dependencies": {
+        "yaml": "^2.9.0"
+      },
       "bin": {
         "qni": "dist/bin/qni.js"
       },
@@ -1383,10 +1386,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
     "@cucumber/cucumber": "^12.2.0",
     "@types/node": "^25.6.0",
     "typescript": "^6.0.3"
+  },
+  "dependencies": {
+    "yaml": "^2.9.0"
   }
 }

--- a/src/commands/benchmark_command.ts
+++ b/src/commands/benchmark_command.ts
@@ -64,10 +64,21 @@ interface DisallowedSubmission {
   readonly command: SubmissionCommand;
 }
 
+type BenchmarkOutputFormat = 'human' | 'json';
+
+type BenchmarkStatus = 'passed' | 'failed' | 'disallowed' | 'error';
+
+interface BenchmarkRequest {
+  readonly format: BenchmarkOutputFormat;
+  readonly submissionFile: string;
+  readonly taskFile: string;
+}
+
 interface BenchmarkResult {
   readonly checks: readonly BenchmarkCheckResult[];
   readonly disallowedSubmission?: DisallowedSubmission;
-  readonly status: 'passed' | 'failed' | 'disallowed';
+  readonly errorMessage?: string;
+  readonly status: BenchmarkStatus;
 }
 
 interface BenchmarkCheckResult {
@@ -93,7 +104,7 @@ const QNI_COMMAND_HANDLERS = new Map<string, CommandHandler>([
   ['add', runAddCommand],
   ['run', runRunCommand]
 ]);
-const USAGE = 'Usage: qni benchmark run <task-file> <submission-file>\n';
+const USAGE = 'Usage: qni benchmark run <task-file> <submission-file> [--json]\n';
 const MAX_FAILED_AMPLITUDE_DETAILS = 16;
 const ZERO_AMPLITUDE: ComplexAmplitude = { imaginary: 0, real: 0 };
 
@@ -105,33 +116,69 @@ export function runBenchmarkCommand(argv: string[], context: CommandHandlerConte
     return 3;
   }
 
+  let task: BenchmarkTask | undefined;
+
   try {
     const taskPath = resolveInputPath(request.taskFile, context);
     const submissionPath = resolveInputPath(request.submissionFile, context);
-    const task = loadBenchmarkTask(taskPath);
+    task = loadBenchmarkTask(taskPath);
     const result = evaluateBenchmark({
       context,
       submissionPath,
       task
     });
 
-    writeHumanResult(task, result);
+    writeBenchmarkResult({
+      format: request.format,
+      result,
+      submission: request.submissionFile,
+      task
+    });
     return exitCodeForResult(result);
   } catch (error) {
-    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-    return 3;
+    const result: BenchmarkResult = {
+      checks: [],
+      errorMessage: errorMessage(error),
+      status: 'error'
+    };
+
+    writeBenchmarkResult({
+      format: request.format,
+      result,
+      submission: request.submissionFile,
+      task
+    });
+    return exitCodeForResult(result);
   }
 }
 
-function parseBenchmarkRequest(argv: readonly string[]): { submissionFile: string; taskFile: string } | undefined {
-  if (argv.length !== 4 || argv[0] !== 'benchmark' || argv[1] !== 'run') {
+function parseBenchmarkRequest(argv: readonly string[]): BenchmarkRequest | undefined {
+  if (argv[0] !== 'benchmark' || argv[1] !== 'run') {
+    return undefined;
+  }
+
+  const args = argv.slice(2);
+  const jsonFlagCount = args.filter((arg) => arg === '--json').length;
+
+  if (jsonFlagCount > 1 || args.some((arg) => arg.startsWith('--') && arg !== '--json')) {
+    return undefined;
+  }
+
+  const positional = args.filter((arg) => arg !== '--json');
+
+  if (positional.length !== 2) {
     return undefined;
   }
 
   return {
-    submissionFile: argv[3] ?? '',
-    taskFile: argv[2] ?? ''
+    format: jsonFlagCount === 1 ? 'json' : 'human',
+    submissionFile: positional[1] ?? '',
+    taskFile: positional[0] ?? ''
   };
+}
+
+function errorMessage(error: unknown): string {
+  return (error instanceof Error ? error.message : String(error)).trimEnd();
 }
 
 function exitCodeForResult(result: BenchmarkResult): number {
@@ -142,6 +189,8 @@ function exitCodeForResult(result: BenchmarkResult): number {
       return 1;
     case 'disallowed':
       return 2;
+    case 'error':
+      return 3;
   }
 }
 
@@ -636,7 +685,30 @@ function splitCommandLine(command: string): string[] {
   return words;
 }
 
-function writeHumanResult(task: BenchmarkTask, result: BenchmarkResult): void {
+function writeBenchmarkResult(options: {
+  readonly format: BenchmarkOutputFormat;
+  readonly result: BenchmarkResult;
+  readonly submission: string;
+  readonly task?: BenchmarkTask;
+}): void {
+  if (options.format === 'json') {
+    writeJsonResult(options.task, options.submission, options.result);
+    return;
+  }
+
+  writeHumanResult(options.task, options.result);
+}
+
+function writeHumanResult(task: BenchmarkTask | undefined, result: BenchmarkResult): void {
+  if (result.status === 'error') {
+    writeErrorResult(task, result);
+    return;
+  }
+
+  if (!task) {
+    throw new BenchmarkError('benchmark task is unavailable');
+  }
+
   if (result.status === 'disallowed') {
     writeDisallowedResult(task, result);
     return;
@@ -647,6 +719,33 @@ function writeHumanResult(task: BenchmarkTask, result: BenchmarkResult): void {
   process.stdout.write(`${label} ${task.title}\n`);
   process.stdout.write(`checks: ${result.checks.length}\n`);
   writeFailedCheckDetails(result);
+}
+
+function writeJsonResult(task: BenchmarkTask | undefined, submission: string, result: BenchmarkResult): void {
+  const payload: Record<string, unknown> = {
+    taskId: task?.id ?? null,
+    title: task?.title ?? null,
+    submission,
+    status: result.status,
+    exitCode: exitCodeForResult(result),
+    checks: result.checks.map((check) => ({
+      type: check.type,
+      status: check.status
+    }))
+  };
+
+  if (result.errorMessage) {
+    payload.error = result.errorMessage;
+  }
+
+  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function writeErrorResult(task: BenchmarkTask | undefined, result: BenchmarkResult): void {
+  process.stdout.write(`ERROR ${task?.title ?? 'benchmark run'}\n`);
+  if (result.errorMessage) {
+    process.stdout.write(`error: ${result.errorMessage}\n`);
+  }
 }
 
 function writeFailedCheckDetails(result: BenchmarkResult): void {

--- a/src/commands/benchmark_command.ts
+++ b/src/commands/benchmark_command.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path = require('node:path');
+import { parseDocument } from 'yaml';
 
 import type { CommandHandler, CommandHandlerContext } from '../dispatcher';
 import { runAddCommand } from './add_command';
@@ -466,6 +467,7 @@ export function streamChunkText(chunk: string | Uint8Array): string {
 
 function loadBenchmarkTask(taskPath: string): BenchmarkTask {
   const frontmatter = frontmatterOf(readFileSync(taskPath, 'utf8'));
+  validateYamlFrontmatter(frontmatter);
 
   return {
     allowedCommands: parseAllowedCommands(frontmatter),
@@ -483,6 +485,19 @@ function frontmatterOf(markdown: string): string {
   }
 
   return match.groups.frontmatter;
+}
+
+function validateYamlFrontmatter(frontmatter: string): void {
+  const document = parseDocument(frontmatter);
+  const firstError = document.errors[0];
+
+  if (firstError) {
+    throw new BenchmarkError(`invalid YAML frontmatter: ${firstYamlErrorLine(firstError)}`);
+  }
+}
+
+function firstYamlErrorLine(error: Error): string {
+  return error.message.split(/\r?\n/u)[0] ?? error.message;
 }
 
 function parseAllowedCommands(frontmatter: string): AllowedCommand[] {

--- a/test/typescript/benchmark_command.test.ts
+++ b/test/typescript/benchmark_command.test.ts
@@ -82,6 +82,168 @@ describe('benchmark command TypeScript route', () => {
     assert.equal(streamChunkText(new Uint8Array([97, 98])), 'ab');
   });
 
+  it('classifies invalid task frontmatter as an error result', async () => {
+    await withTempDir(async (dir) => {
+      await writeFile(path.join(dir, 'task.md'), [
+        '---',
+        'id: basic-gates/state-flip',
+        'title: StateFlip',
+        'source: test',
+        'difficulty: smoke',
+        'checks:',
+        '  tolerance: 1e-9',
+        '  items:',
+        '    - type: run',
+        '      expected:',
+        '        - basis: "|1>"',
+        '          amplitude:',
+        '            real: 1',
+        '            imaginary: 0',
+        '---',
+        '',
+        'Flip the state.'
+      ].join('\n'));
+
+      const result = captureDispatcherRun(dir, [
+        'benchmark',
+        'run',
+        'task.md',
+        'benchmarks/solutions/quantum-katas/basic-gates/state-flip.qni'
+      ]);
+
+      assert.equal(result.exitStatus, 3);
+      assert.equal(result.stdout, 'ERROR benchmark run\nerror: allowed_commands is required\n');
+      assert.equal(result.stderr, '');
+    });
+  });
+
+  it('classifies submission syntax errors as error results', async () => {
+    await withTempDir(async (dir) => {
+      await writeFile(path.join(dir, 'submission.qni'), 'qni add X --qubit "0 --step 0\n');
+
+      const result = captureDispatcherRun(dir, [
+        'benchmark',
+        'run',
+        'benchmarks/quantum-katas/basic-gates/state-flip.md',
+        'submission.qni'
+      ]);
+
+      assert.equal(result.exitStatus, 3);
+      assert.equal(result.stdout, [
+        'ERROR StateFlip',
+        'error: unterminated quote in command: qni add X --qubit "0 --step 0',
+        ''
+      ].join('\n'));
+      assert.equal(result.stderr, '');
+    });
+  });
+
+  it('classifies qni command execution failures as error results', async () => {
+    await withTempDir(async (dir) => {
+      await writeFile(path.join(dir, 'submission.qni'), 'qni add X --qubit nope --step 0\n');
+
+      const result = captureDispatcherRun(dir, [
+        'benchmark',
+        'run',
+        'benchmarks/quantum-katas/basic-gates/state-flip.md',
+        'submission.qni'
+      ]);
+
+      assert.equal(result.exitStatus, 3);
+      assert.equal(result.stdout, [
+        'ERROR StateFlip',
+        'error: submission command failed at line 1: qni add X --qubit nope --step 0',
+        'qubit must be an integer',
+        ''
+      ].join('\n'));
+      assert.equal(result.stderr, '');
+    });
+  });
+
+  it('writes JSON error status and exit code for qni command execution failures', async () => {
+    await withTempDir(async (dir) => {
+      await writeFile(path.join(dir, 'submission.qni'), 'qni add X --qubit nope --step 0\n');
+
+      const result = captureDispatcherRun(dir, [
+        'benchmark',
+        'run',
+        'benchmarks/quantum-katas/basic-gates/state-flip.md',
+        'submission.qni',
+        '--json'
+      ]);
+      const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+      assert.equal(result.exitStatus, 3);
+      assert.equal(payload.status, 'error');
+      assert.equal(payload.exitCode, 3);
+      assert.equal(payload.taskId, 'basic-gates/state-flip');
+      assert.equal(payload.title, 'StateFlip');
+      assert.equal(result.stderr, '');
+    });
+  });
+
+  it('writes JSON passed status and exit code for correct submissions', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, [
+        'benchmark',
+        'run',
+        'benchmarks/quantum-katas/basic-gates/state-flip.md',
+        'benchmarks/solutions/quantum-katas/basic-gates/state-flip.qni',
+        '--json'
+      ]);
+      const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+      assert.equal(result.exitStatus, 0);
+      assert.deepEqual(payload, {
+        taskId: 'basic-gates/state-flip',
+        title: 'StateFlip',
+        submission: 'benchmarks/solutions/quantum-katas/basic-gates/state-flip.qni',
+        status: 'passed',
+        exitCode: 0,
+        checks: [{ type: 'run', status: 'passed' }]
+      });
+      assert.equal(result.stderr, '');
+    });
+  });
+
+  it('writes JSON failed status and exit code for wrong answers', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, [
+        'benchmark',
+        'run',
+        'benchmarks/quantum-katas/basic-gates/state-flip.md',
+        'benchmarks/incorrect/quantum-katas/basic-gates/state-flip-wrong.qni',
+        '--json'
+      ]);
+      const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+      assert.equal(result.exitStatus, 1);
+      assert.equal(payload.status, 'failed');
+      assert.equal(payload.exitCode, 1);
+      assert.deepEqual(payload.checks, [{ type: 'run', status: 'failed' }]);
+      assert.equal(result.stderr, '');
+    });
+  });
+
+  it('writes JSON disallowed status and exit code for rejected submissions', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, [
+        'benchmark',
+        'run',
+        'benchmarks/quantum-katas/basic-gates/state-flip.md',
+        'benchmarks/disallowed/quantum-katas/basic-gates/state-flip-disallowed.qni',
+        '--json'
+      ]);
+      const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+      assert.equal(result.exitStatus, 2);
+      assert.equal(payload.status, 'disallowed');
+      assert.equal(payload.exitCode, 2);
+      assert.deepEqual(payload.checks, []);
+      assert.equal(result.stderr, '');
+    });
+  });
+
   it('rejects submission commands not listed in allowed_commands', async () => {
     await withTempDir(async (dir) => {
       await writeFile(path.join(dir, 'task.md'), [

--- a/test/typescript/benchmark_command.test.ts
+++ b/test/typescript/benchmark_command.test.ts
@@ -117,6 +117,43 @@ describe('benchmark command TypeScript route', () => {
     });
   });
 
+  it('classifies malformed YAML frontmatter as an error result', async () => {
+    await withTempDir(async (dir) => {
+      await writeFile(path.join(dir, 'task.md'), [
+        '---',
+        'id: basic-gates/state-flip',
+        'title: "StateFlip',
+        'source: test',
+        'difficulty: smoke',
+        'allowed_commands:',
+        '  - qni add',
+        'checks:',
+        '  tolerance: 1e-9',
+        '  items:',
+        '    - type: run',
+        '      expected:',
+        '        - basis: "|1>"',
+        '          amplitude:',
+        '            real: 1',
+        '            imaginary: 0',
+        '---',
+        '',
+        'Flip the state.'
+      ].join('\n'));
+
+      const result = captureDispatcherRun(dir, [
+        'benchmark',
+        'run',
+        'task.md',
+        'benchmarks/solutions/quantum-katas/basic-gates/state-flip.qni'
+      ]);
+
+      assert.equal(result.exitStatus, 3);
+      assert.match(result.stdout, /^ERROR benchmark run\nerror: invalid YAML frontmatter: Missing closing "quote/mu);
+      assert.equal(result.stderr, '');
+    });
+  });
+
   it('classifies submission syntax errors as error results', async () => {
     await withTempDir(async (dir) => {
       await writeFile(path.join(dir, 'submission.qni'), 'qni add X --qubit "0 --step 0\n');


### PR DESCRIPTION
## 概要

- `qni benchmark run` の評価基盤側エラーを `error` として扱い、終了コード `3` を返すようにしました。
- frontmatter 不備、提出物の構文不備、提出コマンド実行失敗を人間向け出力で `ERROR` と表示します。
- `--json` 出力で `status: "error"`, `exitCode: 3` を返せるようにしました。
- `passed` / `failed` / `disallowed` / `error` の JSON 出力回帰テストと Cucumber シナリオを追加しました。

Closes #257

## 検証

- `npm run test:ts`
- `npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress "features/cli/benchmark_run.feature.md"`
- `bundle exec rake check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ベンチマーク実行で JSON 出力を選べるようになり、結果を機械的に扱いやすくなりました。
  * 正常終了、誤答、実行不可、エラーの各結果がより明確に表示されます。

* **バグ修正**
  * 不正な入力や設定不備を、より分かりやすいエラーとして返すようになりました。
  * YAML の壊れた記述や提出コマンドの不備も検出されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->