### PR TITLE
研究試行レポートをJSON出力できるようにする

### DIFF
--- a/features/cli/research_report_json.feature.md
+++ b/features/cli/research_report_json.feature.md
@@ -1,0 +1,134 @@
+# Feature: qni research report JSON
+
+qni-cli の利用者として
+保存済み研究試行を機械処理できるように
+qni research report --json で集計済み JSON を出力したい。
+
+## Scenario: 研究試行が無い場合も空の JSON レポートを出力する
+
+- When "qni research report --json" を実行
+- Then 標準出力は次の JSON と一致する:
+
+  ```json
+  {
+    "schemaVersion": 1,
+    "trialSummary": {
+      "passed": 0,
+      "failed": 0,
+      "disallowed": 0,
+      "error": 0,
+      "invalid": 0,
+      "total": 0
+    },
+    "taskSummary": {
+      "passed": 0,
+      "failed": 0,
+      "disallowed": 0,
+      "error": 0,
+      "total": 0
+    },
+    "trials": []
+  }
+  ```
+
+## Scenario: 研究試行が無い場合は成功する
+
+- When "qni research report --json" を実行
+- Then コマンドは成功
+
+## Scenario: 有効な研究試行を集計する
+
+- Given 有効な研究試行 "2026-06-30T123456Z-smoke-claude" を研究ログに保存済み
+- When "qni research report --json" を実行
+- Then 標準出力は次の JSON と一致する:
+
+  ```json
+  {
+    "schemaVersion": 1,
+    "trialSummary": {
+      "passed": 1,
+      "failed": 0,
+      "disallowed": 0,
+      "error": 0,
+      "invalid": 0,
+      "total": 1
+    },
+    "taskSummary": {
+      "passed": 1,
+      "failed": 0,
+      "disallowed": 0,
+      "error": 0,
+      "total": 1
+    },
+    "trials": [
+      {
+        "id": "2026-06-30T123456Z-smoke-claude",
+        "createdAt": "2026-06-30T12:34:56.000Z",
+        "collaborator": "claude-sonnet-4",
+        "benchmark": "benchmarks/quantum-katas",
+        "status": "passed",
+        "summary": {
+          "passed": 1,
+          "failed": 0,
+          "disallowed": 0,
+          "error": 0,
+          "total": 1
+        },
+        "path": "research/runs/2026-06-30T123456Z-smoke-claude"
+      }
+    ]
+  }
+  ```
+
+## Scenario: 無効な研究試行がある場合も JSON レポートを出力する
+
+- Given 無効な研究試行候補 "broken-trial" を研究ログに保存済み
+- When "qni research report --json" を実行
+- Then 標準出力は次の JSON と一致する:
+
+  ```json
+  {
+    "schemaVersion": 1,
+    "trialSummary": {
+      "passed": 0,
+      "failed": 0,
+      "disallowed": 0,
+      "error": 0,
+      "invalid": 1,
+      "total": 1
+    },
+    "taskSummary": {
+      "passed": 0,
+      "failed": 0,
+      "disallowed": 0,
+      "error": 0,
+      "total": 0
+    },
+    "trials": [
+      {
+        "id": "broken-trial",
+        "createdAt": null,
+        "collaborator": null,
+        "benchmark": null,
+        "status": "invalid",
+        "summary": {
+          "passed": 0,
+          "failed": 0,
+          "disallowed": 0,
+          "error": 0,
+          "total": 0
+        },
+        "path": "research/runs/broken-trial",
+        "invalidReason": [
+          "invalid research trial id: broken-trial"
+        ]
+      }
+    ]
+  }
+  ```
+
+## Scenario: 無効な研究試行がある場合は終了コード 1 を返す
+
+- Given 無効な研究試行候補 "broken-trial" を研究ログに保存済み
+- When "qni research report --json" を実行
+- Then 終了コードは 1

--- a/src/commands/research_command.ts
+++ b/src/commands/research_command.ts
@@ -3,6 +3,7 @@ import path = require('node:path');
 
 import type { CommandHandlerContext } from '../dispatcher';
 import { gradeBenchmarkSuite, type BenchmarkSuiteGradingResult } from '../evaluation_runner';
