### PR TITLE
MinusState と AllBasisVectors_TwoQubits のベンチマーク課題を追加する

### DIFF
--- a/benchmarks/quantum-katas/superposition/all-basis-vectors-two-qubits.md
+++ b/benchmarks/quantum-katas/superposition/all-basis-vectors-two-qubits.md
@@ -1,0 +1,34 @@
+---
+id: superposition/all-basis-vectors-two-qubits
+title: AllBasisVectors_TwoQubits
+source: Microsoft Quantum Katas / Superposition
+difficulty: smoke
+allowed_commands:
+  - qni add
+checks:
+  tolerance: 1e-15
+  items:
+    - type: run
+      expected:
+        - basis: "|00>"
+          amplitude:
+            real: 0.5
+            imaginary: 0
+        - basis: "|01>"
+          amplitude:
+            real: 0.5
+            imaginary: 0
+        - basis: "|10>"
+          amplitude:
+            real: 0.5
+            imaginary: 0
+        - basis: "|11>"
+          amplitude:
+            real: 0.5
+            imaginary: 0
+---
+
+2量子ビットを `|00>` から4つの計算基底状態の一様重ね合わせに変える量子回路を、`qni` コマンド列として作成してください。
+
+目標状態は `( |00> + |01> + |10> + |11> ) / 2` です。
+提出物は `.qni` 形式で、1行に1つずつ完全な `qni` コマンドを書いてください。

--- a/benchmarks/quantum-katas/superposition/minus-state.md
+++ b/benchmarks/quantum-katas/superposition/minus-state.md
@@ -1,0 +1,26 @@
+---
+id: superposition/minus-state
+title: MinusState
+source: Microsoft Quantum Katas / Superposition
+difficulty: smoke
+allowed_commands:
+  - qni add
+checks:
+  tolerance: 1e-15
+  items:
+    - type: run
+      expected:
+        - basis: "|0>"
+          amplitude:
+            real: 0.7071067811865476
+            imaginary: 0
+        - basis: "|1>"
+          amplitude:
+            real: -0.7071067811865476
+            imaginary: 0
+---
+
+1量子ビットを `|0>` から `|->` に変える量子回路を、`qni` コマンド列として作成してください。
+
+`|->` は `( |0> - |1> ) / sqrt(2)` の重ね合わせ状態です。
+提出物は `.qni` 形式で、1行に1つずつ完全な `qni` コマンドを書いてください。

--- a/benchmarks/solutions/quantum-katas/superposition/all-basis-vectors-two-qubits.qni
+++ b/benchmarks/solutions/quantum-katas/superposition/all-basis-vectors-two-qubits.qni
@@ -1,0 +1,2 @@
+qni add H --qubit 0 --step 0
+qni add H --qubit 1 --step 0

--- a/benchmarks/solutions/quantum-katas/superposition/minus-state.qni
+++ b/benchmarks/solutions/quantum-katas/superposition/minus-state.qni
@@ -1,0 +1,2 @@
+qni add X --qubit 0 --step 0
+qni add H --qubit 0 --step 1

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -14,7 +14,7 @@
 
 提出物には回路を作るコマンドだけを書きます。`qni run` や `qni expect` などの検証コマンドは書きません。
 
-## 3問の標準解を実行する
+## 5問の標準解を実行する
 
 ### StateFlip
 
@@ -31,6 +31,22 @@ qni benchmark run benchmarks/quantum-katas/superposition/plus-state.md benchmark
 ```
 
 期待される結果は `PASS PlusState` です。
+
+### MinusState
+
+```bash
+qni benchmark run benchmarks/quantum-katas/superposition/minus-state.md benchmarks/solutions/quantum-katas/superposition/minus-state.qni
+```
+
+期待される結果は `PASS MinusState` です。
+
+### AllBasisVectors_TwoQubits
+
+```bash
+qni benchmark run benchmarks/quantum-katas/superposition/all-basis-vectors-two-qubits.md benchmarks/solutions/quantum-katas/superposition/all-basis-vectors-two-qubits.qni
+```
+
+期待される結果は `PASS AllBasisVectors_TwoQubits` です。
 
 ### BellState
 
@@ -94,14 +110,16 @@ qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/
 qni benchmark run-all benchmarks/quantum-katas benchmarks/solutions/quantum-katas
 ```
 
