### PR TITLE
研究試行レポート reader に無効候補の判定を追加する

### DIFF
--- a/features/cli/research_report_reader.feature.md
+++ b/features/cli/research_report_reader.feature.md
@@ -1,0 +1,50 @@
+# Feature: 研究試行レポート reader
+
+qni-cli の保守者として
+保存済み研究試行から研究試行レポートを作るために
+研究試行候補を valid / invalid として読み取りたい。
+
+## Scenario: runs ディレクトリが無い場合は空の一覧を返す
+
+- When 研究試行レポート reader で研究試行を読み取る
+- Then 読み取った研究試行数は 0
+
+## Scenario: 直下のファイルは研究試行候補にしない
+
+- Given 有効な研究試行 "2026-06-30T123456Z-smoke-claude" を研究ログに保存済み
+- Given 作業ディレクトリに "research/runs/README.txt" を作る:
+
+  ```text
+  note
+  ```
+
+- When 研究試行レポート reader で研究試行を読み取る
+- Then 読み取った研究試行ID一覧は:
+
+  ```text
+  2026-06-30T123456Z-smoke-claude
+  ```
+
+## Scenario: 研究試行候補は新しい順で返る
+
+- Given 有効な研究試行 "2026-06-30T123456Z-older" を研究ログに保存済み
+- Given 有効な研究試行 "2026-07-01T000001Z-newer" を研究ログに保存済み
+- When 研究試行レポート reader で研究試行を読み取る
+- Then 読み取った研究試行ID一覧は:
+
+  ```text
+  2026-07-01T000001Z-newer
+  2026-06-30T123456Z-older
+  ```
+
+## Scenario: 壊れた研究試行候補も invalid として残す
+
+- Given 無効な研究試行候補 "broken-trial" を研究ログに保存済み
+- When 研究試行レポート reader で研究試行を読み取る
+- Then 読み取った研究試行 "broken-trial" の status は "invalid"
+
+## Scenario: 壊れた研究試行候補は invalidReason を持つ
+
+- Given 無効な研究試行候補 "broken-trial" を研究ログに保存済み
+- When 研究試行レポート reader で研究試行を読み取る
+- Then 読み取った研究試行 "broken-trial" の invalidReason は "invalid research trial id" を含む

--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -306,6 +306,66 @@ function researchTrialIdAt(timeMs, slug) {
   return `${researchTimestamp(date)}-${slug}`;
 }
 
+function researchReportCreatedAtForId(id) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2})(\d{2})(\d{2})Z/u.exec(id);
+
+  if (!match) {
+    return '2026-06-30T12:34:56.000Z';
+  }
+
+  return `${match[1]}-${match[2]}-${match[3]}T${match[4]}:${match[5]}:${match[6]}.000Z`;
+}
+
+function writeResearchReportJsonFile(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writeResearchReportTrial(scenarioDir, id) {
+  const trialDir = path.join(researchRunsDir(scenarioDir), id);
+
+  fs.mkdirSync(trialDir, { recursive: true });
+  writeResearchReportJsonFile(path.join(trialDir, 'metadata.json'), {
+    schemaVersion: 1,
+    id,
+    createdAt: researchReportCreatedAtForId(id),
+    collaborator: 'claude-sonnet-4',
+    benchmark: 'benchmarks/quantum-katas',
+    submissions: 'submissions',
+    prompt: 'prompt.md',
+    response: 'response.md',
+    result: 'result.json',
+    status: 'passed'
+  });
+  writeResearchReportJsonFile(path.join(trialDir, 'result.json'), {
+    status: 'passed',
+    exitCode: 0,
+    summary: {
+      total: 1,
+      passed: 1,
+      failed: 0,
+      disallowed: 0,
+      error: 0
+    },
+    results: [
+      {
+        task: 'basic-gates/state-flip.md',
+        taskId: 'basic-gates/state-flip',
+        title: 'StateFlip',
+        submission: 'submissions/basic-gates/state-flip.qni',
+        status: 'passed',
+        exitCode: 0,
+        checks: [{ type: 'run', status: 'passed' }]
+      }
+    ]
+  });
+}
+
+function readResearchReportTrials(scenarioDir) {
+  const { readResearchTrials } = require(path.join(PROJECT_ROOT, 'dist', 'research_report'));
+
+  return readResearchTrials({ cwd: scenarioDir });
+}
+
 function readCircuitJson(scenarioDir) {
   return JSON.parse(fs.readFileSync(path.join(scenarioDir, 'circuit.json'), 'utf8'));
 }
@@ -871,8 +931,20 @@ Given('slug {string} の保存先候補に既存の研究試行がある', funct
   this.researchTrialDirsBeforeCommand = researchTrialDirs(this.scenarioDir);
 });
 
