### PR TITLE
qni benchmark run の JSON 出力検証を追加

### DIFF
--- a/features/cli/benchmark_run.feature.md
+++ b/features/cli/benchmark_run.feature.md
@@ -42,6 +42,27 @@ qni benchmark run で最小の合格判定を実行したい。
   "exitCode": 0
   ```
 
+## Scenario: StateFlip 標準解の JSON は機械処理できる結果である
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/solutions/quantum-katas/basic-gates/state-flip.qni --json" を実行
+- Then 標準出力は次の JSON と一致する:
+
+  ```json
+  {
+    "taskId": "basic-gates/state-flip",
+    "title": "StateFlip",
+    "submission": "benchmarks/solutions/quantum-katas/basic-gates/state-flip.qni",
+    "status": "passed",
+    "exitCode": 0,
+    "checks": [
+      {
+        "type": "run",
+        "status": "passed"
+      }
+    ]
+  }
+  ```
+
 ## Scenario: PlusState 標準解は合格する
 
 - When "qni benchmark run benchmarks/quantum-katas/superposition/plus-state.md benchmarks/solutions/quantum-katas/superposition/plus-state.qni" を実行
@@ -124,6 +145,22 @@ qni benchmark run で最小の合格判定を実行したい。
   "exitCode": 2
   ```
 
+## Scenario: StateFlip の不許可コマンドの JSON は機械処理できる結果である
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/disallowed/quantum-katas/basic-gates/state-flip-disallowed.qni --json" を実行
+- Then 標準出力は次の JSON と一致する:
+
+  ```json
+  {
+    "taskId": "basic-gates/state-flip",
+    "title": "StateFlip",
+    "submission": "benchmarks/disallowed/quantum-katas/basic-gates/state-flip-disallowed.qni",
+    "status": "disallowed",
+    "exitCode": 2,
+    "checks": []
+  }
+  ```
+
 ## Scenario: StateFlip 不正解サンプルは終了コード 1 で不合格になる
 
 - When "qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/incorrect/quantum-katas/basic-gates/state-flip-wrong.qni" を実行
@@ -159,6 +196,27 @@ qni benchmark run で最小の合格判定を実行したい。
 
   ```text
   "exitCode": 1
+  ```
+
+## Scenario: StateFlip 不正解サンプルの JSON は機械処理できる結果である
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/incorrect/quantum-katas/basic-gates/state-flip-wrong.qni --json" を実行
+- Then 標準出力は次の JSON と一致する:
+
+  ```json
+  {
+    "taskId": "basic-gates/state-flip",
+    "title": "StateFlip",
+    "submission": "benchmarks/incorrect/quantum-katas/basic-gates/state-flip-wrong.qni",
+    "status": "failed",
+    "exitCode": 1,
+    "checks": [
+      {
+        "type": "run",
+        "status": "failed"
+      }
+    ]
+  }
   ```
 
 ## Scenario: frontmatter 不備の課題ファイルは終了コード 3 になる