-期待される結果は、3問すべてが `passed` になり、終了コードが `0` になることです。
+期待される結果は、5問すべてが `passed` になり、終了コードが `0` になることです。
 
 ```text
 PASS benchmark suite
-tasks: 3
-passed: 3, failed: 0, disallowed: 0, error: 0
+tasks: 5
+passed: 5, failed: 0, disallowed: 0, error: 0
 - passed basic-gates/state-flip StateFlip
+- passed superposition/all-basis-vectors-two-qubits AllBasisVectors_TwoQubits
 - passed superposition/bell-state BellState
+- passed superposition/minus-state MinusState
 - passed superposition/plus-state PlusState
 ```
 

--- a/features/cli/benchmark_run.feature.md
+++ b/features/cli/benchmark_run.feature.md
@@ -77,6 +77,50 @@ qni benchmark run で最小の合格判定を実行したい。
   PASS PlusState
   ```
 
+## Scenario: MinusState 課題ファイルがある
+
+- Then リポジトリファイル "benchmarks/quantum-katas/superposition/minus-state.md" は存在する
+
+## Scenario: MinusState 標準解がある
+
+- Then リポジトリファイル "benchmarks/solutions/quantum-katas/superposition/minus-state.qni" は存在する
+
+## Scenario: MinusState 標準解は合格する
+
+- When "qni benchmark run benchmarks/quantum-katas/superposition/minus-state.md benchmarks/solutions/quantum-katas/superposition/minus-state.qni" を実行
+- Then コマンドは成功
+
+## Scenario: MinusState 標準解の合格が表示される
+
+- When "qni benchmark run benchmarks/quantum-katas/superposition/minus-state.md benchmarks/solutions/quantum-katas/superposition/minus-state.qni" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  PASS MinusState
+  ```
+
+## Scenario: AllBasisVectors_TwoQubits 課題ファイルがある
+
+- Then リポジトリファイル "benchmarks/quantum-katas/superposition/all-basis-vectors-two-qubits.md" は存在する
+
+## Scenario: AllBasisVectors_TwoQubits 標準解がある
+
+- Then リポジトリファイル "benchmarks/solutions/quantum-katas/superposition/all-basis-vectors-two-qubits.qni" は存在する
+
+## Scenario: AllBasisVectors_TwoQubits 標準解は合格する
+
+- When "qni benchmark run benchmarks/quantum-katas/superposition/all-basis-vectors-two-qubits.md benchmarks/solutions/quantum-katas/superposition/all-basis-vectors-two-qubits.qni" を実行
+- Then コマンドは成功
+
+## Scenario: AllBasisVectors_TwoQubits 標準解の合格が表示される
+
+- When "qni benchmark run benchmarks/quantum-katas/superposition/all-basis-vectors-two-qubits.md benchmarks/solutions/quantum-katas/superposition/all-basis-vectors-two-qubits.qni" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  PASS AllBasisVectors_TwoQubits
+  ```
+
 ## Scenario: BellState 課題ファイルがある
 
 - Then リポジトリファイル "benchmarks/quantum-katas/superposition/bell-state.md" は存在する
@@ -301,6 +345,14 @@ qni benchmark run で最小の合格判定を実行したい。
 
 - Then リポジトリファイル "docs/benchmark.md" は "qni benchmark run benchmarks/quantum-katas/superposition/bell-state.md benchmarks/solutions/quantum-katas/superposition/bell-state.qni" を含む
 
+## Scenario: MVP手順は MinusState 標準解の実行例を示す
+
+- Then リポジトリファイル "docs/benchmark.md" は "qni benchmark run benchmarks/quantum-katas/superposition/minus-state.md benchmarks/solutions/quantum-katas/superposition/minus-state.qni" を含む
+
+## Scenario: MVP手順は AllBasisVectors_TwoQubits 標準解の実行例を示す
+
+- Then リポジトリファイル "docs/benchmark.md" は "qni benchmark run benchmarks/quantum-katas/superposition/all-basis-vectors-two-qubits.md benchmarks/solutions/quantum-katas/superposition/all-basis-vectors-two-qubits.qni" を含む
+
 ## Scenario: MVP手順は不正解サンプルの実行例を示す
 
 - Then リポジトリファイル "docs/benchmark.md" は "qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/incorrect/quantum-katas/basic-gates/state-flip-wrong.qni" を含む
@@ -325,10 +377,12 @@ qni benchmark run で最小の合格判定を実行したい。
 
   ```text
   PASS benchmark suite
