### PR TITLE
ベンチマーク系 TypeScript テストを共有 command helper に移行する

### DIFF
--- a/test/typescript/benchmark_command.test.ts
+++ b/test/typescript/benchmark_command.test.ts
@@ -1,101 +1,10 @@
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 
-import { createDispatcher } from '../../src/dispatcher';
 import { gradeBenchmarkSuite } from '../../src/evaluation_runner';
-
-interface CapturedRun {
-  readonly exitStatus: number;
-  readonly stderr: string;
-  readonly stdout: string;
-}
-
-interface CapturedValue<T> {
-  readonly stderr: string;
-  readonly stdout: string;
-  readonly value: T;
-}
-
-async function withTempDir<T>(callback: (dir: string) => Promise<T>): Promise<T> {
-  const dir = await mkdtemp(path.join(tmpdir(), 'qni-cli-benchmark-'));
-
-  try {
-    return await callback(dir);
-  } finally {
-    await rm(dir, { force: true, recursive: true });
-  }
-}
-
-function captureProcessWrites<T>(callback: () => T): CapturedValue<T> {
-  let stdout = '';
-  let stderr = '';
-  const originalStdoutWrite = process.stdout.write;
-  const originalStderrWrite = process.stderr.write;
-
-  process.stdout.write = ((
-    chunk: string | Uint8Array,
-    encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
-    callback?: (error?: Error | null) => void
-  ): boolean => {
-    stdout += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
-    if (typeof encodingOrCallback === 'function') {
-      encodingOrCallback();
-    }
-    if (callback) {
-      callback();
-    }
-    return true;
-  }) as typeof process.stdout.write;
-
-  process.stderr.write = ((
-    chunk: string | Uint8Array,
-    encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
-    callback?: BufferEncoding | ((error?: Error | null) => void)
-  ): boolean => {
-    stderr += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
-    if (typeof encodingOrCallback === 'function') {
-      encodingOrCallback();
-    }
-    if (typeof callback === 'function') {
-      callback();
-    }
-    return true;
-  }) as typeof process.stderr.write;
-
-  try {
-    const value = callback();
-
-    return {
-      stderr,
-      stdout,
-      value
-    };
-  } finally {
-    process.stdout.write = originalStdoutWrite;
-    process.stderr.write = originalStderrWrite;
-  }
-}
-
-function captureDispatcherRun(cwd: string, argv: string[]): CapturedRun {
-  const captured = captureProcessWrites(() => {
-    const dispatcher = createDispatcher({
-      cwd,
-      env: { PATH: '' },
-      projectRoot: process.cwd()
-    });
-
-    return dispatcher.run(argv);
-  });
-
-  return {
-    exitStatus: captured.value,
-    stderr: captured.stderr,
-    stdout: captured.stdout
-  };
-}
+import { captureDispatcherRun, captureProcessWrites, withTempDir } from './helpers/command';
 
 describe('benchmark command TypeScript route', () => {
   it('classifies invalid task frontmatter as an error result', async () => {

--- a/test/typescript/evaluation_runner.test.ts
+++ b/test/typescript/evaluation_runner.test.ts
@@ -1,6 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 
@@ -13,72 +12,7 @@ import {
   gradeBenchmarkTask,
   gradeBenchmarkTaskForReport
 } from '../../src/evaluation_runner';
-
-interface CapturedValue<T> {
-  readonly stderr: string;
-  readonly stdout: string;
-  readonly value: T;
-}
-
-async function withTempDir<T>(callback: (dir: string) => Promise<T>): Promise<T> {
-  const dir = await mkdtemp(path.join(tmpdir(), 'qni-cli-evaluation-runner-'));
-
-  try {
-    return await callback(dir);
-  } finally {
-    await rm(dir, { force: true, recursive: true });
-  }
-}
-
-function captureProcessWrites<T>(callback: () => T): CapturedValue<T> {
-  let stdout = '';
-  let stderr = '';
-  const originalStdoutWrite = process.stdout.write;
-  const originalStderrWrite = process.stderr.write;
-
-  process.stdout.write = ((
-    chunk: string | Uint8Array,
-    encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
-    callback?: (error?: Error | null) => void
-  ): boolean => {
-    stdout += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
-    if (typeof encodingOrCallback === 'function') {
-      encodingOrCallback();
-    }
-    if (callback) {
-      callback();
-    }
-    return true;
-  }) as typeof process.stdout.write;
-
-  process.stderr.write = ((
-    chunk: string | Uint8Array,
-    encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
-    callback?: BufferEncoding | ((error?: Error | null) => void)
-  ): boolean => {
-    stderr += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
-    if (typeof encodingOrCallback === 'function') {
-      encodingOrCallback();
-    }
-    if (typeof callback === 'function') {
-      callback();
-    }
-    return true;
-  }) as typeof process.stderr.write;
-
-  try {
-    const value = callback();
-
-    return {
-      stderr,
-      stdout,
-      value
-    };
-  } finally {
-    process.stdout.write = originalStdoutWrite;
-    process.stderr.write = originalStderrWrite;
-  }
-}
+import { captureProcessWrites, withTempDir } from './helpers/command';
 
 describe('evaluation runner public entrypoints', () => {
   it('reports task frontmatter errors through the evaluation runner seam', async () => {

--- a/test/typescript/evaluation_runner_submission.test.ts
+++ b/test/typescript/evaluation_runner_submission.test.ts
@@ -1,24 +1,14 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 
 import { readBenchmarkSubmission } from '../../src/evaluation_runner/benchmark_submission';
+import { withTempDir } from './helpers/command';
 
 interface AllowedCommand {
   readonly argv: readonly string[];
   readonly source: string;
-}
-
-async function withTempDir<T>(callback: (dir: string) => Promise<T>): Promise<T> {
-  const dir = await mkdtemp(path.join(tmpdir(), 'qni-cli-evaluation-submission-'));
-
-  try {
-    return await callback(dir);
-  } finally {
-    await rm(dir, { force: true, recursive: true });
-  }
 }
 
 function allowedCommand(source: string, argv: readonly string[]): AllowedCommand {


### PR DESCRIPTION
## 概要

ベンチマーク関連の TypeScript テストに残っていた一時ディレクトリ作成、標準出力・標準エラー捕捉、dispatcher 実行捕捉のローカル実装を、#292 で追加された共有 command helper へ移行しました。
本番コードや CLI 出力期待値は変えず、評価ランナー周辺テストの重複を削って次の変更に備えています。

Closes #293

## 変更内容

- `benchmark_command.test.ts` で `captureDispatcherRun`、`captureProcessWrites`、`withTempDir` を共有 helper から使うようにした
- `evaluation_runner.test.ts` でローカルの一時ディレクトリ作成と出力捕捉を削り、共有 helper に統一した
- `evaluation_runner_submission.test.ts` でローカルの `withTempDir` 実装を削り、共有 helper に統一した

## 確認

- `npm run check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * テスト共通処理を整理し、関連テストの保守性と一貫性を向上しました。
  * 一時ディレクトリ作成や出力の捕捉方法を統一し、テストコードを簡潔にしました。
  * 許可コマンドの記述を整理して、テストケースの可読性を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->