### PR TITLE
TypeScript コマンドテストの実行支援を共通化する

### DIFF
--- a/test/typescript/clear_command.test.ts
+++ b/test/typescript/clear_command.test.ts
@@ -6,6 +6,8 @@ import { describe, it } from 'node:test';
 
 import { captureDispatcherRun, withTempDir } from './helpers/command';
 
+const TEMP_DIR_OPTIONS = { prefix: 'qni-cli-clear-' };
+
 const HELP_TEXT = `Usage:
   qni clear
 
@@ -29,50 +31,62 @@ async function circuitExists(dir: string): Promise<boolean> {
 
 describe('clear command TypeScript route', () => {
   it('deletes circuit.json through the TypeScript route', async () => {
-    await withTempDir(async (dir) => {
-      const circuitPath = path.join(dir, 'circuit.json');
-      await writeFile(circuitPath, '{"qubits":1,"cols":[["H"]]}\n');
+    await withTempDir(
+      async (dir) => {
+        const circuitPath = path.join(dir, 'circuit.json');
+        await writeFile(circuitPath, '{"qubits":1,"cols":[["H"]]}\n');
 
-      const result = captureDispatcherRun(dir, ['clear']);
+        const result = captureDispatcherRun(dir, ['clear']);
 
-      assert.equal(result.exitStatus, 0);
-      assert.equal(result.stdout, '');
-      assert.equal(result.stderr, '');
-      assert.equal(await circuitExists(dir), false);
-    });
+        assert.equal(result.exitStatus, 0);
+        assert.equal(result.stdout, '');
+        assert.equal(result.stderr, '');
+        assert.equal(await circuitExists(dir), false);
+      },
+      TEMP_DIR_OPTIONS
+    );
   });
 
   it('succeeds without creating circuit.json when it does not exist', async () => {
-    await withTempDir(async (dir) => {
-      const result = captureDispatcherRun(dir, ['clear']);
+    await withTempDir(
+      async (dir) => {
+        const result = captureDispatcherRun(dir, ['clear']);
 
-      assert.equal(result.exitStatus, 0);
-      assert.equal(result.stdout, '');
-      assert.equal(result.stderr, '');
-      assert.equal(await circuitExists(dir), false);
-    });
+        assert.equal(result.exitStatus, 0);
+        assert.equal(result.stdout, '');
+        assert.equal(result.stderr, '');
+        assert.equal(await circuitExists(dir), false);
+      },
+      TEMP_DIR_OPTIONS
+    );
   });
 
   it('prints clear help through the TypeScript route', async () => {
-    await withTempDir(async (dir) => {
-      const result = captureDispatcherRun(dir, ['clear', '--help']);
+    await withTempDir(
+      async (dir) => {
+        const result = captureDispatcherRun(dir, ['clear', '--help']);
 
-      assert.equal(result.exitStatus, 0);
-      assert.equal(result.stdout, HELP_TEXT);
-      assert.equal(result.stderr, '');
-    });
+        assert.equal(result.exitStatus, 0);
+        assert.equal(result.stdout, HELP_TEXT);
+        assert.equal(result.stderr, '');
+      },
+      TEMP_DIR_OPTIONS
+    );
   });
 
   it('rejects extra arguments like the Ruby command', async () => {
-    await withTempDir(async (dir) => {
-      const result = captureDispatcherRun(dir, ['clear', '--bad', 'foo']);
+    await withTempDir(
+      async (dir) => {
+        const result = captureDispatcherRun(dir, ['clear', '--bad', 'foo']);
 
-      assert.equal(result.exitStatus, 1);
-      assert.equal(result.stdout, '');
-      assert.equal(
-        result.stderr,
-        'ERROR: "qni clear" was called with arguments ["--bad", "foo"]\nUsage: "qni clear"\n'
-      );
-    });
+        assert.equal(result.exitStatus, 1);
+        assert.equal(result.stdout, '');
+        assert.equal(
+          result.stderr,
+          'ERROR: "qni clear" was called with arguments ["--bad", "foo"]\nUsage: "qni clear"\n'
+        );
+      },
+      TEMP_DIR_OPTIONS
+    );
   });
 });

--- a/test/typescript/clear_command.test.ts
+++ b/test/typescript/clear_command.test.ts
@@ -1,17 +1,10 @@
 import assert from 'node:assert/strict';
-import { access, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, writeFile } from 'node:fs/promises';
 import { constants } from 'node:fs';
-import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 
-import { createDispatcher } from '../../src/dispatcher';
-
-interface CapturedRun {
-  readonly exitStatus: number;
-  readonly stderr: string;
-  readonly stdout: string;
-}
+import { captureDispatcherRun, withTempDir } from './helpers/command';
 
 const HELP_TEXT = `Usage:
   qni clear