--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -998,7 +998,7 @@ Then('標準出力は次の JSON と一致する:', function (docString) {
   const actual = JSON.parse(this.lastCommand.stdout);
   const expected = JSON.parse(docStringContent(docString));
 
-  assert.deepEqual(actual, expected);
+  assert.deepStrictEqual(actual, expected);
 });
 
 Then('標準エラー:', function (docString) {

--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -994,6 +994,13 @@ Then('標準出力の内容:', function (docString) {
   );
 });
 
+Then('標準出力は次の JSON と一致する:', function (docString) {
+  const actual = JSON.parse(this.lastCommand.stdout);
+  const expected = JSON.parse(docStringContent(docString));
+
+  assert.deepEqual(actual, expected);
+});
+
 Then('標準エラー:', function (docString) {
   assert.equal(
     normalizeMultilineText(this.lastCommand.stderr),

--- a/test/typescript/benchmark_command.test.ts
+++ b/test/typescript/benchmark_command.test.ts
@@ -255,9 +255,14 @@ describe('benchmark command TypeScript route', () => {
       const payload = JSON.parse(result.stdout) as Record<string, unknown>;
 
       assert.equal(result.exitStatus, 1);
-      assert.equal(payload.status, 'failed');
-      assert.equal(payload.exitCode, 1);
-      assert.deepEqual(payload.checks, [{ type: 'run', status: 'failed' }]);
+      assert.deepEqual(payload, {
+        taskId: 'basic-gates/state-flip',
+        title: 'StateFlip',
+        submission: 'benchmarks/incorrect/quantum-katas/basic-gates/state-flip-wrong.qni',
+        status: 'failed',
+        exitCode: 1,
+        checks: [{ type: 'run', status: 'failed' }]
+      });
       assert.equal(result.stderr, '');
     });
   });
@@ -274,9 +279,14 @@ describe('benchmark command TypeScript route', () => {
       const payload = JSON.parse(result.stdout) as Record<string, unknown>;
 
       assert.equal(result.exitStatus, 2);
-      assert.equal(payload.status, 'disallowed');
-      assert.equal(payload.exitCode, 2);
-      assert.deepEqual(payload.checks, []);
+      assert.deepEqual(payload, {
+        taskId: 'basic-gates/state-flip',
+        title: 'StateFlip',
+        submission: 'benchmarks/disallowed/quantum-katas/basic-gates/state-flip-disallowed.qni',
+        status: 'disallowed',
+        exitCode: 2,
+        checks: []
+      });
       assert.equal(result.stderr, '');
     });
   });

--- a/test/typescript/benchmark_command.test.ts
+++ b/test/typescript/benchmark_command.test.ts
@@ -231,7 +231,7 @@ describe('benchmark command TypeScript route', () => {
       const payload = JSON.parse(result.stdout) as Record<string, unknown>;
 
       assert.equal(result.exitStatus, 0);
-      assert.deepEqual(payload, {
+      assert.deepStrictEqual(payload, {
         taskId: 'basic-gates/state-flip',
         title: 'StateFlip',
         submission: 'benchmarks/solutions/quantum-katas/basic-gates/state-flip.qni',
@@ -255,7 +255,7 @@ describe('benchmark command TypeScript route', () => {
       const payload = JSON.parse(result.stdout) as Record<string, unknown>;
 
       assert.equal(result.exitStatus, 1);
-      assert.deepEqual(payload, {
+      assert.deepStrictEqual(payload, {
         taskId: 'basic-gates/state-flip',
         title: 'StateFlip',
         submission: 'benchmarks/incorrect/quantum-katas/basic-gates/state-flip-wrong.qni',
@@ -279,7 +279,7 @@ describe('benchmark command TypeScript route', () => {
       const payload = JSON.parse(result.stdout) as Record<string, unknown>;
 
       assert.equal(result.exitStatus, 2);
-      assert.deepEqual(payload, {
+      assert.deepStrictEqual(payload, {
         taskId: 'basic-gates/state-flip',
         title: 'StateFlip',
         submission: 'benchmarks/disallowed/quantum-katas/basic-gates/state-flip-disallowed.qni',


### PR DESCRIPTION
## 概要
- `qni benchmark run --json` の合格・不合格・不許可ケースを、完全な JSON として検証する Cucumber シナリオを追加
- JSON 検証用のステップ定義を追加
- TypeScript テストで `taskId`, `title`, `submission`, `status`, `exitCode`, `checks` を全ケース確認

## 検証
- `npm run build && npx tsc -p tsconfig.test.json && node --test tmp/typescript-tests/test/typescript/benchmark_command.test.js`
- `npm run build && npx cucumber-js --config cucumber-js.mjs --require "features/support/**/*.js" --require "features/step_definitions/**/*.js" --format progress features/cli/benchmark_run.feature.md`
- `bundle exec rake check`

Closes #256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `qni benchmark run --json` の出力について、期待される JSON と完全一致することを確認するテストが追加されました。
  * 正解・不許可・不正解の各結果で、出力内容の一致確認がより厳密になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->