-  tasks: 3
-  passed: 3, failed: 0, disallowed: 0, error: 0
+  tasks: 5
+  passed: 5, failed: 0, disallowed: 0, error: 0
   - passed basic-gates/state-flip StateFlip
+  - passed superposition/all-basis-vectors-two-qubits AllBasisVectors_TwoQubits
   - passed superposition/bell-state BellState
+  - passed superposition/minus-state MinusState
   - passed superposition/plus-state PlusState
   ```
 
@@ -342,8 +396,8 @@ qni benchmark run で最小の合格判定を実行したい。
     "status": "passed",
     "exitCode": 0,
     "summary": {
-      "total": 3,
-      "passed": 3,
+      "total": 5,
+      "passed": 5,
       "failed": 0,
       "disallowed": 0,
       "error": 0
@@ -364,6 +418,20 @@ qni benchmark run で最小の合格判定を実行したい。
         ]
       },
       {
+        "taskId": "superposition/all-basis-vectors-two-qubits",
+        "title": "AllBasisVectors_TwoQubits",
+        "task": "benchmarks/quantum-katas/superposition/all-basis-vectors-two-qubits.md",
+        "submission": "benchmarks/solutions/quantum-katas/superposition/all-basis-vectors-two-qubits.qni",
+        "status": "passed",
+        "exitCode": 0,
+        "checks": [
+          {
+            "type": "run",
+            "status": "passed"
+          }
+        ]
+      },
+      {
         "taskId": "superposition/bell-state",
         "title": "BellState",
         "task": "benchmarks/quantum-katas/superposition/bell-state.md",
@@ -373,6 +441,20 @@ qni benchmark run で最小の合格判定を実行したい。
         "checks": [
           {
             "type": "expect",
+            "status": "passed"
+          }
+        ]
+      },
+      {
+        "taskId": "superposition/minus-state",
+        "title": "MinusState",
+        "task": "benchmarks/quantum-katas/superposition/minus-state.md",
+        "submission": "benchmarks/solutions/quantum-katas/superposition/minus-state.qni",
+        "status": "passed",
+        "exitCode": 0,
+        "checks": [
+          {
+            "type": "run",
             "status": "passed"
           }
         ]

--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -216,7 +216,9 @@ function writeCircuitJson(scenarioDir, data) {
 function quantumKatasSubmissionContent(status, relativePath) {
   const passedSubmissions = new Map([
     ['basic-gates/state-flip.qni', 'qni add X --qubit 0 --step 0\n'],
+    ['superposition/all-basis-vectors-two-qubits.qni', 'qni add H --qubit 0 --step 0\nqni add H --qubit 1 --step 0\n'],
     ['superposition/bell-state.qni', 'qni add H --qubit 0 --step 0\nqni add X --control 0 --qubit 1 --step 1\n'],
+    ['superposition/minus-state.qni', 'qni add X --qubit 0 --step 0\nqni add H --qubit 0 --step 1\n'],
     ['superposition/plus-state.qni', 'qni add H --qubit 0 --step 0\n']
   ]);
 
@@ -245,7 +247,9 @@ function quantumKatasSubmissionContent(status, relativePath) {
 function writeQuantumKatasSubmissions(scenarioDir, status, submissionsDir) {
   const relativePaths = [
     'basic-gates/state-flip.qni',
+    'superposition/all-basis-vectors-two-qubits.qni',
     'superposition/bell-state.qni',
+    'superposition/minus-state.qni',
     'superposition/plus-state.qni'
   ];
 

--- a/test/typescript/benchmark_command.test.ts
+++ b/test/typescript/benchmark_command.test.ts
@@ -401,6 +401,36 @@ describe('benchmark command TypeScript route', () => {
     });
   });
 
+  it('passes the MinusState solution using a run check', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, [
+        'benchmark',
+        'run',
+        'benchmarks/quantum-katas/superposition/minus-state.md',
+        'benchmarks/solutions/quantum-katas/superposition/minus-state.qni'
+      ]);
+
+      assert.equal(result.exitStatus, 0, result.stderr);
+      assert.equal(result.stdout, 'PASS MinusState\nchecks: 1\n');
+      assert.equal(result.stderr, '');
+    });
+  });
+
+  it('passes the AllBasisVectors_TwoQubits solution using a run check', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, [
+        'benchmark',
+        'run',
+        'benchmarks/quantum-katas/superposition/all-basis-vectors-two-qubits.md',
+        'benchmarks/solutions/quantum-katas/superposition/all-basis-vectors-two-qubits.qni'
+      ]);
+
+      assert.equal(result.exitStatus, 0, result.stderr);
+      assert.equal(result.stdout, 'PASS AllBasisVectors_TwoQubits\nchecks: 1\n');
+      assert.equal(result.stderr, '');
+    });
+  });
+
   it('passes the BellState solution using an expect check', async () => {
     await withTempDir(async (dir) => {
       const result = captureDispatcherRun(dir, [
@@ -603,8 +633,8 @@ describe('benchmark command TypeScript route', () => {
       assert.equal(captured.value.status, 'passed');
       assert.equal(captured.value.exitCode, 0);
       assert.deepStrictEqual(captured.value.summary, {
-        total: 3,
-        passed: 3,
+        total: 5,
+        passed: 5,
         failed: 0,
         disallowed: 0,
         error: 0
@@ -622,10 +652,22 @@ describe('benchmark command TypeScript route', () => {
           checks: [{ type: 'run', status: 'passed' }]
         },
         {
+          taskId: 'superposition/all-basis-vectors-two-qubits',
+          status: 'passed',
+          exitCode: 0,
+          checks: [{ type: 'run', status: 'passed' }]
+        },
+        {
           taskId: 'superposition/bell-state',
           status: 'passed',
           exitCode: 0,
           checks: [{ type: 'expect', status: 'passed' }]
+        },
+        {
+          taskId: 'superposition/minus-state',
+          status: 'passed',
+          exitCode: 0,
+          checks: [{ type: 'run', status: 'passed' }]
         },
         {
           taskId: 'superposition/plus-state',
@@ -649,10 +691,12 @@ describe('benchmark command TypeScript route', () => {
       assert.equal(result.exitStatus, 0, result.stderr);
       assert.equal(result.stdout, [
         'PASS benchmark suite',
-        'tasks: 3',
-        'passed: 3, failed: 0, disallowed: 0, error: 0',
+        'tasks: 5',
+        'passed: 5, failed: 0, disallowed: 0, error: 0',
         '- passed basic-gates/state-flip StateFlip',
+        '- passed superposition/all-basis-vectors-two-qubits AllBasisVectors_TwoQubits',
         '- passed superposition/bell-state BellState',
+        '- passed superposition/minus-state MinusState',
         '- passed superposition/plus-state PlusState',
         ''
       ].join('\n'));
@@ -676,8 +720,8 @@ describe('benchmark command TypeScript route', () => {
         status: 'passed',
         exitCode: 0,
         summary: {
-          total: 3,
-          passed: 3,
+          total: 5,
+          passed: 5,
           failed: 0,
           disallowed: 0,
           error: 0
@@ -693,6 +737,15 @@ describe('benchmark command TypeScript route', () => {
             checks: [{ type: 'run', status: 'passed' }]
           },
           {
+            taskId: 'superposition/all-basis-vectors-two-qubits',
+            title: 'AllBasisVectors_TwoQubits',
+            task: 'benchmarks/quantum-katas/superposition/all-basis-vectors-two-qubits.md',
+            submission: 'benchmarks/solutions/quantum-katas/superposition/all-basis-vectors-two-qubits.qni',
+            status: 'passed',
+            exitCode: 0,
+            checks: [{ type: 'run', status: 'passed' }]
+          },
+          {
             taskId: 'superposition/bell-state',
             title: 'BellState',
             task: 'benchmarks/quantum-katas/superposition/bell-state.md',
@@ -700,6 +753,15 @@ describe('benchmark command TypeScript route', () => {
             status: 'passed',
             exitCode: 0,
             checks: [{ type: 'expect', status: 'passed' }]
+          },
+          {
+            taskId: 'superposition/minus-state',
+            title: 'MinusState',
+            task: 'benchmarks/quantum-katas/superposition/minus-state.md',
+            submission: 'benchmarks/solutions/quantum-katas/superposition/minus-state.qni',
+            status: 'passed',
+            exitCode: 0,
+            checks: [{ type: 'run', status: 'passed' }]
           },
           {
             taskId: 'superposition/plus-state',

--- a/test/typescript/evaluation_runner.test.ts
+++ b/test/typescript/evaluation_runner.test.ts
@@ -184,8 +184,8 @@ describe('evaluation runner public entrypoints', () => {
       assert.equal(captured.value.status, 'passed');
       assert.equal(captured.value.exitCode, 0);
       assert.deepStrictEqual(captured.value.summary, {
-        total: 3,
-        passed: 3,
+        total: 5,
+        passed: 5,
         failed: 0,
         disallowed: 0,
         error: 0
@@ -210,17 +210,19 @@ describe('evaluation runner public entrypoints', () => {
       assert.equal(output.exitCode, 0);
       assert.equal(output.humanOutput, [
         'PASS benchmark suite',
-        'tasks: 3',
-        'passed: 3, failed: 0, disallowed: 0, error: 0',
+        'tasks: 5',
+        'passed: 5, failed: 0, disallowed: 0, error: 0',
         '- passed basic-gates/state-flip StateFlip',
+        '- passed superposition/all-basis-vectors-two-qubits AllBasisVectors_TwoQubits',
         '- passed superposition/bell-state BellState',
+        '- passed superposition/minus-state MinusState',
         '- passed superposition/plus-state PlusState',
         ''
       ].join('\n'));
       assert.equal(output.jsonOutput.status, 'passed');
       assert.deepStrictEqual(output.jsonOutput.summary, {
-        total: 3,
-        passed: 3,
+        total: 5,
+        passed: 5,
         failed: 0,
         disallowed: 0,
         error: 0

--- a/test/typescript/research_command.test.ts
+++ b/test/typescript/research_command.test.ts
@@ -121,7 +121,9 @@ async function prepareQuantumKatasSubmissions(
 ): Promise<void> {
   const relativePaths = [
     'basic-gates/state-flip.qni',
+    'superposition/all-basis-vectors-two-qubits.qni',
     'superposition/bell-state.qni',
+    'superposition/minus-state.qni',
     'superposition/plus-state.qni'
   ];
 
@@ -136,7 +138,9 @@ async function prepareQuantumKatasSubmissions(
 function quantumKatasSubmissionContent(status: UnsuccessfulResearchStatus, relativePath: string): string {
   const passedSubmissions = new Map<string, string>([
     ['basic-gates/state-flip.qni', 'qni add X --qubit 0 --step 0\n'],
+    ['superposition/all-basis-vectors-two-qubits.qni', 'qni add H --qubit 0 --step 0\nqni add H --qubit 1 --step 0\n'],
     ['superposition/bell-state.qni', 'qni add H --qubit 0 --step 0\nqni add X --control 0 --qubit 1 --step 1\n'],
+    ['superposition/minus-state.qni', 'qni add X --qubit 0 --step 0\nqni add H --qubit 0 --step 1\n'],
     ['superposition/plus-state.qni', 'qni add H --qubit 0 --step 0\n']
   ]);
 
@@ -748,8 +752,8 @@ describe('research command TypeScript route', () => {
       assert.match(String(metadata.createdAt), /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.000Z$/u);
       assert.equal(gradingResult.status, 'passed');
       assert.deepStrictEqual(gradingResult.summary, {
-        total: 3,
-        passed: 3,
+        total: 5,
+        passed: 5,
         failed: 0,
         disallowed: 0,
         error: 0


### PR DESCRIPTION
## 概要

Quantum Katas の状態準備ベンチマークに、現行評価ランナーで採点できる `MinusState` と `AllBasisVectors_TwoQubits` を追加しました。
標準解と課題文を追加し、既存のベンチマーク仕様、TypeScript テスト、ドキュメントの課題数と出力例を5問構成に更新しています。

Closes #311

## 変更内容

- `MinusState` と `AllBasisVectors_TwoQubits` のベンチマーク課題と標準解 `.qni` を追加
- `qni benchmark run` / `run-all` の Cucumber 仕様と TypeScript テストを、追加課題を含む5問スイートに更新
- `docs/benchmark.md` と研究記録向けテスト補助を、追加課題を含む出力に追従

## 確認

- `npm run check`
