### PR TITLE
ベンチマーク課題の grading_cases frontmatter を読み込めるようにする

### DIFF
--- a/features/cli/benchmark_grading_cases.feature.md
+++ b/features/cli/benchmark_grading_cases.feature.md
@@ -40,10 +40,12 @@ qni-cli の評価ランナー利用者として
 
   checks と grading_cases を同時指定した不正な課題です。
   ```
+
 - Given 作業ディレクトリに "submission.qni" を作る:
 
   ```text
   qni add X --qubit 0 --step 0
   ```
+
 - When "qni benchmark run task.md submission.qni" を実行
 - Then 終了コードは 3

--- a/features/cli/benchmark_grading_cases.feature.md
+++ b/features/cli/benchmark_grading_cases.feature.md
@@ -1,0 +1,49 @@
+# Feature: qni benchmark grading cases
+
+qni-cli の評価ランナー利用者として
+複数の採点ケースを含む課題へ移行できるように
+課題 frontmatter の採点ケース仕様を読み込み時に検証したい。
+
+## Scenario: checks と grading_cases を同時に持つ課題は不正になる
+
+- Given 作業ディレクトリに "task.md" を作る:
+
+  ```markdown
+  ---
+  id: grading-cases/conflict
+  title: GradingCasesConflict
+  source: test
+  difficulty: smoke
+  allowed_commands:
+    - qni add
+  checks:
+    tolerance: 1e-9
+    items:
+      - type: run
+        expected:
+          - basis: "|1>"
+            amplitude:
+              real: 1
+              imaginary: 0
+  grading_cases:
+    - id: default
+      checks:
+        tolerance: 1e-9
+        items:
+          - type: run
+            expected:
+              - basis: "|1>"
+                amplitude:
+                  real: 1
+                  imaginary: 0
+  ---
+
+  checks と grading_cases を同時指定した不正な課題です。
+  ```
+- Given 作業ディレクトリに "submission.qni" を作る:
+
+  ```text
+  qni add X --qubit 0 --step 0
+  ```
+- When "qni benchmark run task.md submission.qni" を実行
+- Then 終了コードは 3

--- a/src/evaluation_runner/benchmark_task.ts
+++ b/src/evaluation_runner/benchmark_task.ts
@@ -16,9 +16,15 @@ interface ParsedQniCommand {
   readonly source: string;
 }
 
-export interface AllowedCommand extends ParsedQniCommand {}
+export interface AllowedCommand {
+  readonly argv: readonly string[];
+  readonly source: string;
+}
 
-export interface BenchmarkSetupCommand extends ParsedQniCommand {}
+export interface BenchmarkSetupCommand {
+  readonly argv: readonly string[];
+  readonly source: string;
+}
 
 export interface BenchmarkGradingCase {
   readonly checks: BenchmarkChecks;

--- a/src/evaluation_runner/benchmark_task.ts
+++ b/src/evaluation_runner/benchmark_task.ts
@@ -6,13 +6,24 @@ import { splitCommandLine } from '../qni_command_line';
 export interface BenchmarkTask {
   readonly allowedCommands: readonly AllowedCommand[];
   readonly checks: BenchmarkChecks;
+  readonly gradingCases: readonly BenchmarkGradingCase[];
   readonly id: string;
   readonly title: string;
 }
 
-export interface AllowedCommand {
+interface ParsedQniCommand {
   readonly argv: readonly string[];
   readonly source: string;
+}
+
+export interface AllowedCommand extends ParsedQniCommand {}
+
+export interface BenchmarkSetupCommand extends ParsedQniCommand {}
+
+export interface BenchmarkGradingCase {
+  readonly checks: BenchmarkChecks;
+  readonly id: string;
+  readonly setupCommands: readonly BenchmarkSetupCommand[];
 }
 
 export interface BenchmarkChecks {
@@ -51,12 +62,17 @@ type FrontmatterRecord = Readonly<Record<string, unknown>>;
 
 class BenchmarkTaskError extends Error {}
 
+const IMPLICIT_GRADING_CASE_ID = 'default';
+
 export function loadBenchmarkTask(taskPath: string): BenchmarkTask {
   const frontmatter = frontmatterRecord(frontmatterOf(readFileSync(taskPath, 'utf8')));
+  const allowedCommands = parseAllowedCommands(frontmatter);
+  const gradingCases = parseGradingCases(frontmatter);
 
   return {
-    allowedCommands: parseAllowedCommands(frontmatter),
-    checks: parseChecks(frontmatter),
+    allowedCommands,
+    checks: gradingCases[0].checks,
+    gradingCases,
     id: scalarValue(frontmatter, 'id'),
     title: scalarValue(frontmatter, 'title')
   };
@@ -94,18 +110,8 @@ function firstYamlErrorLine(error: Error): string {
 }
 
 function parseAllowedCommands(frontmatter: FrontmatterRecord): AllowedCommand[] {
-  return frontmatterListValues(frontmatter, 'allowed_commands').map((source) => {
-    const argv = splitCommandLine(source);
-
-    if (argv[0] !== 'qni' || argv.length < 2) {
-      throw new BenchmarkTaskError(`allowed_commands entries must start with a qni subcommand: ${source}`);
-    }
-
-    return {
-      argv: argv.slice(1),
-      source: argv.join(' ')
-    };
-  });
+  return frontmatterListValues(frontmatter, 'allowed_commands')
+    .map((source) => parseQniCommand(source, 'allowed_commands entries must start with a qni subcommand'));
 }
 
 function frontmatterListValues(frontmatter: FrontmatterRecord, key: string): string[] {
@@ -129,6 +135,70 @@ function parseChecks(frontmatter: FrontmatterRecord): BenchmarkChecks {
     items: parseCheckItems(checks),
     tolerance: checksTolerance(checks)
   };
+}
+
+function parseGradingCases(frontmatter: FrontmatterRecord): BenchmarkGradingCase[] {
+  const hasRootChecks = hasValue(frontmatter, 'checks');
+  const hasExplicitGradingCases = hasValue(frontmatter, 'grading_cases');
+
+  if (hasRootChecks && hasExplicitGradingCases) {
+    throw new BenchmarkTaskError('checks and grading_cases must not both be specified');
+  }
+
+  if (hasExplicitGradingCases) {
+    return parseExplicitGradingCases(frontmatter);
+  }
+
+  return [
+    {
+      checks: parseChecks(frontmatter),
+      id: IMPLICIT_GRADING_CASE_ID,
+      setupCommands: []
+    }
+  ];
+}
+
+function parseExplicitGradingCases(frontmatter: FrontmatterRecord): BenchmarkGradingCase[] {
+  const cases = requiredValue(frontmatter, 'grading_cases');
+
+  if (!Array.isArray(cases) || cases.length === 0) {
+    throw new BenchmarkTaskError('grading_cases must list at least one case');
+  }
+
+  const seenIds = new Set<string>();
+
+  return cases.map((item) => {
+    const gradingCase = requiredRecord(item, 'grading_cases entries must be mappings');
+    const id = nonEmptyScalarValue(gradingCase, 'id', 'grading_cases id must not be empty');
+
+    if (seenIds.has(id)) {
+      throw new BenchmarkTaskError(`duplicate grading_cases id: ${id}`);
+    }
+
+    seenIds.add(id);
+
+    return {
+      checks: parseChecks(gradingCase),
+      id,
+      setupCommands: parseSetupCommands(gradingCase)
+    };
+  });
+}
+
+function parseSetupCommands(gradingCase: FrontmatterRecord): BenchmarkSetupCommand[] {
+  const setupCommands = gradingCase.setup_commands;
+
+  if (setupCommands === undefined) {
+    return [];
+  }
+
+  if (!Array.isArray(setupCommands)) {
+    throw new BenchmarkTaskError('setup_commands must be a list of qni commands');
+  }
+
+  return setupCommands
+    .map((item) => stringListValue(item, 'setup_commands'))
+    .map((source) => parseQniCommand(source, 'setup_commands entries must start with a qni command'));
 }
 
 function checksTolerance(checks: FrontmatterRecord): number {
@@ -226,11 +296,25 @@ function requiredValue(record: FrontmatterRecord, key: string, errorMessage = `$
   return value;
 }
 