+import { buildResearchReport, readResearchTrialsForReport } from '../research_report';
 
 interface ResearchRecordRequest {
   readonly benchmark: string;
@@ -82,6 +83,10 @@ export function runResearchCommand(argv: string[], context: CommandHandlerContex
     return 0;
   }
 
+  if (isResearchReportJsonRequest(argv)) {
+    return runResearchReportJson(context);
+  }
+
   const request = parseResearchRecordRequest(argv);
 
   if (!request) {
@@ -91,6 +96,22 @@ export function runResearchCommand(argv: string[], context: CommandHandlerContex
 
   try {
     return recordResearchTrial(request, context);
+  } catch (error) {
+    process.stderr.write(`${errorMessage(error)}\n`);
+    return 3;
+  }
+}
+
+function isResearchReportJsonRequest(argv: readonly string[]): boolean {
+  return argv[0] === 'research' && argv[1] === 'report' && argv.length === 3 && argv[2] === '--json';
+}
+
+function runResearchReportJson(context: CommandHandlerContext): number {
+  try {
+    const report = buildResearchReport(readResearchTrialsForReport({ cwd: context.cwd }));
+
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    return report.trialSummary.invalid > 0 ? 1 : 0;
   } catch (error) {
     process.stderr.write(`${errorMessage(error)}\n`);
     return 3;

--- a/src/research_report.ts
+++ b/src/research_report.ts
@@ -7,6 +7,45 @@ export interface ReadResearchTrialsOptions {
   readonly cwd: string;
 }
 
+export interface ResearchReport {
+  readonly schemaVersion: 1;
+  readonly taskSummary: BenchmarkSuiteSummary;
+  readonly trials: readonly ResearchReportTrial[];
+  readonly trialSummary: ResearchReportTrialSummary;
+}
+
+export type ResearchReportTrial = ResearchReportValidTrial | ResearchReportInvalidTrial;
+
+export interface ResearchReportValidTrial {
+  readonly benchmark: string;
+  readonly collaborator: string;
+  readonly createdAt: string;
+  readonly id: string;
+  readonly path: string;
+  readonly status: BenchmarkStatus;
+  readonly summary: BenchmarkSuiteSummary;
+}
+
+export interface ResearchReportInvalidTrial {
+  readonly benchmark: null;
+  readonly collaborator: null;
+  readonly createdAt: null;
+  readonly id: string;
+  readonly invalidReason: readonly string[];
+  readonly path: string;
+  readonly status: 'invalid';
+  readonly summary: BenchmarkSuiteSummary;
+}
+
+export interface ResearchReportTrialSummary {
+  readonly disallowed: number;
+  readonly error: number;
+  readonly failed: number;
+  readonly invalid: number;
+  readonly passed: number;
+  readonly total: number;
+}
+
 export type ResearchTrial = ValidResearchTrial | InvalidResearchTrial;
 
 export interface ValidResearchTrial {
@@ -52,17 +91,75 @@ const RESEARCH_RUNS_PATH = path.join('research', 'runs');
 const RESEARCH_TRIAL_TIMESTAMP_PATTERN = /^(\d{4}-\d{2}-\d{2}T\d{6}Z)/u;
 const RESEARCH_TRIAL_ID_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{6}Z-[a-z0-9]+(?:-[a-z0-9]+)*$/u;
 
+export function buildResearchReport(trials: readonly ResearchTrial[]): ResearchReport {
+  const trialSummary = emptyResearchReportTrialSummary();
+  const taskSummary = emptyBenchmarkSuiteSummary();
+
+  for (const trial of trials) {
+    addTrialStatus(trialSummary, trial.status);
+
+    if (trial.kind === 'valid') {
+      addBenchmarkSuiteSummary(taskSummary, trial.summary);
+    }
+  }
+
+  return {
+    schemaVersion: 1,
+    trialSummary,
+    taskSummary,
+    trials: trials.map((trial) => researchReportTrial(trial))
+  };
+}
+
 export function readResearchTrials(options: ReadResearchTrialsOptions): ResearchTrial[] {
+  try {
+    return readResearchTrialsFromRunsDir(options, { strict: false });
+  } catch {
+    return [];
+  }
+}
+
+export function readResearchTrialsForReport(options: ReadResearchTrialsOptions): ResearchTrial[] {
+  return readResearchTrialsFromRunsDir(options, { strict: true });
+}
+
+function readResearchTrialsFromRunsDir(
+  options: ReadResearchTrialsOptions,
+  readOptions: { readonly strict: boolean }
+): ResearchTrial[] {
   const runsDir = path.join(options.cwd, RESEARCH_RUNS_PATH);
   let entries: Dirent[];
+  let runsDirStats: ReturnType<typeof statSync>;
 
   try {
-    if (!statSync(runsDir).isDirectory()) {
+    runsDirStats = statSync(runsDir);
+  } catch (error) {
+    if (isMissingPathError(error)) {
       return [];
     }
 
+    if (readOptions.strict) {
+      throw new Error(`Research runs path could not be read: ${RESEARCH_RUNS_PATH}`);
+    }
+
+    return [];
+  }
+
+  if (!runsDirStats.isDirectory()) {
+    if (readOptions.strict) {
+      throw new Error(`Research runs path is not a directory: ${RESEARCH_RUNS_PATH}`);
+    }
+
+    return [];
+  }
+
+  try {
     entries = readdirSync(runsDir, { withFileTypes: true });
   } catch {
+    if (readOptions.strict) {
+      throw new Error(`Research runs path could not be read: ${RESEARCH_RUNS_PATH}`);
+    }
+
     return [];
   }
 
@@ -70,6 +167,100 @@ export function readResearchTrials(options: ReadResearchTrialsOptions): Research
     .filter((entry) => entry.isDirectory())
     .map((entry) => readResearchTrial(options.cwd, path.join(runsDir, entry.name), entry.name))
     .sort(compareResearchTrials);
+}
+
+function emptyResearchReportTrialSummary(): {
+  disallowed: number;
+  error: number;
+  failed: number;
+  invalid: number;
+  passed: number;
+  total: number;
+} {
+  return {
+    passed: 0,
+    failed: 0,
+    disallowed: 0,
+    error: 0,
+    invalid: 0,
+    total: 0
+  };
+}
+
+function emptyBenchmarkSuiteSummary(): {
+  disallowed: number;
+  error: number;
+  failed: number;
+  passed: number;
+  total: number;
+} {
+  return {
+    passed: 0,
+    failed: 0,
+    disallowed: 0,
+    error: 0,
+    total: 0
+  };
+}
+
+function addTrialStatus(summary: {
+  disallowed: number;
+  error: number;
+  failed: number;
+  invalid: number;
+  passed: number;
+  total: number;
+}, status: BenchmarkStatus | 'invalid'): void {
+  summary[status] += 1;
+  summary.total += 1;
+}
+
+function addBenchmarkSuiteSummary(
+  target: {
+    disallowed: number;
+    error: number;
+    failed: number;
+    passed: number;
+    total: number;
+  },
+  source: BenchmarkSuiteSummary
+): void {
+  target.passed += source.passed;
+  target.failed += source.failed;
+  target.disallowed += source.disallowed;
+  target.error += source.error;
+  target.total += source.total;
+}
+
+function researchReportTrial(trial: ResearchTrial): ResearchReportTrial {
+  if (trial.kind === 'invalid') {
+    return {
+      id: trial.id,
+      createdAt: null,
+      collaborator: null,
+      benchmark: null,
+      status: 'invalid',
+      summary: emptyBenchmarkSuiteSummary(),
+      path: trial.path,
+      invalidReason: trial.invalidReason
+    };
+  }
+
+  return {
+    id: trial.id,
+    createdAt: trial.createdAt,
+    collaborator: trial.collaborator,
+    benchmark: trial.benchmark,
+    status: trial.status,
+    summary: {
+      passed: trial.summary.passed,
+      failed: trial.summary.failed,
+      disallowed: trial.summary.disallowed,
+      error: trial.summary.error,
+      total: trial.summary.total
+    },
+    path: trial.path
+  };
 }
 
 function readResearchTrial(cwd: string, trialDir: string, id: string): ResearchTrial {
@@ -285,6 +476,14 @@ function isBenchmarkStatus(value: unknown): value is BenchmarkStatus {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return isErrnoException(error) && error.code === 'ENOENT';
+}
+
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
 }
 
 function invalidReasonsForTrialId(id: string): string[] {

--- a/src/research_report.ts
+++ b/src/research_report.ts
@@ -87,6 +87,7 @@ interface JsonObjectReadResult {
   readonly value?: Record<string, unknown>;
 }
 
+const RESEARCH_RUNS_DISPLAY_PATH = 'research/runs';
 const RESEARCH_RUNS_PATH = path.join('research', 'runs');
 const RESEARCH_TRIAL_TIMESTAMP_PATTERN = /^(\d{4}-\d{2}-\d{2}T\d{6}Z)/u;
 const RESEARCH_TRIAL_ID_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{6}Z-[a-z0-9]+(?:-[a-z0-9]+)*$/u;
@@ -112,11 +113,7 @@ export function buildResearchReport(trials: readonly ResearchTrial[]): ResearchR
 }
 
 export function readResearchTrials(options: ReadResearchTrialsOptions): ResearchTrial[] {
-  try {
-    return readResearchTrialsFromRunsDir(options, { strict: false });
-  } catch {
-    return [];
-  }
+  return readResearchTrialsFromRunsDir(options, { strict: false });
 }
 
 export function readResearchTrialsForReport(options: ReadResearchTrialsOptions): ResearchTrial[] {
@@ -139,7 +136,7 @@ function readResearchTrialsFromRunsDir(
     }
 
     if (readOptions.strict) {
-      throw new Error(`Research runs path could not be read: ${RESEARCH_RUNS_PATH}`);
+      throw new Error(`Research runs path could not be read: ${RESEARCH_RUNS_DISPLAY_PATH}`);
     }
 
     return [];
@@ -147,7 +144,7 @@ function readResearchTrialsFromRunsDir(
 
   if (!runsDirStats.isDirectory()) {
     if (readOptions.strict) {
-      throw new Error(`Research runs path is not a directory: ${RESEARCH_RUNS_PATH}`);
+      throw new Error(`Research runs path is not a directory: ${RESEARCH_RUNS_DISPLAY_PATH}`);
     }
 
     return [];
@@ -157,7 +154,7 @@ function readResearchTrialsFromRunsDir(
     entries = readdirSync(runsDir, { withFileTypes: true });
   } catch {
     if (readOptions.strict) {
-      throw new Error(`Research runs path could not be read: ${RESEARCH_RUNS_PATH}`);
+      throw new Error(`Research runs path could not be read: ${RESEARCH_RUNS_DISPLAY_PATH}`);
     }
 
     return [];

--- a/test/typescript/helpers/research_trial.ts
+++ b/test/typescript/helpers/research_trial.ts
@@ -1,0 +1,116 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+export type StoredResearchStatus = 'disallowed' | 'error' | 'failed' | 'passed';
+
+export async function writeStoredResearchTrial(
+  dir: string,
+  id: string,
+  options: {
+    readonly benchmark?: string;
+    readonly collaborator?: string;
+    readonly status?: StoredResearchStatus;
+    readonly summaryTotal?: number;
+  } = {}
+): Promise<void> {
+  const status = options.status ?? 'passed';
+  const trialDir = await makeStoredResearchTrialDir(dir, id);
+
+  await writeJsonFile(path.join(trialDir, 'metadata.json'), storedResearchMetadata(id, {
+    benchmark: options.benchmark,
+    collaborator: options.collaborator,
+    status
+  }));
+  await writeJsonFile(path.join(trialDir, 'result.json'), storedResearchResult(status, {
+    summaryTotal: options.summaryTotal
+  }));
+}
+
+export async function makeStoredResearchTrialDir(dir: string, id: string): Promise<string> {
+  const trialDir = path.join(dir, 'research', 'runs', id);
+
+  await mkdir(trialDir, { recursive: true });
+
+  return trialDir;
+}
+
+export async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+export function storedResearchMetadata(
+  id: string,
+  options: {
+    readonly benchmark?: string;
+    readonly collaborator?: string;
+    readonly result?: string;
+    readonly schemaVersion?: number;
+    readonly status?: StoredResearchStatus;
+  } = {}
+): Record<string, unknown> {
+  return {
+    schemaVersion: options.schemaVersion ?? 1,
+    id,
+    createdAt: createdAtForResearchTrialId(id),
+    collaborator: options.collaborator ?? 'claude-sonnet-4',
+    benchmark: options.benchmark ?? 'benchmarks/quantum-katas',
+    submissions: 'submissions',
+    prompt: 'prompt.md',
+    response: 'response.md',
+    result: options.result ?? 'result.json',
+    status: options.status ?? 'passed'
+  };
+}
+
+export function storedResearchResult(
+  status: StoredResearchStatus = 'passed',
+  options: {
+    readonly summaryTotal?: number;
+  } = {}
+): Record<string, unknown> {
+  return {
+    status,
+    exitCode: researchStatusExitCode(status),
+    summary: {
+      total: options.summaryTotal ?? 1,
+      passed: status === 'passed' ? 1 : 0,
+      failed: status === 'failed' ? 1 : 0,
+      disallowed: status === 'disallowed' ? 1 : 0,
+      error: status === 'error' ? 1 : 0
+    },
+    results: [
+      {
+        task: 'basic-gates/state-flip.md',
+        taskId: 'basic-gates/state-flip',
+        title: 'StateFlip',
+        submission: 'submissions/basic-gates/state-flip.qni',
+        status,
+        exitCode: researchStatusExitCode(status),
+        checks: [{ type: 'run', status: status === 'passed' ? 'passed' : 'failed' }]
+      }
+    ]
+  };
+}
+
+export function createdAtForResearchTrialId(id: string): string {
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2})(\d{2})(\d{2})Z/u.exec(id);
+
+  if (!match) {
+    return '2026-06-30T12:34:56.000Z';
+  }
+
+  return `${match[1]}-${match[2]}-${match[3]}T${match[4]}:${match[5]}:${match[6]}.000Z`;
+}
+
+export function researchStatusExitCode(status: StoredResearchStatus): number {
+  switch (status) {
+    case 'passed':
+      return 0;
+    case 'failed':
+      return 1;
+    case 'disallowed':
+      return 2;
+    case 'error':
+      return 3;
+  }
+}

--- a/test/typescript/research_command.test.ts
+++ b/test/typescript/research_command.test.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { describe, it } from 'node:test';
 
 import { createDispatcher } from '../../src/dispatcher';
+import { type StoredResearchStatus, writeStoredResearchTrial } from './helpers/research_trial';
 
 interface CapturedRun {
   readonly exitStatus: number;
@@ -19,8 +20,7 @@ interface CapturedValue<T> {
   readonly value: T;
 }
 
-type UnsuccessfulResearchStatus = 'disallowed' | 'error' | 'failed';
-type StoredResearchStatus = UnsuccessfulResearchStatus | 'passed';
+type UnsuccessfulResearchStatus = Exclude<StoredResearchStatus, 'passed'>;
 
 const UNSUCCESSFUL_RESEARCH_TRIAL_CASES: readonly {
   readonly exitCode: number;
@@ -194,80 +194,6 @@ async function readJsonFile(filePath: string): Promise<Record<string, unknown>> 
   return JSON.parse(await readFile(filePath, 'utf8')) as Record<string, unknown>;
 }
 
-async function writeStoredResearchTrial(
-  dir: string,
-  id: string,
-  options: {
-    readonly status?: StoredResearchStatus;
-  } = {}
-): Promise<void> {
-  const status = options.status ?? 'passed';
-  const trialDir = path.join(dir, 'research', 'runs', id);
-
-  await mkdir(trialDir, { recursive: true });
-  await writeJsonFile(path.join(trialDir, 'metadata.json'), {
-    schemaVersion: 1,
-    id,
-    createdAt: createdAtForResearchTrialId(id),
-    collaborator: 'claude-sonnet-4',
-    benchmark: 'benchmarks/quantum-katas',
-    submissions: 'submissions',
-    prompt: 'prompt.md',
-    response: 'response.md',
-    result: 'result.json',
-    status
-  });
-  await writeJsonFile(path.join(trialDir, 'result.json'), {
-    status,
-    exitCode: researchStatusExitCode(status),
-    summary: {
-      total: 1,
-      passed: status === 'passed' ? 1 : 0,
-      failed: status === 'failed' ? 1 : 0,
-      disallowed: status === 'disallowed' ? 1 : 0,
-      error: status === 'error' ? 1 : 0
-    },
-    results: [
-      {
-        task: 'basic-gates/state-flip.md',
-        taskId: 'basic-gates/state-flip',
-        title: 'StateFlip',
-        submission: 'submissions/basic-gates/state-flip.qni',
-        status,
-        exitCode: researchStatusExitCode(status),
-        checks: [{ type: 'run', status: status === 'passed' ? 'passed' : 'failed' }]
-      }
-    ]
-  });
-}
-
-async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
-  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`);
-}
-
-function createdAtForResearchTrialId(id: string): string {
-  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2})(\d{2})(\d{2})Z/u.exec(id);
-
-  if (!match) {
-    return '2026-06-30T12:34:56.000Z';
-  }
-
-  return `${match[1]}-${match[2]}-${match[3]}T${match[4]}:${match[5]}:${match[6]}.000Z`;
-}
-
-function researchStatusExitCode(status: StoredResearchStatus): number {
-  switch (status) {
-    case 'passed':
-      return 0;
-    case 'failed':
-      return 1;
-    case 'disallowed':
-      return 2;
-    case 'error':
-      return 3;
-  }
-}
-
 function git(cwd: string, args: readonly string[]): string {
   return execFileSync('git', [...args], { cwd, encoding: 'utf8' }).trim();
 }
@@ -313,6 +239,52 @@ describe('research command TypeScript route', () => {
           total: 0
         },
         trials: []
+      });
+    });
+  });
+
+  it('prints a JSON research report and exits with 0 when only valid trials exist', async () => {
+    await withTempDir(async (dir) => {
+      await writeStoredResearchTrial(dir, '2026-07-01T000001Z-passed');
+
+      const result = captureDispatcherRun(dir, ['research', 'report', '--json']);
+
+      assert.equal(result.exitStatus, 0);
+      assert.equal(result.stderr, '');
+      assert.deepStrictEqual(JSON.parse(result.stdout) as unknown, {
+        schemaVersion: 1,
+        trialSummary: {
+          passed: 1,
+          failed: 0,
+          disallowed: 0,
+          error: 0,
+          invalid: 0,
+          total: 1
+        },
+        taskSummary: {
+          passed: 1,
+          failed: 0,
+          disallowed: 0,
+          error: 0,
+          total: 1
+        },
+        trials: [
+          {
+            id: '2026-07-01T000001Z-passed',
+            createdAt: '2026-07-01T00:00:01.000Z',
+            collaborator: 'claude-sonnet-4',
+            benchmark: 'benchmarks/quantum-katas',
+            status: 'passed',
+            summary: {
+              passed: 1,
+              failed: 0,
+              disallowed: 0,
+              error: 0,
+              total: 1
+            },
+            path: 'research/runs/2026-07-01T000001Z-passed'
+          }
+        ]
       });
     });
   });

--- a/test/typescript/research_command.test.ts
+++ b/test/typescript/research_command.test.ts
@@ -20,6 +20,7 @@ interface CapturedValue<T> {
 }
 
 type UnsuccessfulResearchStatus = 'disallowed' | 'error' | 'failed';
+type StoredResearchStatus = UnsuccessfulResearchStatus | 'passed';
 
 const UNSUCCESSFUL_RESEARCH_TRIAL_CASES: readonly {
   readonly exitCode: number;
@@ -193,6 +194,80 @@ async function readJsonFile(filePath: string): Promise<Record<string, unknown>> 
   return JSON.parse(await readFile(filePath, 'utf8')) as Record<string, unknown>;
 }
 
+async function writeStoredResearchTrial(
+  dir: string,
+  id: string,
+  options: {
+    readonly status?: StoredResearchStatus;
+  } = {}
+): Promise<void> {
+  const status = options.status ?? 'passed';
+  const trialDir = path.join(dir, 'research', 'runs', id);
+
+  await mkdir(trialDir, { recursive: true });
+  await writeJsonFile(path.join(trialDir, 'metadata.json'), {
+    schemaVersion: 1,
+    id,
+    createdAt: createdAtForResearchTrialId(id),
+    collaborator: 'claude-sonnet-4',
+    benchmark: 'benchmarks/quantum-katas',
+    submissions: 'submissions',
+    prompt: 'prompt.md',
+    response: 'response.md',
+    result: 'result.json',
+    status
+  });
+  await writeJsonFile(path.join(trialDir, 'result.json'), {
+    status,
+    exitCode: researchStatusExitCode(status),
+    summary: {
+      total: 1,
+      passed: status === 'passed' ? 1 : 0,
+      failed: status === 'failed' ? 1 : 0,
+      disallowed: status === 'disallowed' ? 1 : 0,
+      error: status === 'error' ? 1 : 0
+    },
+    results: [
+      {
+        task: 'basic-gates/state-flip.md',
+        taskId: 'basic-gates/state-flip',
+        title: 'StateFlip',
+        submission: 'submissions/basic-gates/state-flip.qni',
+        status,
+        exitCode: researchStatusExitCode(status),
+        checks: [{ type: 'run', status: status === 'passed' ? 'passed' : 'failed' }]
+      }
+    ]
+  });
+}
+
+async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function createdAtForResearchTrialId(id: string): string {
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2})(\d{2})(\d{2})Z/u.exec(id);
+
+  if (!match) {
+    return '2026-06-30T12:34:56.000Z';
+  }
+
+  return `${match[1]}-${match[2]}-${match[3]}T${match[4]}:${match[5]}:${match[6]}.000Z`;
+}
+
+function researchStatusExitCode(status: StoredResearchStatus): number {
+  switch (status) {
+    case 'passed':
+      return 0;
+    case 'failed':
+      return 1;
+    case 'disallowed':
+      return 2;
+    case 'error':
+      return 3;
+  }
+}
+
 function git(cwd: string, args: readonly string[]): string {
   return execFileSync('git', [...args], { cwd, encoding: 'utf8' }).trim();
 }
@@ -214,6 +289,110 @@ async function withFixedDateNow<T>(isoTimestamp: string, callback: () => Promise
 }
 
 describe('research command TypeScript route', () => {
+  it('prints an empty JSON research report when no trials exist', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, ['research', 'report', '--json']);
+
+      assert.equal(result.exitStatus, 0);
+      assert.equal(result.stderr, '');
+      assert.deepStrictEqual(JSON.parse(result.stdout) as unknown, {
+        schemaVersion: 1,
+        trialSummary: {
+          passed: 0,
+          failed: 0,
+          disallowed: 0,
+          error: 0,
+          invalid: 0,
+          total: 0
+        },
+        taskSummary: {
+          passed: 0,
+          failed: 0,
+          disallowed: 0,
+          error: 0,
+          total: 0
+        },
+        trials: []
+      });
+    });
+  });
+
+  it('prints a JSON research report and exits with 1 when a trial is invalid', async () => {
+    await withTempDir(async (dir) => {
+      await writeStoredResearchTrial(dir, '2026-07-01T000001Z-passed');
+      await writeStoredResearchTrial(dir, 'broken-trial');
+
+      const result = captureDispatcherRun(dir, ['research', 'report', '--json']);
+
+      assert.equal(result.exitStatus, 1);
+      assert.equal(result.stderr, '');
+      assert.deepStrictEqual(JSON.parse(result.stdout) as unknown, {
+        schemaVersion: 1,
+        trialSummary: {
+          passed: 1,
+          failed: 0,
+          disallowed: 0,
+          error: 0,
+          invalid: 1,
+          total: 2
+        },
+        taskSummary: {
+          passed: 1,
+          failed: 0,
+          disallowed: 0,
+          error: 0,
+          total: 1
+        },
+        trials: [
+          {
+            id: '2026-07-01T000001Z-passed',
+            createdAt: '2026-07-01T00:00:01.000Z',
+            collaborator: 'claude-sonnet-4',
+            benchmark: 'benchmarks/quantum-katas',
+            status: 'passed',
+            summary: {
+              passed: 1,
+              failed: 0,
+              disallowed: 0,
+              error: 0,
+              total: 1
+            },
+            path: 'research/runs/2026-07-01T000001Z-passed'
+          },
+          {
+            id: 'broken-trial',
+            createdAt: null,
+            collaborator: null,
+            benchmark: null,
+            status: 'invalid',
+            summary: {
+              passed: 0,
+              failed: 0,
+              disallowed: 0,
+              error: 0,
+              total: 0
+            },
+            path: 'research/runs/broken-trial',
+            invalidReason: ['invalid research trial id: broken-trial']
+          }
+        ]
+      });
+    });
+  });
+
+  it('returns exit code 3 when the research runs path cannot be read as a directory', async () => {
+    await withTempDir(async (dir) => {
+      await mkdir(path.join(dir, 'research'), { recursive: true });
+      await writeFile(path.join(dir, 'research', 'runs'), 'not a directory\n');
+
+      const result = captureDispatcherRun(dir, ['research', 'report', '--json']);
+
+      assert.equal(result.exitStatus, 3);
+      assert.equal(result.stdout, '');
+      assert.match(result.stderr, /Research runs path is not a directory: research\/runs/u);
+    });
+  });
+
   it('rejects unsafe research trial slugs before creating a trial directory', async () => {
     for (const slug of ['Smoke_Claude', 'smoke--claude', 'smoke-', '-smoke', '../escape']) {
       await withTempDir(async (dir) => {

--- a/test/typescript/research_report.test.ts
+++ b/test/typescript/research_report.test.ts
@@ -5,6 +5,13 @@ import path from 'node:path';
 import { describe, it } from 'node:test';
 
 import { buildResearchReport, readResearchTrials, type ResearchTrial } from '../../src/research_report';
+import {
+  makeStoredResearchTrialDir,
+  storedResearchMetadata,
+  storedResearchResult,
+  writeJsonFile,
+  writeStoredResearchTrial
+} from './helpers/research_trial';
 
 async function withTempDir<T>(callback: (dir: string) => Promise<T>): Promise<T> {
   const dir = await mkdtemp(path.join(tmpdir(), 'qni-cli-research-report-'));
@@ -14,102 +21,6 @@ async function withTempDir<T>(callback: (dir: string) => Promise<T>): Promise<T>
   } finally {
     await rm(dir, { force: true, recursive: true });
   }
-}
-
-async function writeResearchTrial(
-  dir: string,
-  id: string,
-  options: {
-    readonly benchmark?: string;
-    readonly collaborator?: string;
-    readonly status?: 'disallowed' | 'error' | 'failed' | 'passed';
-  } = {}
-): Promise<void> {
-  const status = options.status ?? 'passed';
-  const trialDir = path.join(dir, 'research', 'runs', id);
-
-  await mkdir(trialDir, { recursive: true });
-  await writeJsonFile(path.join(trialDir, 'metadata.json'), researchMetadata(id, {
-    benchmark: options.benchmark,
-    collaborator: options.collaborator,
-    status
-  }));
-  await writeJsonFile(path.join(trialDir, 'result.json'), researchResult(status));
-}
-
-function createdAtForTrialId(id: string): string {
-  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2})(\d{2})(\d{2})Z/u.exec(id);
-
-  if (!match) {
-    return '2026-06-30T12:34:56.000Z';
-  }
-
-  return `${match[1]}-${match[2]}-${match[3]}T${match[4]}:${match[5]}:${match[6]}.000Z`;
-}
-
-async function makeResearchTrialDir(dir: string, id: string): Promise<string> {
-  const trialDir = path.join(dir, 'research', 'runs', id);
-
-  await mkdir(trialDir, { recursive: true });
-
-  return trialDir;
-}
-
-async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
-  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`);
-}
-
-function researchMetadata(
-  id: string,
-  options: {
-    readonly benchmark?: string;
-    readonly collaborator?: string;
-    readonly schemaVersion?: number;
-    readonly status?: 'disallowed' | 'error' | 'failed' | 'passed';
-  } = {}
-): Record<string, unknown> {
-  return {
-    schemaVersion: options.schemaVersion ?? 1,
-    id,
-    createdAt: createdAtForTrialId(id),
-    collaborator: options.collaborator ?? 'claude-sonnet-4',
-    benchmark: options.benchmark ?? 'benchmarks/quantum-katas',
-    submissions: 'submissions',
-    prompt: 'prompt.md',
-    response: 'response.md',
-    result: 'result.json',
-    status: options.status ?? 'passed'
-  };
-}
-
-function researchResult(
-  status: 'disallowed' | 'error' | 'failed' | 'passed' = 'passed',
-  options: {
-    readonly summaryTotal?: number;
-  } = {}
-): Record<string, unknown> {
-  return {
-    status,
-    exitCode: status === 'passed' ? 0 : 1,
-    summary: {
-      total: options.summaryTotal ?? 1,
-      passed: status === 'passed' ? 1 : 0,
-      failed: status === 'failed' ? 1 : 0,
-      disallowed: status === 'disallowed' ? 1 : 0,
-      error: status === 'error' ? 1 : 0
-    },
-    results: [
-      {
-        task: 'basic-gates/state-flip.md',
-        taskId: 'basic-gates/state-flip',
-        title: 'StateFlip',
-        submission: 'submissions/basic-gates/state-flip.qni',
-        status,
-        exitCode: status === 'passed' ? 0 : 1,
-        checks: [{ type: 'run', status: status === 'passed' ? 'passed' : 'failed' }]
-      }
-    ]
-  };
 }
 
 function invalidReasonsById(trials: readonly ResearchTrial[]): Map<string, string[]> {
@@ -147,7 +58,7 @@ describe('research report reader', () => {
 
       await mkdir(path.join(dir, 'research', 'runs'), { recursive: true });
       await writeFile(path.join(dir, 'research', 'runs', 'README.txt'), 'note\n');
-      await writeResearchTrial(dir, id);
+      await writeStoredResearchTrial(dir, id);
 
       assert.deepStrictEqual(readResearchTrials({ cwd: dir }).map((trial) => trial.id), [id]);
     });
@@ -155,8 +66,8 @@ describe('research report reader', () => {
 
   it('sorts research trial candidates by timestamp descending', async () => {
     await withTempDir(async (dir) => {
-      await writeResearchTrial(dir, '2026-06-30T123456Z-older');
-      await writeResearchTrial(dir, '2026-07-01T000001Z-newer');
+      await writeStoredResearchTrial(dir, '2026-06-30T123456Z-older');
+      await writeStoredResearchTrial(dir, '2026-07-01T000001Z-newer');
 
       assert.deepStrictEqual(readResearchTrials({ cwd: dir }).map((trial) => trial.id), [
         '2026-07-01T000001Z-newer',
@@ -169,7 +80,7 @@ describe('research report reader', () => {
     await withTempDir(async (dir) => {
       const id = '2026-06-30T123456Z-smoke-claude';
 
-      await writeResearchTrial(dir, id);
+      await writeStoredResearchTrial(dir, id);
 
       const trials = readResearchTrials({ cwd: dir });
       const trial = trials[0] as ResearchTrial | undefined;
@@ -200,7 +111,7 @@ describe('research report reader', () => {
 
   it('keeps research trial candidates with invalid ids', async () => {
     await withTempDir(async (dir) => {
-      await writeResearchTrial(dir, 'broken-trial');
+      await writeStoredResearchTrial(dir, 'broken-trial');
 
       const trials = readResearchTrials({ cwd: dir });
       const trial = trials[0] as ResearchTrial | undefined;
@@ -219,11 +130,11 @@ describe('research report reader', () => {
     await withTempDir(async (dir) => {
       const missingMetadataId = '2026-06-30T123456Z-missing-metadata';
       const missingResultId = '2026-06-30T123457Z-missing-result';
-      const missingMetadataDir = await makeResearchTrialDir(dir, missingMetadataId);
-      const missingResultDir = await makeResearchTrialDir(dir, missingResultId);
+      const missingMetadataDir = await makeStoredResearchTrialDir(dir, missingMetadataId);
+      const missingResultDir = await makeStoredResearchTrialDir(dir, missingResultId);
 
-      await writeJsonFile(path.join(missingMetadataDir, 'result.json'), researchResult());
-      await writeJsonFile(path.join(missingResultDir, 'metadata.json'), researchMetadata(missingResultId));
+      await writeJsonFile(path.join(missingMetadataDir, 'result.json'), storedResearchResult());
+      await writeJsonFile(path.join(missingResultDir, 'metadata.json'), storedResearchMetadata(missingResultId));
 
       assert.deepStrictEqual(invalidReasonsById(readResearchTrials({ cwd: dir })), new Map([
         [missingResultId, ['result.json is missing']],
@@ -236,12 +147,12 @@ describe('research report reader', () => {
     await withTempDir(async (dir) => {
       const malformedMetadataId = '2026-06-30T123456Z-malformed-metadata';
       const malformedResultId = '2026-06-30T123457Z-malformed-result';
-      const malformedMetadataDir = await makeResearchTrialDir(dir, malformedMetadataId);
-      const malformedResultDir = await makeResearchTrialDir(dir, malformedResultId);
+      const malformedMetadataDir = await makeStoredResearchTrialDir(dir, malformedMetadataId);
+      const malformedResultDir = await makeStoredResearchTrialDir(dir, malformedResultId);
 
       await writeFile(path.join(malformedMetadataDir, 'metadata.json'), '{\n');
-      await writeJsonFile(path.join(malformedMetadataDir, 'result.json'), researchResult());
-      await writeJsonFile(path.join(malformedResultDir, 'metadata.json'), researchMetadata(malformedResultId));
+      await writeJsonFile(path.join(malformedMetadataDir, 'result.json'), storedResearchResult());
+      await writeJsonFile(path.join(malformedResultDir, 'metadata.json'), storedResearchMetadata(malformedResultId));
       await writeFile(path.join(malformedResultDir, 'result.json'), '{\n');
 
       assert.deepStrictEqual(invalidReasonsById(readResearchTrials({ cwd: dir })), new Map([
@@ -255,12 +166,12 @@ describe('research report reader', () => {
     await withTempDir(async (dir) => {
       const unreadableMetadataId = '2026-06-30T123456Z-unreadable-metadata';
       const unreadableResultId = '2026-06-30T123457Z-unreadable-result';
-      const unreadableMetadataDir = await makeResearchTrialDir(dir, unreadableMetadataId);
-      const unreadableResultDir = await makeResearchTrialDir(dir, unreadableResultId);
+      const unreadableMetadataDir = await makeStoredResearchTrialDir(dir, unreadableMetadataId);
+      const unreadableResultDir = await makeStoredResearchTrialDir(dir, unreadableResultId);
 
       await mkdir(path.join(unreadableMetadataDir, 'metadata.json'));
-      await writeJsonFile(path.join(unreadableMetadataDir, 'result.json'), researchResult());
-      await writeJsonFile(path.join(unreadableResultDir, 'metadata.json'), researchMetadata(unreadableResultId));
+      await writeJsonFile(path.join(unreadableMetadataDir, 'result.json'), storedResearchResult());
+      await writeJsonFile(path.join(unreadableResultDir, 'metadata.json'), storedResearchMetadata(unreadableResultId));
       await mkdir(path.join(unreadableResultDir, 'result.json'));
 
       assert.deepStrictEqual(invalidReasonsById(readResearchTrials({ cwd: dir })), new Map([
@@ -273,10 +184,10 @@ describe('research report reader', () => {
   it('marks unknown metadata schemas invalid', async () => {
     await withTempDir(async (dir) => {
       const id = '2026-06-30T123456Z-schema-v2';
-      const trialDir = await makeResearchTrialDir(dir, id);
+      const trialDir = await makeStoredResearchTrialDir(dir, id);
 
-      await writeJsonFile(path.join(trialDir, 'metadata.json'), researchMetadata(id, { schemaVersion: 2 }));
-      await writeJsonFile(path.join(trialDir, 'result.json'), researchResult());
+      await writeJsonFile(path.join(trialDir, 'metadata.json'), storedResearchMetadata(id, { schemaVersion: 2 }));
+      await writeJsonFile(path.join(trialDir, 'result.json'), storedResearchResult());
 
       assert.deepStrictEqual(invalidReasonsById(readResearchTrials({ cwd: dir })).get(id), [
         'unsupported metadata schemaVersion: 2'
@@ -288,13 +199,13 @@ describe('research report reader', () => {
     await withTempDir(async (dir) => {
       const id = '2026-06-30T123456Z-id-mismatch';
       const metadataId = '2026-06-30T123456Z-other-trial';
-      const trialDir = await makeResearchTrialDir(dir, id);
+      const trialDir = await makeStoredResearchTrialDir(dir, id);
 
       await writeJsonFile(path.join(trialDir, 'metadata.json'), {
-        ...researchMetadata(id),
+        ...storedResearchMetadata(id),
         id: metadataId
       });
-      await writeJsonFile(path.join(trialDir, 'result.json'), researchResult());
+      await writeJsonFile(path.join(trialDir, 'result.json'), storedResearchResult());
 
       assert.deepStrictEqual(invalidReasonsById(readResearchTrials({ cwd: dir })).get(id), [
         `metadata id ${metadataId} does not match research trial id ${id}`
@@ -306,13 +217,13 @@ describe('research report reader', () => {
     await withTempDir(async (dir) => {
       const id = '2026-06-30T123456Z-result-path-mismatch';
       const resultPath = 'other-result.json';
-      const trialDir = await makeResearchTrialDir(dir, id);
+      const trialDir = await makeStoredResearchTrialDir(dir, id);
 
       await writeJsonFile(path.join(trialDir, 'metadata.json'), {
-        ...researchMetadata(id),
+        ...storedResearchMetadata(id),
         result: resultPath
       });
-      await writeJsonFile(path.join(trialDir, 'result.json'), researchResult());
+      await writeJsonFile(path.join(trialDir, 'result.json'), storedResearchResult());
 
       assert.deepStrictEqual(invalidReasonsById(readResearchTrials({ cwd: dir })).get(id), [
         `metadata result ${resultPath} does not point to result.json`
@@ -323,10 +234,10 @@ describe('research report reader', () => {
   it('marks metadata and result status mismatches invalid', async () => {
     await withTempDir(async (dir) => {
       const id = '2026-06-30T123456Z-status-mismatch';
-      const trialDir = await makeResearchTrialDir(dir, id);
+      const trialDir = await makeStoredResearchTrialDir(dir, id);
 
-      await writeJsonFile(path.join(trialDir, 'metadata.json'), researchMetadata(id, { status: 'passed' }));
-      await writeJsonFile(path.join(trialDir, 'result.json'), researchResult('failed'));
+      await writeJsonFile(path.join(trialDir, 'metadata.json'), storedResearchMetadata(id, { status: 'passed' }));
+      await writeJsonFile(path.join(trialDir, 'result.json'), storedResearchResult('failed'));
 
       assert.deepStrictEqual(invalidReasonsById(readResearchTrials({ cwd: dir })).get(id), [
         'metadata status passed does not match result status failed'
@@ -337,10 +248,10 @@ describe('research report reader', () => {
   it('marks result summary totals that do not match result count invalid', async () => {
     await withTempDir(async (dir) => {
       const id = '2026-06-30T123456Z-summary-mismatch';
-      const trialDir = await makeResearchTrialDir(dir, id);
+      const trialDir = await makeStoredResearchTrialDir(dir, id);
 
-      await writeJsonFile(path.join(trialDir, 'metadata.json'), researchMetadata(id));
-      await writeJsonFile(path.join(trialDir, 'result.json'), researchResult('passed', { summaryTotal: 2 }));
+      await writeJsonFile(path.join(trialDir, 'metadata.json'), storedResearchMetadata(id));
+      await writeJsonFile(path.join(trialDir, 'result.json'), storedResearchResult('passed', { summaryTotal: 2 }));
 
       assert.deepStrictEqual(invalidReasonsById(readResearchTrials({ cwd: dir })).get(id), [
         'result summary total 2 does not match results length 1'
@@ -351,11 +262,11 @@ describe('research report reader', () => {
   it('does not rewrite research trial files while reading invalid candidates', async () => {
     await withTempDir(async (dir) => {
       const id = '2026-06-30T123456Z-malformed-result';
-      const trialDir = await makeResearchTrialDir(dir, id);
+      const trialDir = await makeStoredResearchTrialDir(dir, id);
       const metadataPath = path.join(trialDir, 'metadata.json');
       const resultPath = path.join(trialDir, 'result.json');
 
-      await writeJsonFile(metadataPath, researchMetadata(id));
+      await writeJsonFile(metadataPath, storedResearchMetadata(id));
       await writeFile(resultPath, '{\n');
 
       const metadataBefore = await readFile(metadataPath, 'utf8');
@@ -394,9 +305,9 @@ describe('research report builder', () => {
 
   it('aggregates valid and invalid research trial reader results', async () => {
     await withTempDir(async (dir) => {
-      await writeResearchTrial(dir, '2026-07-01T000001Z-passed');
-      await writeResearchTrial(dir, '2026-06-30T123456Z-failed', { status: 'failed' });
-      await writeResearchTrial(dir, 'broken-trial');
+      await writeStoredResearchTrial(dir, '2026-07-01T000001Z-passed');
+      await writeStoredResearchTrial(dir, '2026-06-30T123456Z-failed', { status: 'failed' });
+      await writeStoredResearchTrial(dir, 'broken-trial');
 
       assert.deepStrictEqual(buildResearchReport(readResearchTrials({ cwd: dir })), {
         schemaVersion: 1,

--- a/test/typescript/research_report.test.ts
+++ b/test/typescript/research_report.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 
-import { readResearchTrials, type ResearchTrial } from '../../src/research_report';
+import { buildResearchReport, readResearchTrials, type ResearchTrial } from '../../src/research_report';
 
 async function withTempDir<T>(callback: (dir: string) => Promise<T>): Promise<T> {
   const dir = await mkdtemp(path.join(tmpdir(), 'qni-cli-research-report-'));
@@ -365,6 +365,105 @@ describe('research report reader', () => {
 
       assert.equal(await readFile(metadataPath, 'utf8'), metadataBefore);
       assert.equal(await readFile(resultPath, 'utf8'), resultBefore);
+    });
+  });
+});
+
+describe('research report builder', () => {
+  it('builds an empty report from an empty reader result', () => {
+    assert.deepStrictEqual(buildResearchReport([]), {
+      schemaVersion: 1,
+      trialSummary: {
+        passed: 0,
+        failed: 0,
+        disallowed: 0,
+        error: 0,
+        invalid: 0,
+        total: 0
+      },
+      taskSummary: {
+        passed: 0,
+        failed: 0,
+        disallowed: 0,
+        error: 0,
+        total: 0
+      },
+      trials: []
+    });
+  });
+
+  it('aggregates valid and invalid research trial reader results', async () => {
+    await withTempDir(async (dir) => {
+      await writeResearchTrial(dir, '2026-07-01T000001Z-passed');
+      await writeResearchTrial(dir, '2026-06-30T123456Z-failed', { status: 'failed' });
+      await writeResearchTrial(dir, 'broken-trial');
+
+      assert.deepStrictEqual(buildResearchReport(readResearchTrials({ cwd: dir })), {
+        schemaVersion: 1,
+        trialSummary: {
+          passed: 1,
+          failed: 1,
+          disallowed: 0,
+          error: 0,
+          invalid: 1,
+          total: 3
+        },
+        taskSummary: {
+          passed: 1,
+          failed: 1,
+          disallowed: 0,
+          error: 0,
+          total: 2
+        },
+        trials: [
+          {
+            id: '2026-07-01T000001Z-passed',
+            createdAt: '2026-07-01T00:00:01.000Z',
+            collaborator: 'claude-sonnet-4',
+            benchmark: 'benchmarks/quantum-katas',
+            status: 'passed',
+            summary: {
+              passed: 1,
+              failed: 0,
+              disallowed: 0,
+              error: 0,
+              total: 1
+            },
+            path: 'research/runs/2026-07-01T000001Z-passed'
+          },
+          {
+            id: '2026-06-30T123456Z-failed',
+            createdAt: '2026-06-30T12:34:56.000Z',
+            collaborator: 'claude-sonnet-4',
+            benchmark: 'benchmarks/quantum-katas',
+            status: 'failed',
+            summary: {
+              passed: 0,
+              failed: 1,
+              disallowed: 0,
+              error: 0,
+              total: 1
+            },
+            path: 'research/runs/2026-06-30T123456Z-failed'
+          },
+          {
+            id: 'broken-trial',
+            createdAt: null,
+            collaborator: null,
+            benchmark: null,
+            status: 'invalid',
+            summary: {
+              passed: 0,
+              failed: 0,
+              disallowed: 0,
+              error: 0,
+              total: 0
+            },
+            path: 'research/runs/broken-trial',
+            invalidReason: ['invalid research trial id: broken-trial']
+          }
+        ]
+      });
     });
   });
 });


### PR DESCRIPTION
## 概要

保存済み研究試行を再採点せずに読み取り、`qni research report --json` で機械処理向けのレポートを出力できるようにしました。`schemaVersion: 1`、試行単位と課題単位の集計、研究試行一覧、invalid trial の理由を同じレポート構造から生成します。

Closes #300

## 変更内容

- `buildResearchReport(...)` を追加し、reader の valid / invalid な研究試行から JSON レポート構造を構築するようにした
- `qni research report --json` を追加し、invalid trial がある場合は JSON 出力後に終了コード `1`、読み取り不能な環境エラーは終了コード `3` を返すようにした
- JSON 出力用の Cucumber feature、TypeScript 単体テスト、CLI アダプタテストを追加した

## 確認

- `npm run check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * `research report --json` で、研究試行の集計結果をJSON形式で出力できるようになりました。
  * 試行がない場合は空のレポート、正常・無効な試行が混在する場合は状態や理由を含む詳細レポートを返します。

* **バグ修正**
  * 読み取り失敗時の扱いを改善し、存在しないパスは空結果、それ以外の問題は適切なエラーとして扱うようになりました。
  * 無効な試行がある場合、終了コードが正しく返るようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->