@@ -24,66 +17,6 @@ Overview:
 Examples:
   qni clear
 `;
-
-async function withTempDir<T>(callback: (dir: string) => Promise<T>): Promise<T> {
-  const dir = await mkdtemp(path.join(tmpdir(), 'qni-cli-clear-'));
-
-  try {
-    return await callback(dir);
-  } finally {
-    await rm(dir, { force: true, recursive: true });
-  }
-}
-
-function captureDispatcherRun(
-  cwd: string,
-  argv: string[],
-  env: NodeJS.ProcessEnv = { PATH: '' }
-): CapturedRun {
-  let stdout = '';
-  let stderr = '';
-  const originalStdoutWrite = process.stdout.write;
-  const originalStderrWrite = process.stderr.write;
-
-  process.stdout.write = ((chunk: string | Uint8Array, encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void), callback?: (error?: Error | null) => void): boolean => {
-    stdout += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk.toString();
-    if (typeof encodingOrCallback === 'function') {
-      encodingOrCallback();
-    }
-    if (callback) {
-      callback();
-    }
-    return true;
-  }) as typeof process.stdout.write;
-
-  process.stderr.write = ((chunk: string | Uint8Array, encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void), callback?: BufferEncoding | ((error?: Error | null) => void)): boolean => {
-    stderr += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk.toString();
-    if (typeof encodingOrCallback === 'function') {
-      encodingOrCallback();
-    }
-    if (typeof callback === 'function') {
-      callback();
-    }
-    return true;
-  }) as typeof process.stderr.write;
-
-  try {
-    const dispatcher = createDispatcher({
-      cwd,
-      env,
-      projectRoot: process.cwd()
-    });
-
-    return {
-      exitStatus: dispatcher.run(argv),
-      stderr,
-      stdout
-    };
-  } finally {
-    process.stdout.write = originalStdoutWrite;
-    process.stderr.write = originalStderrWrite;
-  }
-}
 
 async function circuitExists(dir: string): Promise<boolean> {
   try {

--- a/test/typescript/help_command.test.ts
+++ b/test/typescript/help_command.test.ts
@@ -1,16 +1,7 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import path from 'node:path';
 import { describe, it } from 'node:test';
 
-import { createDispatcher } from '../../src/dispatcher';
-
-interface CapturedRun {
-  readonly exitStatus: number;
-  readonly stderr: string;
-  readonly stdout: string;
-}
+import { captureDispatcherRun, withTempDir } from './helpers/command';
 
 const HELP_TEXT = `qni commands:
   qni add       # Add a gate to the circuit
@@ -25,66 +16,6 @@ const HELP_TEXT = `qni commands:
   qni variable  # Manage symbolic angle variables
   qni view      # Render the circuit as ASCII art
 `;