+function hasValue(record: FrontmatterRecord, key: string): boolean {
+  return record[key] !== undefined;
+}
+
 function scalarValue(record: FrontmatterRecord, key: string): string {
   const value = requiredValue(record, key);
 
   if (typeof value !== 'string') {
     throw new BenchmarkTaskError(`${key} must be a string`);
+  }
+
+  return value;
+}
+
+function nonEmptyScalarValue(record: FrontmatterRecord, key: string, errorMessage: string): string {
+  const value = scalarValue(record, key).trim();
+
+  if (value.length === 0) {
+    throw new BenchmarkTaskError(errorMessage);
   }
 
   return value;
@@ -242,6 +326,19 @@ function stringListValue(value: unknown, key: string): string {
   }
 
   return value;
+}
+
+function parseQniCommand(source: string, errorPrefix: string): ParsedQniCommand {
+  const argv = splitCommandLine(source);
+
+  if (argv[0] !== 'qni' || argv.length < 2) {
+    throw new BenchmarkTaskError(`${errorPrefix}: ${source}`);
+  }
+
+  return {
+    argv: argv.slice(1),
+    source: argv.join(' ')
+  };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/evaluation_runner/benchmark_task.ts
+++ b/src/evaluation_runner/benchmark_task.ts
@@ -71,11 +71,15 @@ export function loadBenchmarkTask(taskPath: string): BenchmarkTask {
 
   return {
     allowedCommands,
-    checks: gradingCases[0].checks,
+    checks: compatibleChecks(gradingCases),
     gradingCases,
     id: scalarValue(frontmatter, 'id'),
     title: scalarValue(frontmatter, 'title')
   };
+}
+
+function compatibleChecks(gradingCases: readonly BenchmarkGradingCase[]): BenchmarkChecks {
+  return (gradingCases.find((gradingCase) => gradingCase.id === IMPLICIT_GRADING_CASE_ID) ?? gradingCases[0]).checks;
 }
 
 function frontmatterOf(markdown: string): string {
@@ -193,12 +197,12 @@ function parseSetupCommands(gradingCase: FrontmatterRecord): BenchmarkSetupComma
   }
 
   if (!Array.isArray(setupCommands)) {
-    throw new BenchmarkTaskError('setup_commands must be a list of qni commands');
+    throw new BenchmarkTaskError('setup_commands must be a list of qni subcommands');
   }
 
   return setupCommands
     .map((item) => stringListValue(item, 'setup_commands'))
-    .map((source) => parseQniCommand(source, 'setup_commands entries must start with a qni command'));
+    .map((source) => parseQniCommand(source, 'setup_commands entries must start with a qni subcommand'));
 }
 
 function checksTolerance(checks: FrontmatterRecord): number {

--- a/test/typescript/benchmark_task.test.ts
+++ b/test/typescript/benchmark_task.test.ts
@@ -144,6 +144,45 @@ describe('benchmark task frontmatter parser', () => {
     });
   });
 