+Given('有効な研究試行 {string} を研究ログに保存済み', function (id) {
+  writeResearchReportTrial(this.scenarioDir, id);
+});
+
+Given('無効な研究試行候補 {string} を研究ログに保存済み', function (id) {
+  writeResearchReportTrial(this.scenarioDir, id);
+});
+
 When('{string} を TTY で実行', async function (command) {
   this.lastCommand = await runQniCommandInTty(this.scenarioDir, command, this.commandEnv);
+});
+
+When('研究試行レポート reader で研究試行を読み取る', function () {
+  this.lastResearchTrials = readResearchReportTrials(this.scenarioDir);
 });
 
 Then('コマンドは成功', function () {
@@ -1120,6 +1192,40 @@ Then('研究試行 JSON ファイル {string} の {string} は {string}', functi
   const actual = JSON.parse(fs.readFileSync(actualPath, 'utf8'));
 
   assert.equal(actual[key], value);
+});
+
+Then('読み取った研究試行数は {int}', function (expectedCount) {
+  assert.equal(this.lastResearchTrials.length, expectedCount);
+});
+
+Then('読み取った研究試行ID一覧は:', function (docString) {
+  assert.equal(
+    this.lastResearchTrials.map((trial) => trial.id).join('\n'),
+    normalizeMultilineText(docStringContent(docString))
+  );
+});
+
+Then('読み取った研究試行 {string} の status は {string}', function (id, expectedStatus) {
+  const trial = this.lastResearchTrials.find((item) => item.id === id);
+
+  assert.ok(trial, `expected research trial to be read: ${id}`);
+  assert.equal(trial.status, expectedStatus);
+});
+
+Then('読み取った研究試行 {string} の invalidReason は {string} を含む', function (id, expectedReason) {
+  const trial = this.lastResearchTrials.find((item) => item.id === id);
+
+  assert.ok(trial, `expected research trial to be read: ${id}`);
+  assert.equal(trial.kind, 'invalid');
+  assert.ok(
+    trial.invalidReason.some((reason) => reason.includes(expectedReason)),
+    [
+      'expected invalid reason to include text',
+      `trial: ${id}`,
+      `expected: ${expectedReason}`,
+      `actual: ${JSON.stringify(trial.invalidReason)}`
+    ].join('\n')
+  );
 });
 
 Then('作業ディレクトリのファイル {string} は {string} を含む', function (filePath, text) {

--- a/src/research_report.ts
+++ b/src/research_report.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, statSync, type Dirent } from 'node:fs';
 import path = require('node:path');
 
 import type { BenchmarkStatus, BenchmarkSuiteSummary } from './evaluation_runner';
@@ -54,12 +54,19 @@ const RESEARCH_TRIAL_ID_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{6}Z-[a-z0-9]+(?:-[a-z0-
 
 export function readResearchTrials(options: ReadResearchTrialsOptions): ResearchTrial[] {
   const runsDir = path.join(options.cwd, RESEARCH_RUNS_PATH);
+  let entries: Dirent[];
 
-  if (!existsSync(runsDir) || !statSync(runsDir).isDirectory()) {
+  try {
+    if (!statSync(runsDir).isDirectory()) {
+      return [];
+    }
+
+    entries = readdirSync(runsDir, { withFileTypes: true });
+  } catch {
     return [];
   }
 
-  return readdirSync(runsDir, { withFileTypes: true })
+  return entries
     .filter((entry) => entry.isDirectory())
     .map((entry) => readResearchTrial(options.cwd, path.join(runsDir, entry.name), entry.name))
     .sort(compareResearchTrials);
@@ -91,11 +98,7 @@ function readResearchTrial(cwd: string, trialDir: string, id: string): ResearchT
     invalidReason.push(`result summary total ${result.summary.total} does not match results length ${result.resultsLength}`);
   }
 
-  if (invalidReason.length > 0) {
-    return invalidResearchTrial(cwd, trialDir, id, invalidReason);
-  }
-
-  if (!metadata || !result) {
+  if (!metadata || !result || invalidReason.length > 0) {
     return invalidResearchTrial(cwd, trialDir, id, invalidReason);
   }
 

--- a/src/research_report.ts
+++ b/src/research_report.ts
@@ -1,0 +1,305 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import path = require('node:path');
+
+import type { BenchmarkStatus, BenchmarkSuiteSummary } from './evaluation_runner';
+
+export interface ReadResearchTrialsOptions {
+  readonly cwd: string;
+}
+
+export type ResearchTrial = ValidResearchTrial | InvalidResearchTrial;
+
+export interface ValidResearchTrial {
+  readonly benchmark: string;
+  readonly collaborator: string;
+  readonly createdAt: string;
+  readonly id: string;
+  readonly kind: 'valid';
+  readonly path: string;
+  readonly status: BenchmarkStatus;
+  readonly summary: BenchmarkSuiteSummary;
+}
+
+export interface InvalidResearchTrial {
+  readonly id: string;
+  readonly invalidReason: string[];
+  readonly kind: 'invalid';
+  readonly path: string;
+  readonly status: 'invalid';
+}
+
+interface ResearchTrialMetadata {
+  readonly benchmark: string;
+  readonly collaborator: string;
+  readonly createdAt: string;
+  readonly id: string;
+  readonly result: string;
+  readonly status: BenchmarkStatus;
+}
+
+interface ResearchTrialResult {
+  readonly resultsLength: number;
+  readonly status: BenchmarkStatus;
+  readonly summary: BenchmarkSuiteSummary;
+}
+
+interface JsonObjectReadResult {
+  readonly invalidReason: string[];
+  readonly value?: Record<string, unknown>;
+}
+
+const RESEARCH_RUNS_PATH = path.join('research', 'runs');
+const RESEARCH_TRIAL_TIMESTAMP_PATTERN = /^(\d{4}-\d{2}-\d{2}T\d{6}Z)/u;
+const RESEARCH_TRIAL_ID_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{6}Z-[a-z0-9]+(?:-[a-z0-9]+)*$/u;
+
+export function readResearchTrials(options: ReadResearchTrialsOptions): ResearchTrial[] {
+  const runsDir = path.join(options.cwd, RESEARCH_RUNS_PATH);
+
+  if (!existsSync(runsDir) || !statSync(runsDir).isDirectory()) {
+    return [];
+  }
+
+  return readdirSync(runsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => readResearchTrial(options.cwd, path.join(runsDir, entry.name), entry.name))
+    .sort(compareResearchTrials);
+}
+
+function readResearchTrial(cwd: string, trialDir: string, id: string): ResearchTrial {
+  const invalidReason = invalidReasonsForTrialId(id);
+  const metadataFile = readJsonObject(path.join(trialDir, 'metadata.json'), 'metadata.json');
+  const resultFile = readJsonObject(path.join(trialDir, 'result.json'), 'result.json');
+
+  invalidReason.push(...metadataFile.invalidReason, ...resultFile.invalidReason);
+
+  const metadata = metadataFile.value ? researchTrialMetadata(metadataFile.value, invalidReason) : undefined;
+  const result = resultFile.value ? researchTrialResult(resultFile.value, invalidReason) : undefined;
+
+  if (metadata && metadata.id !== id) {
+    invalidReason.push(`metadata id ${metadata.id} does not match research trial id ${id}`);
+  }
+
+  if (metadata && metadata.result !== 'result.json') {
+    invalidReason.push(`metadata result ${metadata.result} does not point to result.json`);
+  }
+
+  if (metadata && result && metadata.status !== result.status) {
+    invalidReason.push(`metadata status ${metadata.status} does not match result status ${result.status}`);
+  }
+
+  if (result && result.summary.total !== result.resultsLength) {
+    invalidReason.push(`result summary total ${result.summary.total} does not match results length ${result.resultsLength}`);
+  }
+
+  if (invalidReason.length > 0) {
+    return invalidResearchTrial(cwd, trialDir, id, invalidReason);
+  }
+
+  if (!metadata || !result) {
+    return invalidResearchTrial(cwd, trialDir, id, invalidReason);
+  }
+
+  return {
+    kind: 'valid',
+    id,
+    createdAt: metadata.createdAt,
+    collaborator: metadata.collaborator,
+    benchmark: metadata.benchmark,
+    status: metadata.status,
+    summary: result.summary,
+    path: toPosixPath(path.relative(cwd, trialDir))
+  };
+}
+
+function readJsonObject(filePath: string, displayName: string): JsonObjectReadResult {
+  if (!existsSync(filePath)) {
+    return { invalidReason: [`${displayName} is missing`] };
+  }
+
+  let value: unknown;
+
+  try {
+    value = JSON.parse(readFileSync(filePath, 'utf8')) as unknown;
+  } catch {
+    return { invalidReason: [`${displayName} is not valid JSON`] };
+  }
+
+  if (!isRecord(value)) {
+    return { invalidReason: [`${displayName} must be a JSON object`] };
+  }
+
+  return {
+    invalidReason: [],
+    value
+  };
+}
+
+function researchTrialMetadata(
+  value: Record<string, unknown>,
+  invalidReason: string[]
+): ResearchTrialMetadata | undefined {
+  if (value.schemaVersion !== 1) {
+    invalidReason.push(`unsupported metadata schemaVersion: ${String(value.schemaVersion)}`);
+    return undefined;
+  }
+
+  const id = requiredString(value, 'id', 'metadata.json', invalidReason);
+  const createdAt = requiredString(value, 'createdAt', 'metadata.json', invalidReason);
+  const collaborator = requiredString(value, 'collaborator', 'metadata.json', invalidReason);
+  const benchmark = requiredString(value, 'benchmark', 'metadata.json', invalidReason);
+  const result = requiredString(value, 'result', 'metadata.json', invalidReason);
+  const status = requiredBenchmarkStatus(value.status, 'metadata.json status', invalidReason);
+
+  if (!id || !createdAt || !collaborator || !benchmark || !result || !status) {
+    return undefined;
+  }
+
+  return {
+    id,
+    createdAt,
+    collaborator,
+    benchmark,
+    result,
+    status
+  };
+}
+
+function researchTrialResult(
+  value: Record<string, unknown>,
+  invalidReason: string[]
+): ResearchTrialResult | undefined {
+  const status = requiredBenchmarkStatus(value.status, 'result.json status', invalidReason);
+  const summary = benchmarkSuiteSummary(value.summary, invalidReason);
+  const resultsLength = resultsArrayLength(value.results, invalidReason);
+
+  if (!status || !summary || resultsLength === undefined) {
+    return undefined;
+  }
+
+  return {
+    status,
+    summary,
+    resultsLength
+  };
+}
+
+function benchmarkSuiteSummary(value: unknown, invalidReason: string[]): BenchmarkSuiteSummary | undefined {
+  if (!isRecord(value)) {
+    invalidReason.push('result summary must be a JSON object');
+    return undefined;
+  }
+
+  const total = requiredInteger(value, 'total', 'result summary', invalidReason);
+  const passed = requiredInteger(value, 'passed', 'result summary', invalidReason);
+  const failed = requiredInteger(value, 'failed', 'result summary', invalidReason);
+  const disallowed = requiredInteger(value, 'disallowed', 'result summary', invalidReason);
+  const error = requiredInteger(value, 'error', 'result summary', invalidReason);
+
+  if (
+    total === undefined ||
+    passed === undefined ||
+    failed === undefined ||
+    disallowed === undefined ||
+    error === undefined
+  ) {
+    return undefined;
+  }
+
+  return {
+    total,
+    passed,
+    failed,
+    disallowed,
+    error
+  };
+}
+
+function resultsArrayLength(value: unknown, invalidReason: string[]): number | undefined {
+  if (!Array.isArray(value)) {
+    invalidReason.push('result results must be an array');
+    return undefined;
+  }
+
+  return value.length;
+}
+
+function requiredString(
+  value: Record<string, unknown>,
+  fieldName: string,
+  sourceName: string,
+  invalidReason: string[]
+): string | undefined {
+  const fieldValue = value[fieldName];
+
+  if (typeof fieldValue !== 'string' || fieldValue.length === 0) {
+    invalidReason.push(`${sourceName} ${fieldName} must be a non-empty string`);
+    return undefined;
+  }
+
+  return fieldValue;
+}
+
+function requiredInteger(
+  value: Record<string, unknown>,
+  fieldName: string,
+  sourceName: string,
+  invalidReason: string[]
+): number | undefined {
+  const fieldValue = value[fieldName];
+
+  if (typeof fieldValue !== 'number' || !Number.isInteger(fieldValue)) {
+    invalidReason.push(`${sourceName} ${fieldName} must be an integer`);
+    return undefined;
+  }
+
+  return fieldValue;
+}
+
+function requiredBenchmarkStatus(
+  value: unknown,
+  sourceName: string,
+  invalidReason: string[]
+): BenchmarkStatus | undefined {
+  if (isBenchmarkStatus(value)) {
+    return value;
+  }
+
+  invalidReason.push(`${sourceName} must be passed, failed, disallowed, or error`);
+  return undefined;
+}
+
+function isBenchmarkStatus(value: unknown): value is BenchmarkStatus {
+  return value === 'passed' || value === 'failed' || value === 'disallowed' || value === 'error';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function invalidReasonsForTrialId(id: string): string[] {
+  return RESEARCH_TRIAL_ID_PATTERN.test(id) ? [] : [`invalid research trial id: ${id}`];
+}
+
+function invalidResearchTrial(cwd: string, trialDir: string, id: string, invalidReason: string[]): InvalidResearchTrial {
+  return {
+    kind: 'invalid',
+    id,
+    status: 'invalid',
+    invalidReason,
+    path: toPosixPath(path.relative(cwd, trialDir))
+  };
+}
+
+function toPosixPath(filePath: string): string {
+  return filePath.split(path.sep).join('/');
+}
+
+function compareResearchTrials(left: ResearchTrial, right: ResearchTrial): number {
+  const timestampOrder = timestampPart(right.id).localeCompare(timestampPart(left.id));
+
+  return timestampOrder === 0 ? left.id.localeCompare(right.id) : timestampOrder;
+}
+
+function timestampPart(id: string): string {
+  return RESEARCH_TRIAL_TIMESTAMP_PATTERN.exec(id)?.[1] ?? '';
+}

--- a/src/research_report.ts
+++ b/src/research_report.ts
@@ -116,10 +116,18 @@ function readJsonObject(filePath: string, displayName: string): JsonObjectReadRe
     return { invalidReason: [`${displayName} is missing`] };
   }
 
+  let contents: string;
+
+  try {
+    contents = readFileSync(filePath, 'utf8');
+  } catch {
+    return { invalidReason: [`${displayName} could not be read`] };
+  }
+
   let value: unknown;
 
   try {
-    value = JSON.parse(readFileSync(filePath, 'utf8')) as unknown;
+    value = JSON.parse(contents) as unknown;
   } catch {
     return { invalidReason: [`${displayName} is not valid JSON`] };
   }

--- a/test/typescript/research_report.test.ts
+++ b/test/typescript/research_report.test.ts
@@ -236,6 +236,25 @@ describe('research report reader', () => {
     });
   });
 
+  it('marks unreadable research trial JSON files invalid', async () => {
+    await withTempDir(async (dir) => {
+      const unreadableMetadataId = '2026-06-30T123456Z-unreadable-metadata';
+      const unreadableResultId = '2026-06-30T123457Z-unreadable-result';
+      const unreadableMetadataDir = await makeResearchTrialDir(dir, unreadableMetadataId);
+      const unreadableResultDir = await makeResearchTrialDir(dir, unreadableResultId);
+
+      await mkdir(path.join(unreadableMetadataDir, 'metadata.json'));
+      await writeJsonFile(path.join(unreadableMetadataDir, 'result.json'), researchResult());
+      await writeJsonFile(path.join(unreadableResultDir, 'metadata.json'), researchMetadata(unreadableResultId));
+      await mkdir(path.join(unreadableResultDir, 'result.json'));
+
+      assert.deepStrictEqual(invalidReasonsById(readResearchTrials({ cwd: dir })), new Map([
+        [unreadableResultId, ['result.json could not be read']],
+        [unreadableMetadataId, ['metadata.json could not be read']]
+      ]));
+    });
+  });
+
   it('marks unknown metadata schemas invalid', async () => {
     await withTempDir(async (dir) => {
       const id = '2026-06-30T123456Z-schema-v2';

--- a/test/typescript/research_report.test.ts
+++ b/test/typescript/research_report.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, it } from 'node:test';
@@ -123,6 +123,21 @@ describe('research report reader', () => {
   it('returns an empty list when research runs do not exist', async () => {
     await withTempDir(async (dir) => {
       assert.deepStrictEqual(readResearchTrials({ cwd: dir }), []);
+    });
+  });
+
+  it('returns an empty list when research runs cannot be read', async () => {
+    await withTempDir(async (dir) => {
+      const runsDir = path.join(dir, 'research', 'runs');
+
+      await mkdir(runsDir, { recursive: true });
+      await chmod(runsDir, 0o000);
+
+      try {
+        assert.deepStrictEqual(readResearchTrials({ cwd: dir }), []);
+      } finally {
+        await chmod(runsDir, 0o700);
+      }
     });
   });
 

--- a/test/typescript/research_report.test.ts
+++ b/test/typescript/research_report.test.ts
@@ -1,0 +1,300 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import { readResearchTrials, type ResearchTrial } from '../../src/research_report';
+
+async function withTempDir<T>(callback: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'qni-cli-research-report-'));
+
+  try {
+    return await callback(dir);
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+}
+
+async function writeResearchTrial(
+  dir: string,
+  id: string,
+  options: {
+    readonly benchmark?: string;
+    readonly collaborator?: string;
+    readonly status?: 'disallowed' | 'error' | 'failed' | 'passed';
+  } = {}
+): Promise<void> {
+  const status = options.status ?? 'passed';
+  const trialDir = path.join(dir, 'research', 'runs', id);
+
+  await mkdir(trialDir, { recursive: true });
+  await writeJsonFile(path.join(trialDir, 'metadata.json'), researchMetadata(id, {
+    benchmark: options.benchmark,
+    collaborator: options.collaborator,
+    status
+  }));
+  await writeJsonFile(path.join(trialDir, 'result.json'), researchResult(status));
+}
+
+function createdAtForTrialId(id: string): string {
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2})(\d{2})(\d{2})Z/u.exec(id);
+
+  if (!match) {
+    return '2026-06-30T12:34:56.000Z';
+  }
+
+  return `${match[1]}-${match[2]}-${match[3]}T${match[4]}:${match[5]}:${match[6]}.000Z`;
+}
+
+async function makeResearchTrialDir(dir: string, id: string): Promise<string> {
+  const trialDir = path.join(dir, 'research', 'runs', id);
+
+  await mkdir(trialDir, { recursive: true });
+
+  return trialDir;
+}
+
+async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function researchMetadata(
+  id: string,
+  options: {
+    readonly benchmark?: string;
+    readonly collaborator?: string;
+    readonly schemaVersion?: number;
+    readonly status?: 'disallowed' | 'error' | 'failed' | 'passed';
+  } = {}
+): Record<string, unknown> {
+  return {
+    schemaVersion: options.schemaVersion ?? 1,
+    id,
+    createdAt: createdAtForTrialId(id),
+    collaborator: options.collaborator ?? 'claude-sonnet-4',
+    benchmark: options.benchmark ?? 'benchmarks/quantum-katas',
+    submissions: 'submissions',
+    prompt: 'prompt.md',
+    response: 'response.md',
+    result: 'result.json',
+    status: options.status ?? 'passed'
+  };
+}
+
+function researchResult(
+  status: 'disallowed' | 'error' | 'failed' | 'passed' = 'passed',
+  options: {
+    readonly summaryTotal?: number;
+  } = {}
+): Record<string, unknown> {
+  return {
+    status,
+    exitCode: status === 'passed' ? 0 : 1,
+    summary: {
+      total: options.summaryTotal ?? 1,
+      passed: status === 'passed' ? 1 : 0,
+      failed: status === 'failed' ? 1 : 0,
+      disallowed: status === 'disallowed' ? 1 : 0,
+      error: status === 'error' ? 1 : 0
+    },
+    results: [
+      {
+        task: 'basic-gates/state-flip.md',
+        taskId: 'basic-gates/state-flip',
+        title: 'StateFlip',
+        submission: 'submissions/basic-gates/state-flip.qni',
+        status,
+        exitCode: status === 'passed' ? 0 : 1,
+        checks: [{ type: 'run', status: status === 'passed' ? 'passed' : 'failed' }]
+      }
+    ]
+  };
+}
+
+function invalidReasonsById(trials: readonly ResearchTrial[]): Map<string, string[]> {
+  return new Map(trials.map((trial) => [
+    trial.id,
+    trial.kind === 'invalid' ? trial.invalidReason : []
+  ]));
+}
+
+describe('research report reader', () => {
+  it('returns an empty list when research runs do not exist', async () => {
+    await withTempDir(async (dir) => {
+      assert.deepStrictEqual(readResearchTrials({ cwd: dir }), []);
+    });
+  });
+
+  it('ignores files directly under research/runs', async () => {
+    await withTempDir(async (dir) => {
+      const id = '2026-06-30T123456Z-smoke-claude';
+
+      await mkdir(path.join(dir, 'research', 'runs'), { recursive: true });
+      await writeFile(path.join(dir, 'research', 'runs', 'README.txt'), 'note\n');
+      await writeResearchTrial(dir, id);
+
+      assert.deepStrictEqual(readResearchTrials({ cwd: dir }).map((trial) => trial.id), [id]);
+    });
+  });
+
+  it('sorts research trial candidates by timestamp descending', async () => {
+    await withTempDir(async (dir) => {
+      await writeResearchTrial(dir, '2026-06-30T123456Z-older');
+      await writeResearchTrial(dir, '2026-07-01T000001Z-newer');
+
+      assert.deepStrictEqual(readResearchTrials({ cwd: dir }).map((trial) => trial.id), [
+        '2026-07-01T000001Z-newer',
+        '2026-06-30T123456Z-older'
+      ]);
+    });
+  });
+
+  it('reads valid research trials with report fields', async () => {
+    await withTempDir(async (dir) => {
+      const id = '2026-06-30T123456Z-smoke-claude';
+
+      await writeResearchTrial(dir, id);
+
+      const trials = readResearchTrials({ cwd: dir });
+      const trial = trials[0] as ResearchTrial | undefined;
+
+      assert.equal(trials.length, 1);
+      assert.equal(trial?.kind, 'valid');
+      if (trial?.kind !== 'valid') {
+        assert.fail('expected a valid research trial');
+      }
+      assert.deepStrictEqual(trial, {
+        kind: 'valid',
+        id,
+        createdAt: '2026-06-30T12:34:56.000Z',
+        collaborator: 'claude-sonnet-4',
+        benchmark: 'benchmarks/quantum-katas',
+        status: 'passed',
+        summary: {
+          total: 1,
+          passed: 1,
+          failed: 0,
+          disallowed: 0,
+          error: 0
+        },
+        path: `research/runs/${id}`
+      });
+    });
+  });
+
+  it('keeps research trial candidates with invalid ids', async () => {
+    await withTempDir(async (dir) => {
+      await writeResearchTrial(dir, 'broken-trial');
+
+      const trials = readResearchTrials({ cwd: dir });
+      const trial = trials[0] as ResearchTrial | undefined;
+
+      assert.equal(trials.length, 1);
+      assert.equal(trial?.kind, 'invalid');
+      if (trial?.kind !== 'invalid') {
+        assert.fail('expected an invalid research trial');
+      }
+      assert.equal(trial.status, 'invalid');
+      assert.deepStrictEqual(trial.invalidReason, ['invalid research trial id: broken-trial']);
+    });
+  });
+
+  it('marks missing research trial JSON files invalid', async () => {
+    await withTempDir(async (dir) => {
+      const missingMetadataId = '2026-06-30T123456Z-missing-metadata';
+      const missingResultId = '2026-06-30T123457Z-missing-result';
+      const missingMetadataDir = await makeResearchTrialDir(dir, missingMetadataId);
+      const missingResultDir = await makeResearchTrialDir(dir, missingResultId);
+
+      await writeJsonFile(path.join(missingMetadataDir, 'result.json'), researchResult());
+      await writeJsonFile(path.join(missingResultDir, 'metadata.json'), researchMetadata(missingResultId));
+
+      assert.deepStrictEqual(invalidReasonsById(readResearchTrials({ cwd: dir })), new Map([
+        [missingResultId, ['result.json is missing']],
+        [missingMetadataId, ['metadata.json is missing']]
+      ]));
+    });
+  });
+
+  it('marks malformed research trial JSON files invalid', async () => {
+    await withTempDir(async (dir) => {
+      const malformedMetadataId = '2026-06-30T123456Z-malformed-metadata';
+      const malformedResultId = '2026-06-30T123457Z-malformed-result';
+      const malformedMetadataDir = await makeResearchTrialDir(dir, malformedMetadataId);
+      const malformedResultDir = await makeResearchTrialDir(dir, malformedResultId);
+
+      await writeFile(path.join(malformedMetadataDir, 'metadata.json'), '{\n');
+      await writeJsonFile(path.join(malformedMetadataDir, 'result.json'), researchResult());
+      await writeJsonFile(path.join(malformedResultDir, 'metadata.json'), researchMetadata(malformedResultId));
+      await writeFile(path.join(malformedResultDir, 'result.json'), '{\n');
+
+      assert.deepStrictEqual(invalidReasonsById(readResearchTrials({ cwd: dir })), new Map([
+        [malformedResultId, ['result.json is not valid JSON']],
+        [malformedMetadataId, ['metadata.json is not valid JSON']]
+      ]));
+    });
+  });
+
+  it('marks unknown metadata schemas invalid', async () => {
+    await withTempDir(async (dir) => {
+      const id = '2026-06-30T123456Z-schema-v2';
+      const trialDir = await makeResearchTrialDir(dir, id);
+
+      await writeJsonFile(path.join(trialDir, 'metadata.json'), researchMetadata(id, { schemaVersion: 2 }));
+      await writeJsonFile(path.join(trialDir, 'result.json'), researchResult());
+
+      assert.deepStrictEqual(invalidReasonsById(readResearchTrials({ cwd: dir })).get(id), [
+        'unsupported metadata schemaVersion: 2'
+      ]);
+    });
+  });
+
+  it('marks metadata and result status mismatches invalid', async () => {
+    await withTempDir(async (dir) => {
+      const id = '2026-06-30T123456Z-status-mismatch';
+      const trialDir = await makeResearchTrialDir(dir, id);
+
+      await writeJsonFile(path.join(trialDir, 'metadata.json'), researchMetadata(id, { status: 'passed' }));
+      await writeJsonFile(path.join(trialDir, 'result.json'), researchResult('failed'));
+
+      assert.deepStrictEqual(invalidReasonsById(readResearchTrials({ cwd: dir })).get(id), [
+        'metadata status passed does not match result status failed'
+      ]);
+    });
+  });
+
+  it('marks result summary totals that do not match result count invalid', async () => {
+    await withTempDir(async (dir) => {
+      const id = '2026-06-30T123456Z-summary-mismatch';
+      const trialDir = await makeResearchTrialDir(dir, id);
+
+      await writeJsonFile(path.join(trialDir, 'metadata.json'), researchMetadata(id));
+      await writeJsonFile(path.join(trialDir, 'result.json'), researchResult('passed', { summaryTotal: 2 }));
+
+      assert.deepStrictEqual(invalidReasonsById(readResearchTrials({ cwd: dir })).get(id), [
+        'result summary total 2 does not match results length 1'
+      ]);
+    });
+  });
+
+  it('does not rewrite research trial files while reading invalid candidates', async () => {
+    await withTempDir(async (dir) => {
+      const id = '2026-06-30T123456Z-malformed-result';
+      const trialDir = await makeResearchTrialDir(dir, id);
+      const metadataPath = path.join(trialDir, 'metadata.json');
+      const resultPath = path.join(trialDir, 'result.json');
+
+      await writeJsonFile(metadataPath, researchMetadata(id));
+      await writeFile(resultPath, '{\n');
+
+      const metadataBefore = await readFile(metadataPath, 'utf8');
+      const resultBefore = await readFile(resultPath, 'utf8');
+
+      readResearchTrials({ cwd: dir });
+
+      assert.equal(await readFile(metadataPath, 'utf8'), metadataBefore);
+      assert.equal(await readFile(resultPath, 'utf8'), resultBefore);
+    });
+  });
+});

--- a/test/typescript/research_report.test.ts
+++ b/test/typescript/research_report.test.ts
@@ -284,6 +284,42 @@ describe('research report reader', () => {
     });
   });
 
+  it('marks metadata ids that do not match trial directories invalid', async () => {
+    await withTempDir(async (dir) => {
+      const id = '2026-06-30T123456Z-id-mismatch';
+      const metadataId = '2026-06-30T123456Z-other-trial';
+      const trialDir = await makeResearchTrialDir(dir, id);
+
+      await writeJsonFile(path.join(trialDir, 'metadata.json'), {
+        ...researchMetadata(id),
+        id: metadataId
+      });
+      await writeJsonFile(path.join(trialDir, 'result.json'), researchResult());
+
+      assert.deepStrictEqual(invalidReasonsById(readResearchTrials({ cwd: dir })).get(id), [
+        `metadata id ${metadataId} does not match research trial id ${id}`
+      ]);
+    });
+  });
+
+  it('marks metadata result paths that do not point to result.json invalid', async () => {
+    await withTempDir(async (dir) => {
+      const id = '2026-06-30T123456Z-result-path-mismatch';
+      const resultPath = 'other-result.json';
+      const trialDir = await makeResearchTrialDir(dir, id);
+
+      await writeJsonFile(path.join(trialDir, 'metadata.json'), {
+        ...researchMetadata(id),
+        result: resultPath
+      });
+      await writeJsonFile(path.join(trialDir, 'result.json'), researchResult());
+
+      assert.deepStrictEqual(invalidReasonsById(readResearchTrials({ cwd: dir })).get(id), [
+        `metadata result ${resultPath} does not point to result.json`
+      ]);
+    });
+  });
+
   it('marks metadata and result status mismatches invalid', async () => {
     await withTempDir(async (dir) => {
       const id = '2026-06-30T123456Z-status-mismatch';


### PR DESCRIPTION
## 概要

研究試行レポートの土台として、`research/runs/` 配下の保存済み研究試行を読み取る reader を追加しました。
保存済みファイルは再採点や修復をせず、valid / invalid の一覧として返すことで、後続の集計や表示が同じ入口を使えるようにしています。
壊れた候補も捨てずに `invalidReason` 付きで保持します。

Closes #299

## 変更内容

- `src/research_report.ts` に `readResearchTrials({ cwd })` を追加し、研究試行候補の読み取り、整列、valid / invalid 判定を実装
- `test/typescript/research_report.test.ts` で valid 読み取り、欠落ファイル、壊れた JSON、schemaVersion、status 不一致、summary 件数不一致などを検証
- `features/cli/research_report_reader.feature.md` を追加し、reader の受け入れ仕様を記述
- `features/step_definitions/cli_steps.js` に研究試行候補の fixture 作成と reader 検証ステップを追加

## 確認

- `npm run check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 研究試行レポートの読み取り機能を追加し、保存済みの実行候補を一覧表示できるようになりました。
  * 実行候補は新しい順に並び、無効な候補も状態付きで保持されます。
* **不具合修正**
  * 実行ログが存在しない場合は空として扱うようになりました。
  * ルート直下の参照ファイルを実行候補として誤認しないようになりました。
  * 不正なIDや不整合な内容は、理由を含めて無効として返されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->