-
-async function withTempDir<T>(callback: (dir: string) => Promise<T>): Promise<T> {
-  const dir = await mkdtemp(path.join(tmpdir(), 'qni-cli-help-'));
-
-  try {
-    return await callback(dir);
-  } finally {
-    await rm(dir, { force: true, recursive: true });
-  }
-}
-
-function captureDispatcherRun(
-  cwd: string,
-  argv: string[],
-  env: NodeJS.ProcessEnv = { PATH: '' }
-): CapturedRun {
-  let stdout = '';
-  let stderr = '';
-  const originalStdoutWrite = process.stdout.write;
-  const originalStderrWrite = process.stderr.write;
-
-  process.stdout.write = ((chunk: string | Uint8Array, encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void), callback?: (error?: Error | null) => void): boolean => {
-    stdout += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk.toString();
-    if (typeof encodingOrCallback === 'function') {
-      encodingOrCallback();
-    }
-    if (callback) {
-      callback();
-    }
-    return true;
-  }) as typeof process.stdout.write;
-
-  process.stderr.write = ((chunk: string | Uint8Array, encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void), callback?: BufferEncoding | ((error?: Error | null) => void)): boolean => {
-    stderr += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk.toString();
-    if (typeof encodingOrCallback === 'function') {
-      encodingOrCallback();
-    }
-    if (typeof callback === 'function') {
-      callback();
-    }
-    return true;
-  }) as typeof process.stderr.write;
-
-  try {
-    const dispatcher = createDispatcher({
-      cwd,
-      env,
-      projectRoot: process.cwd()
-    });
-
-    return {
-      exitStatus: dispatcher.run(argv),
-      stderr,
-      stdout
-    };
-  } finally {
-    process.stdout.write = originalStdoutWrite;
-    process.stderr.write = originalStderrWrite;
-  }
-}
 
 describe('top-level help TypeScript route', () => {
   it('prints the command list through the TypeScript route', async () => {

--- a/test/typescript/help_command.test.ts
+++ b/test/typescript/help_command.test.ts
@@ -3,6 +3,8 @@ import { describe, it } from 'node:test';
 
 import { captureDispatcherRun, withTempDir } from './helpers/command';
 
+const TEMP_DIR_OPTIONS = { prefix: 'qni-cli-help-' };
+
 const HELP_TEXT = `qni commands:
   qni add       # Add a gate to the circuit
   qni bloch     # Render the current 1-qubit state on the Bloch sphere
@@ -19,42 +21,54 @@ const HELP_TEXT = `qni commands:
 
 describe('top-level help TypeScript route', () => {
   it('prints the command list through the TypeScript route', async () => {
-    await withTempDir(async (dir) => {
-      const result = captureDispatcherRun(dir, []);
+    await withTempDir(
+      async (dir) => {
+        const result = captureDispatcherRun(dir, []);
 
-      assert.equal(result.exitStatus, 0);
-      assert.equal(result.stdout, HELP_TEXT);
-      assert.equal(result.stderr, '');
-    });
+        assert.equal(result.exitStatus, 0);
+        assert.equal(result.stdout, HELP_TEXT);
+        assert.equal(result.stderr, '');
+      },
+      TEMP_DIR_OPTIONS
+    );
   });
 
   it('prints the command list for --help through the TypeScript route', async () => {
-    await withTempDir(async (dir) => {
-      const result = captureDispatcherRun(dir, ['--help']);
+    await withTempDir(
+      async (dir) => {
+        const result = captureDispatcherRun(dir, ['--help']);
 
-      assert.equal(result.exitStatus, 0);
-      assert.equal(result.stdout, HELP_TEXT);
-      assert.equal(result.stderr, '');
-    });
+        assert.equal(result.exitStatus, 0);
+        assert.equal(result.stdout, HELP_TEXT);
+        assert.equal(result.stderr, '');
+      },
+      TEMP_DIR_OPTIONS
+    );
   });
 
   it('rejects qni help subcommands like the Ruby command', async () => {
-    await withTempDir(async (dir) => {
-      const result = captureDispatcherRun(dir, ['help', 'add']);
+    await withTempDir(
+      async (dir) => {
+        const result = captureDispatcherRun(dir, ['help', 'add']);
 
-      assert.equal(result.exitStatus, 1);
-      assert.equal(result.stdout, '');
-      assert.equal(result.stderr, 'qni help is not available; use qni or qni COMMAND --help\n');
-    });
+        assert.equal(result.exitStatus, 1);
+        assert.equal(result.stdout, '');
+        assert.equal(result.stderr, 'qni help is not available; use qni or qni COMMAND --help\n');
+      },
+      TEMP_DIR_OPTIONS
+    );
   });
 
   it('rejects unknown commands through the TypeScript route', async () => {
-    await withTempDir(async (dir) => {
-      const result = captureDispatcherRun(dir, ['__missing_command__'], { PATH: '' });
+    await withTempDir(
+      async (dir) => {
+        const result = captureDispatcherRun(dir, ['__missing_command__'], { PATH: '' });
 
-      assert.equal(result.exitStatus, 1);
-      assert.equal(result.stdout, '');
-      assert.equal(result.stderr, 'Could not find command "__missing_command__".\n');
-    });
+        assert.equal(result.exitStatus, 1);
+        assert.equal(result.stdout, '');
+        assert.equal(result.stderr, 'Could not find command "__missing_command__".\n');
+      },
+      TEMP_DIR_OPTIONS
+    );
   });
 });

--- a/test/typescript/helpers/command.test.ts
+++ b/test/typescript/helpers/command.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import { captureProcessWrites, withTempDir } from './command';
+
+describe('TypeScript command test helpers', () => {
+  it('keeps temporary directories under tmpdir when prefix includes path segments', async () => {
+    await withTempDir(
+      (dir) => {
+        assert.equal(path.dirname(dir), tmpdir());
+        assert.match(path.basename(dir), /^qni-review-/);
+      },
+      { prefix: '../qni-review-' }
+    );
+  });
+
+  it('falls back to the default temporary directory prefix for empty prefixes', async () => {
+    await withTempDir(
+      (dir) => {
+        assert.equal(path.dirname(dir), tmpdir());
+        assert.match(path.basename(dir), /^qni-cli-ts-/);
+      },
+      { prefix: '' }
+    );
+  });
+
+  it('rejects async callbacks when capturing process writes', () => {
+    assert.throws(
+      () => captureProcessWrites((async () => undefined) as () => unknown),
+      /only supports synchronous callbacks/
+    );
+  });
+});

--- a/test/typescript/helpers/command.test.ts
+++ b/test/typescript/helpers/command.test.ts
@@ -5,6 +5,12 @@ import { describe, it } from 'node:test';
 
 import { captureProcessWrites, withTempDir } from './command';
 
+function assertCaptureProcessWritesRejectsAsyncCallbackType(): void {
+  // The helper must reject async callbacks during type checking, before runtime.
+  // @ts-expect-error captureProcessWrites only supports synchronous callbacks.
+  captureProcessWrites(async () => undefined);
+}
+
 describe('TypeScript command test helpers', () => {
   it('keeps temporary directories under tmpdir when prefix includes path segments', async () => {
     await withTempDir(

--- a/test/typescript/helpers/command.ts
+++ b/test/typescript/helpers/command.ts
@@ -1,0 +1,114 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { createDispatcher } from '../../../src/dispatcher';
+
+export interface CapturedRun {
+  readonly exitStatus: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}
+
+export interface CapturedValue<T> {
+  readonly stderr: string;
+  readonly stdout: string;
+  readonly value: T;
+}
+
+interface TempDirOptions {
+  readonly prefix?: string;
+}
+
+type WriteCallback = (error?: Error | null) => void;
+
+export async function withTempDir<T>(
+  callback: (dir: string) => Promise<T> | T,
+  options: TempDirOptions = {}
+): Promise<T> {
+  const dir = await mkdtemp(path.join(tmpdir(), options.prefix ?? 'qni-cli-ts-'));
+
+  try {
+    return await callback(dir);
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+}
+
+export function captureProcessWrites<T>(callback: () => T): CapturedValue<T> {
+  let stdout = '';
+  let stderr = '';
+  const originalStdoutWrite = process.stdout.write;
+  const originalStderrWrite = process.stderr.write;
+
+  process.stdout.write = ((
+    chunk: string | Uint8Array,
+    encodingOrCallback?: BufferEncoding | WriteCallback,
+    callback?: WriteCallback
+  ): boolean => {
+    stdout += chunkToString(chunk);
+    callWriteCallbacks(encodingOrCallback, callback);
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = ((
+    chunk: string | Uint8Array,
+    encodingOrCallback?: BufferEncoding | WriteCallback,
+    callback?: WriteCallback
+  ): boolean => {
+    stderr += chunkToString(chunk);
+    callWriteCallbacks(encodingOrCallback, callback);
+    return true;
+  }) as typeof process.stderr.write;
+
+  try {
+    const value = callback();
+
+    return {
+      stderr,
+      stdout,
+      value
+    };
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+}
+
+export function captureDispatcherRun(
+  cwd: string,
+  argv: string[],
+  env: NodeJS.ProcessEnv = { PATH: '' }
+): CapturedRun {
+  const captured = captureProcessWrites(() => {
+    const dispatcher = createDispatcher({
+      cwd,
+      env,
+      projectRoot: process.cwd()
+    });
+
+    return dispatcher.run(argv);
+  });
+
+  return {
+    exitStatus: captured.value,
+    stderr: captured.stderr,
+    stdout: captured.stdout
+  };
+}
+
+function chunkToString(chunk: string | Uint8Array): string {
+  return typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+}
+
+function callWriteCallbacks(
+  encodingOrCallback: BufferEncoding | WriteCallback | undefined,
+  callback: WriteCallback | undefined
+): void {
+  if (typeof encodingOrCallback === 'function') {
+    encodingOrCallback();
+  }
+  if (callback) {
+    callback();
+  }
+}

--- a/test/typescript/helpers/command.ts
+++ b/test/typescript/helpers/command.ts
@@ -21,6 +21,7 @@ interface TempDirOptions {
 }
 
 type WriteCallback = (error?: Error | null) => void;
+type NonPromise<T> = T extends PromiseLike<unknown> ? never : T;
 
 const DEFAULT_TEMP_DIR_PREFIX = 'qni-cli-ts-';
 
@@ -37,10 +38,7 @@ export async function withTempDir<T>(
   }
 }
 
-export function captureProcessWrites<TCallback extends () => unknown>(
-  callback: ReturnType<TCallback> extends PromiseLike<unknown> ? never : TCallback
-): CapturedValue<ReturnType<TCallback>>;
-export function captureProcessWrites<T>(callback: () => T): CapturedValue<T> {
+export function captureProcessWrites<T>(callback: () => T & NonPromise<T>): CapturedValue<T> {
   let stdout = '';
   let stderr = '';
   const originalStdoutWrite = process.stdout.write;

--- a/test/typescript/helpers/command.ts
+++ b/test/typescript/helpers/command.ts
@@ -22,11 +22,13 @@ interface TempDirOptions {
 
 type WriteCallback = (error?: Error | null) => void;
 
+const DEFAULT_TEMP_DIR_PREFIX = 'qni-cli-ts-';
+
 export async function withTempDir<T>(
   callback: (dir: string) => Promise<T> | T,
   options: TempDirOptions = {}
 ): Promise<T> {
-  const dir = await mkdtemp(path.join(tmpdir(), options.prefix ?? 'qni-cli-ts-'));
+  const dir = await mkdtemp(path.join(tmpdir(), safeTempDirPrefix(options.prefix)));
 
   try {
     return await callback(dir);
@@ -35,6 +37,9 @@ export async function withTempDir<T>(
   }
 }
 
+export function captureProcessWrites<TCallback extends () => unknown>(
+  callback: ReturnType<TCallback> extends PromiseLike<unknown> ? never : TCallback
+): CapturedValue<ReturnType<TCallback>>;
 export function captureProcessWrites<T>(callback: () => T): CapturedValue<T> {
   let stdout = '';
   let stderr = '';
@@ -63,6 +68,9 @@ export function captureProcessWrites<T>(callback: () => T): CapturedValue<T> {
 
   try {
     const value = callback();
+    if (isPromiseLike(value)) {
+      throw new TypeError('captureProcessWrites only supports synchronous callbacks');
+    }
 
     return {
       stderr,
@@ -95,6 +103,25 @@ export function captureDispatcherRun(
     stderr: captured.stderr,
     stdout: captured.stdout
   };
+}
+
+function safeTempDirPrefix(prefix: string | undefined): string {
+  const basename = path.basename(prefix ?? DEFAULT_TEMP_DIR_PREFIX);
+
+  if (basename === '' || basename === '.' || basename === '..') {
+    return DEFAULT_TEMP_DIR_PREFIX;
+  }
+
+  return basename;
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    (typeof value === 'object' || typeof value === 'function') &&
+    value !== null &&
+    'then' in value &&
+    typeof value.then === 'function'
+  );
 }
 
 function chunkToString(chunk: string | Uint8Array): string {


### PR DESCRIPTION
## 概要

TypeScript のコマンド系テストで重複していた、一時ディレクトリ作成、標準出力・標準エラー捕捉、dispatcher 実行捕捉を共有支援モジュールにまとめました。
まず `help_command.test.ts` と `clear_command.test.ts` を移行し、今後ほかのテストを同じ支援関数へ寄せる土台を作っています。

Closes #292

## 変更内容

- `test/typescript/helpers/command.ts` を追加し、`withTempDir`、`captureProcessWrites`、`captureDispatcherRun` を共有化
- `help_command.test.ts` のローカル支援関数を削除し、共有支援関数を利用
- `clear_command.test.ts` のローカル支援関数を削除し、共有支援関数を利用
- CLI 出力と終了コードの期待値は変更せず、テスト支援コードだけを整理

## 確認

- `npm run check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * 一時ディレクトリ管理やコマンド実行結果の取得を共通化し、関連テストの重複を削減しました。
  * `help` / `clear` コマンドの期待値や出力確認はそのまま維持しています。

* **リファクタ**
  * テスト内の補助実装を整理し、出力キャプチャや実行補助の責務を共通ヘルパーへ移しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->