+  it('uses the default grading case for legacy checks compatibility', async () => {
+    await withTempDir(async (dir) => {
+      const taskPath = path.join(dir, 'task.md');
+
+      await writeTask(taskPath, [
+        'id: grading-cases/default-compatibility',
+        'title: DefaultCompatibility',
+        'source: test',
+        'difficulty: smoke',
+        'allowed_commands:',
+        '  - qni add',
+        'grading_cases:',
+        '  - id: starts-at-one',
+        '    checks:',
+        '      tolerance: 1e-6',
+        '      items:',
+        '        - type: expect',
+        '          expected:',
+        '            - pauli: Z',
+        '              value: -1',
+        '  - id: default',
+        '    checks:',
+        '      tolerance: 1e-9',
+        '      items:',
+        '        - type: expect',
+        '          expected:',
+        '            - pauli: Z',
+        '              value: 1'
+      ]);
+
+      const task = loadBenchmarkTask(taskPath);
+      const defaultCase = task.gradingCases.find((gradingCase) => gradingCase.id === 'default');
+
+      assert.deepStrictEqual(task.gradingCases.map((gradingCase) => gradingCase.id), ['starts-at-one', 'default']);
+      assert.ok(defaultCase);
+      assert.strictEqual(task.checks, defaultCase.checks);
+    });
+  });
+
   it('rejects root checks and explicit grading cases together', async () => {
     await assertInvalidTask([
       'id: grading-cases/conflict',
@@ -265,7 +304,29 @@ describe('benchmark task frontmatter parser', () => {
       '          expected:',
       '            - pauli: Z',
       '              value: 1'
-    ], /setup_commands entries must start with a qni command: echo not-qni/u);
+    ], /setup_commands entries must start with a qni subcommand: echo not-qni/u);
+  });
+
+  it('rejects setup commands without a qni subcommand', async () => {
+    await assertInvalidTask([
+      'id: grading-cases/missing-setup-subcommand',
+      'title: MissingSetupSubcommand',
+      'source: test',
+      'difficulty: smoke',
+      'allowed_commands:',
+      '  - qni add',
+      'grading_cases:',
+      '  - id: missing-setup-subcommand',
+      '    setup_commands:',
+      '      - qni',
+      '    checks:',
+      '      tolerance: 1e-9',
+      '      items:',
+      '        - type: expect',
+      '          expected:',
+      '            - pauli: Z',
+      '              value: 1'
+    ], /setup_commands entries must start with a qni subcommand: qni/u);
   });
 });
 

--- a/test/typescript/benchmark_task.test.ts
+++ b/test/typescript/benchmark_task.test.ts
@@ -1,0 +1,277 @@
+import assert from 'node:assert/strict';
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import { loadBenchmarkTask } from '../../src/evaluation_runner/benchmark_task';
+import { withTempDir } from './helpers/command';
+
+describe('benchmark task frontmatter parser', () => {
+  it('normalizes root checks into an implicit grading case', async () => {
+    await withTempDir(async (dir) => {
+      const taskPath = path.join(dir, 'task.md');
+
+      await writeTask(taskPath, [
+        'id: basic-gates/state-flip',
+        'title: StateFlip',
+        'source: test',
+        'difficulty: smoke',
+        'allowed_commands:',
+        '  - qni add',
+        'checks:',
+        '  tolerance: 1e-9',
+        '  items:',
+        '    - type: run',
+        '      expected:',
+        '        - basis: "|1>"',
+        '          amplitude:',
+        '            real: 1',
+        '            imaginary: 0'
+      ]);
+
+      const task = loadBenchmarkTask(taskPath);
+
+      assert.deepStrictEqual(task.gradingCases, [
+        {
+          id: 'default',
+          setupCommands: [],
+          checks: {
+            tolerance: 1e-9,
+            items: [
+              {
+                type: 'run',
+                expected: [
+                  {
+                    basis: '|1>',
+                    amplitude: {
+                      real: 1,
+                      imaginary: 0
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]);
+      assert.strictEqual(task.checks, task.gradingCases[0]?.checks);
+    });
+  });
+
+  it('parses explicit grading cases with qni setup commands', async () => {
+    await withTempDir(async (dir) => {
+      const taskPath = path.join(dir, 'task.md');
+
+      await writeTask(taskPath, [
+        'id: grading-cases/state-preparation',
+        'title: StatePreparationCases',
+        'source: test',
+        'difficulty: smoke',
+        'allowed_commands:',
+        '  - qni add',
+        'grading_cases:',
+        '  - id: starts-at-one',
+        '    setup_commands:',
+        '      - qni state set "1|1>"',
+        '    checks:',
+        '      tolerance: 1e-9',
+        '      items:',
+        '        - type: run',
+        '          expected:',
+        '            - basis: "|1>"',
+        '              amplitude:',
+        '                real: 1',
+        '                imaginary: 0',
+        '  - id: starts-at-zero',
+        '    checks:',
+        '      tolerance: 1e-9',
+        '      items:',
+        '        - type: expect',
+        '          expected:',
+        '            - pauli: z',
+        '              value: 1'
+      ]);
+
+      const task = loadBenchmarkTask(taskPath);
+
+      assert.deepStrictEqual(task.gradingCases, [
+        {
+          id: 'starts-at-one',
+          setupCommands: [
+            {
+              argv: ['state', 'set', '1|1>'],
+              source: 'qni state set 1|1>'
+            }
+          ],
+          checks: {
+            tolerance: 1e-9,
+            items: [
+              {
+                type: 'run',
+                expected: [
+                  {
+                    basis: '|1>',
+                    amplitude: {
+                      real: 1,
+                      imaginary: 0
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          id: 'starts-at-zero',
+          setupCommands: [],
+          checks: {
+            tolerance: 1e-9,
+            items: [
+              {
+                type: 'expect',
+                expected: [
+                  {
+                    pauli: 'Z',
+                    value: 1
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]);
+      assert.strictEqual(task.checks, task.gradingCases[0]?.checks);
+    });
+  });
+
+  it('rejects root checks and explicit grading cases together', async () => {
+    await assertInvalidTask([
+      'id: grading-cases/conflict',
+      'title: GradingCasesConflict',
+      'source: test',
+      'difficulty: smoke',
+      'allowed_commands:',
+      '  - qni add',
+      'checks:',
+      '  tolerance: 1e-9',
+      '  items:',
+      '    - type: run',
+      '      expected:',
+      '        - basis: "|1>"',
+      '          amplitude:',
+      '            real: 1',
+      '            imaginary: 0',
+      'grading_cases:',
+      '  - id: default',
+      '    checks:',
+      '      tolerance: 1e-9',
+      '      items:',
+      '        - type: expect',
+      '          expected:',
+      '            - pauli: Z',
+      '              value: 1'
+    ], /checks and grading_cases must not both be specified/u);
+  });
+
+  it('rejects empty grading cases', async () => {
+    await assertInvalidTask([
+      'id: grading-cases/empty',
+      'title: EmptyGradingCases',
+      'source: test',
+      'difficulty: smoke',
+      'allowed_commands:',
+      '  - qni add',
+      'grading_cases: []'
+    ], /grading_cases must list at least one case/u);
+  });
+
+  it('rejects duplicate grading case ids', async () => {
+    await assertInvalidTask([
+      'id: grading-cases/duplicate',
+      'title: DuplicateGradingCaseIds',
+      'source: test',
+      'difficulty: smoke',
+      'allowed_commands:',
+      '  - qni add',
+      'grading_cases:',
+      '  - id: same',
+      '    checks:',
+      '      tolerance: 1e-9',
+      '      items:',
+      '        - type: expect',
+      '          expected:',
+      '            - pauli: Z',
+      '              value: 1',
+      '  - id: same',
+      '    checks:',
+      '      tolerance: 1e-9',
+      '      items:',
+      '        - type: expect',
+      '          expected:',
+      '            - pauli: X',
+      '              value: 0'
+    ], /duplicate grading_cases id: same/u);
+  });
+
+  it('rejects empty grading case ids', async () => {
+    await assertInvalidTask([
+      'id: grading-cases/empty-id',
+      'title: EmptyGradingCaseId',
+      'source: test',
+      'difficulty: smoke',
+      'allowed_commands:',
+      '  - qni add',
+      'grading_cases:',
+      '  - id: ""',
+      '    checks:',
+      '      tolerance: 1e-9',
+      '      items:',
+      '        - type: expect',
+      '          expected:',
+      '            - pauli: Z',
+      '              value: 1'
+    ], /grading_cases id must not be empty/u);
+  });
+
+  it('rejects setup commands that do not start with qni', async () => {
+    await assertInvalidTask([
+      'id: grading-cases/shell-setup',
+      'title: ShellSetup',
+      'source: test',
+      'difficulty: smoke',
+      'allowed_commands:',
+      '  - qni add',
+      'grading_cases:',
+      '  - id: shell-setup',
+      '    setup_commands:',
+      '      - echo not-qni',
+      '    checks:',
+      '      tolerance: 1e-9',
+      '      items:',
+      '        - type: expect',
+      '          expected:',
+      '            - pauli: Z',
+      '              value: 1'
+    ], /setup_commands entries must start with a qni command: echo not-qni/u);
+  });
+});
+
+async function assertInvalidTask(frontmatterLines: readonly string[], errorPattern: RegExp): Promise<void> {
+  await withTempDir(async (dir) => {
+    const taskPath = path.join(dir, 'task.md');
+
+    await writeTask(taskPath, frontmatterLines);
+
+    assert.throws(() => loadBenchmarkTask(taskPath), errorPattern);
+  });
+}
+
+async function writeTask(taskPath: string, frontmatterLines: readonly string[]): Promise<void> {
+  await writeFile(taskPath, [
+    '---',
+    ...frontmatterLines,
+    '---',
+    '',
+    'Grade the submission.'
+  ].join('\n'));
+}

--- a/test/typescript/benchmark_task.test.ts
+++ b/test/typescript/benchmark_task.test.ts
@@ -185,6 +185,19 @@ describe('benchmark task frontmatter parser', () => {
     ], /grading_cases must list at least one case/u);
   });
 
+  it('rejects grading_cases that is not a list', async () => {
+    await assertInvalidTask([
+      'id: grading-cases/not-a-list',
+      'title: GradingCasesNotAList',
+      'source: test',
+      'difficulty: smoke',
+      'allowed_commands:',
+      '  - qni add',
+      'grading_cases:',
+      '  id: default'
+    ], /grading_cases must list at least one case/u);
+  });
+
   it('rejects duplicate grading case ids', async () => {
     await assertInvalidTask([
       'id: grading-cases/duplicate',


### PR DESCRIPTION
## 概要

ベンチマーク課題 frontmatter に `grading_cases` を読み込む内部モデルを追加しました。
既存の root `checks` 形式は `default` の暗黙採点ケースへ正規化し、既存の `qni benchmark run` / `run-all` が参照する `checks` 互換も維持しています。

Closes #306

## 変更内容

- `src/evaluation_runner/benchmark_task.ts` に `BenchmarkGradingCase` と `BenchmarkSetupCommand` を追加し、`grading_cases` と root `checks` の正規化を実装
- `checks` と `grading_cases` の同時指定、空の `grading_cases`、重複 ID、空 ID、`qni ...` 以外の `setup_commands` を読み込み時エラーに変更
- `test/typescript/benchmark_task.test.ts` で既存 `checks` 互換、正常な `grading_cases`、主要な不正形式を検証
- `features/cli/benchmark_grading_cases.feature.md` で CLI 経由の不正 frontmatter ケースを仕様化

## 確認

- `npm run check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 課題の採点条件で、単一の評価ケースだけでなく複数ケースを扱えるようになりました。
  * ケースごとの実行前コマンドを指定できるようになりました。

* **バグ修正**
  * 標準の評価条件と個別評価ケースの同時指定を正しくエラーにするようになりました。
  * 空のケース、重複するケース ID、空の ID、無効なコマンド形式を検出するようになりました。

* **テスト**
  * 評価条件の解釈と入力検証をカバーするテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->