### PR TITLE
位相付き二量子ビット重ね合わせ課題をベンチマークに追加する

### DIFF
--- a/benchmarks/quantum-katas/superposition/all-basis-vector-with-phase-flip-two-qubits.md
+++ b/benchmarks/quantum-katas/superposition/all-basis-vector-with-phase-flip-two-qubits.md
@@ -1,0 +1,34 @@
+---
+id: superposition/all-basis-vector-with-phase-flip-two-qubits
+title: AllBasisVectorWithPhaseFlip_TwoQubits
+source: Microsoft Quantum Katas / Superposition
+difficulty: smoke
+allowed_commands:
+  - qni add
+checks:
+  tolerance: 1e-15
+  items:
+    - type: run
+      expected:
+        - basis: "|00>"
+          amplitude:
+            real: 0.5
+            imaginary: 0
+        - basis: "|01>"
+          amplitude:
+            real: 0.5
+            imaginary: 0
+        - basis: "|10>"
+          amplitude:
+            real: 0.5
+            imaginary: 0
+        - basis: "|11>"
+          amplitude:
+            real: -0.5
+            imaginary: 0
+---
+
+2量子ビットを `|00>` から、`|11>` だけ符号が反転した一様重ね合わせに変える量子回路を、`qni` コマンド列として作成してください。
+
+目標状態は `( |00> + |01> + |10> - |11> ) / 2` です。
+提出物は `.qni` 形式で、1行に1つずつ完全な `qni` コマンドを書いてください。

--- a/benchmarks/quantum-katas/superposition/all-basis-vectors-with-phases-two-qubits.md
+++ b/benchmarks/quantum-katas/superposition/all-basis-vectors-with-phases-two-qubits.md
@@ -1,0 +1,34 @@
+---
+id: superposition/all-basis-vectors-with-phases-two-qubits
+title: AllBasisVectorsWithPhases_TwoQubits
+source: Microsoft Quantum Katas / Superposition
+difficulty: smoke
+allowed_commands:
+  - qni add
+checks:
+  tolerance: 1e-15
+  items:
+    - type: run
+      expected:
+        - basis: "|00>"
+          amplitude:
+            real: 0.5
+            imaginary: 0
+        - basis: "|01>"
+          amplitude:
+            real: 0
+            imaginary: 0.5
+        - basis: "|10>"
+          amplitude:
+            real: -0.5
+            imaginary: 0
+        - basis: "|11>"
+          amplitude:
+            real: 0
+            imaginary: -0.5
+---
+
+2量子ビットを `|00>` から、計算基底ごとに異なる位相を持つ一様重ね合わせに変える量子回路を、`qni` コマンド列として作成してください。
+
+目標状態は `( |00> + i|01> - |10> - i|11> ) / 2` です。
+提出物は `.qni` 形式で、1行に1つずつ完全な `qni` コマンドを書いてください。

--- a/benchmarks/solutions/quantum-katas/superposition/all-basis-vector-with-phase-flip-two-qubits.qni
+++ b/benchmarks/solutions/quantum-katas/superposition/all-basis-vector-with-phase-flip-two-qubits.qni
@@ -1,0 +1,3 @@
+qni add H --qubit 0 --step 0
+qni add H --qubit 1 --step 0
+qni add Z --control 0 --qubit 1 --step 1

--- a/benchmarks/solutions/quantum-katas/superposition/all-basis-vectors-with-phases-two-qubits.qni
+++ b/benchmarks/solutions/quantum-katas/superposition/all-basis-vectors-with-phases-two-qubits.qni
@@ -1,0 +1,4 @@
+qni add H --qubit 0 --step 0
+qni add H --qubit 1 --step 0
+qni add Z --qubit 0 --step 1
+qni add S --qubit 1 --step 1

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -94,13 +94,15 @@ qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/
 qni benchmark run-all benchmarks/quantum-katas benchmarks/solutions/quantum-katas
 ```
 
-期待される結果は、3問すべてが `passed` になり、終了コードが `0` になることです。
+期待される結果は、5問すべてが `passed` になり、終了コードが `0` になることです。
 
 ```text
 PASS benchmark suite
-tasks: 3
-passed: 3, failed: 0, disallowed: 0, error: 0
+tasks: 5
+passed: 5, failed: 0, disallowed: 0, error: 0
 - passed basic-gates/state-flip StateFlip
+- passed superposition/all-basis-vector-with-phase-flip-two-qubits AllBasisVectorWithPhaseFlip_TwoQubits
+- passed superposition/all-basis-vectors-with-phases-two-qubits AllBasisVectorsWithPhases_TwoQubits
 - passed superposition/bell-state BellState
 - passed superposition/plus-state PlusState
 ```

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -14,7 +14,7 @@
 
 提出物には回路を作るコマンドだけを書きます。`qni run` や `qni expect` などの検証コマンドは書きません。
 
-## 5問の標準解を実行する
+## 7問の標準解を実行する
 
 ### StateFlip
 
@@ -47,6 +47,22 @@ qni benchmark run benchmarks/quantum-katas/superposition/all-basis-vectors-two-q
 ```
 
 期待される結果は `PASS AllBasisVectors_TwoQubits` です。
+
+### AllBasisVectorWithPhaseFlip_TwoQubits
+
+```bash
+qni benchmark run benchmarks/quantum-katas/superposition/all-basis-vector-with-phase-flip-two-qubits.md benchmarks/solutions/quantum-katas/superposition/all-basis-vector-with-phase-flip-two-qubits.qni
+```
+
+期待される結果は `PASS AllBasisVectorWithPhaseFlip_TwoQubits` です。
+
+### AllBasisVectorsWithPhases_TwoQubits
+
+```bash
+qni benchmark run benchmarks/quantum-katas/superposition/all-basis-vectors-with-phases-two-qubits.md benchmarks/solutions/quantum-katas/superposition/all-basis-vectors-with-phases-two-qubits.qni
+```
+
+期待される結果は `PASS AllBasisVectorsWithPhases_TwoQubits` です。
 
 ### BellState
 

--- a/features/cli/benchmark_run.feature.md
+++ b/features/cli/benchmark_run.feature.md
@@ -108,6 +108,50 @@ qni benchmark run で最小の合格判定を実行したい。
   "type": "expect"
   ```
 
+## Scenario: AllBasisVectorWithPhaseFlip_TwoQubits 課題ファイルがある
+
+- Then リポジトリファイル "benchmarks/quantum-katas/superposition/all-basis-vector-with-phase-flip-two-qubits.md" は存在する
+
+## Scenario: AllBasisVectorWithPhaseFlip_TwoQubits 標準解がある
+
+- Then リポジトリファイル "benchmarks/solutions/quantum-katas/superposition/all-basis-vector-with-phase-flip-two-qubits.qni" は存在する
+
+## Scenario: AllBasisVectorWithPhaseFlip_TwoQubits 標準解は合格する
+
+- When "qni benchmark run benchmarks/quantum-katas/superposition/all-basis-vector-with-phase-flip-two-qubits.md benchmarks/solutions/quantum-katas/superposition/all-basis-vector-with-phase-flip-two-qubits.qni" を実行
+- Then コマンドは成功
+
+## Scenario: AllBasisVectorWithPhaseFlip_TwoQubits 標準解の合格が表示される
+
+- When "qni benchmark run benchmarks/quantum-katas/superposition/all-basis-vector-with-phase-flip-two-qubits.md benchmarks/solutions/quantum-katas/superposition/all-basis-vector-with-phase-flip-two-qubits.qni" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  PASS AllBasisVectorWithPhaseFlip_TwoQubits
+  ```
+
+## Scenario: AllBasisVectorsWithPhases_TwoQubits 課題ファイルがある
+
+- Then リポジトリファイル "benchmarks/quantum-katas/superposition/all-basis-vectors-with-phases-two-qubits.md" は存在する
+
+## Scenario: AllBasisVectorsWithPhases_TwoQubits 標準解がある
+
+- Then リポジトリファイル "benchmarks/solutions/quantum-katas/superposition/all-basis-vectors-with-phases-two-qubits.qni" は存在する
+
+## Scenario: AllBasisVectorsWithPhases_TwoQubits 標準解は合格する
+
+- When "qni benchmark run benchmarks/quantum-katas/superposition/all-basis-vectors-with-phases-two-qubits.md benchmarks/solutions/quantum-katas/superposition/all-basis-vectors-with-phases-two-qubits.qni" を実行
+- Then コマンドは成功
+
+## Scenario: AllBasisVectorsWithPhases_TwoQubits 標準解の合格が表示される
+
+- When "qni benchmark run benchmarks/quantum-katas/superposition/all-basis-vectors-with-phases-two-qubits.md benchmarks/solutions/quantum-katas/superposition/all-basis-vectors-with-phases-two-qubits.qni" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  PASS AllBasisVectorsWithPhases_TwoQubits
+  ```
+
 ## Scenario: StateFlip の不許可サンプルがある
 
 - Then リポジトリファイル "benchmarks/disallowed/quantum-katas/basic-gates/state-flip-disallowed.qni" は存在する
@@ -325,9 +369,11 @@ qni benchmark run で最小の合格判定を実行したい。
 
   ```text
   PASS benchmark suite
-  tasks: 3
-  passed: 3, failed: 0, disallowed: 0, error: 0
+  tasks: 5
+  passed: 5, failed: 0, disallowed: 0, error: 0
   - passed basic-gates/state-flip StateFlip
+  - passed superposition/all-basis-vector-with-phase-flip-two-qubits AllBasisVectorWithPhaseFlip_TwoQubits
+  - passed superposition/all-basis-vectors-with-phases-two-qubits AllBasisVectorsWithPhases_TwoQubits
   - passed superposition/bell-state BellState
   - passed superposition/plus-state PlusState
   ```
@@ -342,8 +388,8 @@ qni benchmark run で最小の合格判定を実行したい。
     "status": "passed",
     "exitCode": 0,
     "summary": {
-      "total": 3,
-      "passed": 3,
+      "total": 5,
+      "passed": 5,
       "failed": 0,
       "disallowed": 0,
       "error": 0
@@ -354,6 +400,34 @@ qni benchmark run で最小の合格判定を実行したい。
         "title": "StateFlip",
         "task": "benchmarks/quantum-katas/basic-gates/state-flip.md",
         "submission": "benchmarks/solutions/quantum-katas/basic-gates/state-flip.qni",
+        "status": "passed",
+        "exitCode": 0,
+        "checks": [
+          {
+            "type": "run",
+            "status": "passed"
+          }
+        ]
+      },
+      {
+        "taskId": "superposition/all-basis-vector-with-phase-flip-two-qubits",
+        "title": "AllBasisVectorWithPhaseFlip_TwoQubits",
+        "task": "benchmarks/quantum-katas/superposition/all-basis-vector-with-phase-flip-two-qubits.md",
+        "submission": "benchmarks/solutions/quantum-katas/superposition/all-basis-vector-with-phase-flip-two-qubits.qni",
+        "status": "passed",
+        "exitCode": 0,
+        "checks": [
+          {
+            "type": "run",
+            "status": "passed"
+          }
+        ]
+      },
+      {
+        "taskId": "superposition/all-basis-vectors-with-phases-two-qubits",
+        "title": "AllBasisVectorsWithPhases_TwoQubits",
+        "task": "benchmarks/quantum-katas/superposition/all-basis-vectors-with-phases-two-qubits.md",
+        "submission": "benchmarks/solutions/quantum-katas/superposition/all-basis-vectors-with-phases-two-qubits.qni",
         "status": "passed",
         "exitCode": 0,
         "checks": [

--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -216,6 +216,14 @@ function writeCircuitJson(scenarioDir, data) {
 function quantumKatasSubmissionContent(status, relativePath) {
   const passedSubmissions = new Map([
     ['basic-gates/state-flip.qni', 'qni add X --qubit 0 --step 0\n'],
+    [
+      'superposition/all-basis-vector-with-phase-flip-two-qubits.qni',
+      'qni add H --qubit 0 --step 0\nqni add H --qubit 1 --step 0\nqni add Z --control 0 --qubit 1 --step 1\n'
+    ],
+    [
+      'superposition/all-basis-vectors-with-phases-two-qubits.qni',
+      'qni add H --qubit 0 --step 0\nqni add H --qubit 1 --step 0\nqni add Z --qubit 0 --step 1\nqni add S --qubit 1 --step 1\n'
+    ],
     ['superposition/bell-state.qni', 'qni add H --qubit 0 --step 0\nqni add X --control 0 --qubit 1 --step 1\n'],
     ['superposition/plus-state.qni', 'qni add H --qubit 0 --step 0\n']
   ]);
@@ -245,6 +253,8 @@ function quantumKatasSubmissionContent(status, relativePath) {
 function writeQuantumKatasSubmissions(scenarioDir, status, submissionsDir) {
   const relativePaths = [
     'basic-gates/state-flip.qni',
+    'superposition/all-basis-vector-with-phase-flip-two-qubits.qni',
+    'superposition/all-basis-vectors-with-phases-two-qubits.qni',
     'superposition/bell-state.qni',
     'superposition/plus-state.qni'
   ];

--- a/test/typescript/benchmark_command.test.ts
+++ b/test/typescript/benchmark_command.test.ts
@@ -440,6 +440,36 @@ describe('benchmark command TypeScript route', () => {
     });
   });
 
+  it('passes the AllBasisVectorWithPhaseFlip_TwoQubits solution using a run check', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, [
+        'benchmark',
+        'run',
+        'benchmarks/quantum-katas/superposition/all-basis-vector-with-phase-flip-two-qubits.md',
+        'benchmarks/solutions/quantum-katas/superposition/all-basis-vector-with-phase-flip-two-qubits.qni'
+      ]);
+
+      assert.equal(result.exitStatus, 0, result.stderr);
+      assert.equal(result.stdout, 'PASS AllBasisVectorWithPhaseFlip_TwoQubits\nchecks: 1\n');
+      assert.equal(result.stderr, '');
+    });
+  });
+
+  it('passes the AllBasisVectorsWithPhases_TwoQubits solution using a run check', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, [
+        'benchmark',
+        'run',
+        'benchmarks/quantum-katas/superposition/all-basis-vectors-with-phases-two-qubits.md',
+        'benchmarks/solutions/quantum-katas/superposition/all-basis-vectors-with-phases-two-qubits.qni'
+      ]);
+
+      assert.equal(result.exitStatus, 0, result.stderr);
+      assert.equal(result.stdout, 'PASS AllBasisVectorsWithPhases_TwoQubits\nchecks: 1\n');
+      assert.equal(result.stderr, '');
+    });
+  });
+
   it('uses checks.tolerance from the task file during expect checks', async () => {
     await withTempDir(async (dir) => {
       const taskLines = (tolerance: string) => [
@@ -603,8 +633,8 @@ describe('benchmark command TypeScript route', () => {
       assert.equal(captured.value.status, 'passed');
       assert.equal(captured.value.exitCode, 0);
       assert.deepStrictEqual(captured.value.summary, {
-        total: 3,
-        passed: 3,
+        total: 5,
+        passed: 5,
         failed: 0,
         disallowed: 0,
         error: 0
@@ -617,6 +647,18 @@ describe('benchmark command TypeScript route', () => {
       })), [
         {
           taskId: 'basic-gates/state-flip',
+          status: 'passed',
+          exitCode: 0,
+          checks: [{ type: 'run', status: 'passed' }]
+        },
+        {
+          taskId: 'superposition/all-basis-vector-with-phase-flip-two-qubits',
+          status: 'passed',
+          exitCode: 0,
+          checks: [{ type: 'run', status: 'passed' }]
+        },
+        {
+          taskId: 'superposition/all-basis-vectors-with-phases-two-qubits',
           status: 'passed',
           exitCode: 0,
           checks: [{ type: 'run', status: 'passed' }]
@@ -649,9 +691,11 @@ describe('benchmark command TypeScript route', () => {
       assert.equal(result.exitStatus, 0, result.stderr);
       assert.equal(result.stdout, [
         'PASS benchmark suite',
-        'tasks: 3',
-        'passed: 3, failed: 0, disallowed: 0, error: 0',
+        'tasks: 5',
+        'passed: 5, failed: 0, disallowed: 0, error: 0',
         '- passed basic-gates/state-flip StateFlip',
+        '- passed superposition/all-basis-vector-with-phase-flip-two-qubits AllBasisVectorWithPhaseFlip_TwoQubits',
+        '- passed superposition/all-basis-vectors-with-phases-two-qubits AllBasisVectorsWithPhases_TwoQubits',
         '- passed superposition/bell-state BellState',
         '- passed superposition/plus-state PlusState',
         ''
@@ -676,8 +720,8 @@ describe('benchmark command TypeScript route', () => {
         status: 'passed',
         exitCode: 0,
         summary: {
-          total: 3,
-          passed: 3,
+          total: 5,
+          passed: 5,
           failed: 0,
           disallowed: 0,
           error: 0
@@ -688,6 +732,24 @@ describe('benchmark command TypeScript route', () => {
             title: 'StateFlip',
             task: 'benchmarks/quantum-katas/basic-gates/state-flip.md',
             submission: 'benchmarks/solutions/quantum-katas/basic-gates/state-flip.qni',
+            status: 'passed',
+            exitCode: 0,
+            checks: [{ type: 'run', status: 'passed' }]
+          },
+          {
+            taskId: 'superposition/all-basis-vector-with-phase-flip-two-qubits',
+            title: 'AllBasisVectorWithPhaseFlip_TwoQubits',
+            task: 'benchmarks/quantum-katas/superposition/all-basis-vector-with-phase-flip-two-qubits.md',
+            submission: 'benchmarks/solutions/quantum-katas/superposition/all-basis-vector-with-phase-flip-two-qubits.qni',
+            status: 'passed',
+            exitCode: 0,
+            checks: [{ type: 'run', status: 'passed' }]
+          },
+          {
+            taskId: 'superposition/all-basis-vectors-with-phases-two-qubits',
+            title: 'AllBasisVectorsWithPhases_TwoQubits',
+            task: 'benchmarks/quantum-katas/superposition/all-basis-vectors-with-phases-two-qubits.md',
+            submission: 'benchmarks/solutions/quantum-katas/superposition/all-basis-vectors-with-phases-two-qubits.qni',
             status: 'passed',
             exitCode: 0,
             checks: [{ type: 'run', status: 'passed' }]

--- a/test/typescript/evaluation_runner.test.ts
+++ b/test/typescript/evaluation_runner.test.ts
@@ -184,8 +184,8 @@ describe('evaluation runner public entrypoints', () => {
       assert.equal(captured.value.status, 'passed');
       assert.equal(captured.value.exitCode, 0);
       assert.deepStrictEqual(captured.value.summary, {
-        total: 3,
-        passed: 3,
+        total: 5,
+        passed: 5,
         failed: 0,
         disallowed: 0,
         error: 0
@@ -210,17 +210,19 @@ describe('evaluation runner public entrypoints', () => {
       assert.equal(output.exitCode, 0);
       assert.equal(output.humanOutput, [
         'PASS benchmark suite',
-        'tasks: 3',
-        'passed: 3, failed: 0, disallowed: 0, error: 0',
+        'tasks: 5',
+        'passed: 5, failed: 0, disallowed: 0, error: 0',
         '- passed basic-gates/state-flip StateFlip',
+        '- passed superposition/all-basis-vector-with-phase-flip-two-qubits AllBasisVectorWithPhaseFlip_TwoQubits',
+        '- passed superposition/all-basis-vectors-with-phases-two-qubits AllBasisVectorsWithPhases_TwoQubits',
         '- passed superposition/bell-state BellState',
         '- passed superposition/plus-state PlusState',
         ''
       ].join('\n'));
       assert.equal(output.jsonOutput.status, 'passed');
       assert.deepStrictEqual(output.jsonOutput.summary, {
-        total: 3,
-        passed: 3,
+        total: 5,
+        passed: 5,
         failed: 0,
         disallowed: 0,
         error: 0

--- a/test/typescript/research_command.test.ts
+++ b/test/typescript/research_command.test.ts
@@ -121,6 +121,8 @@ async function prepareQuantumKatasSubmissions(
 ): Promise<void> {
   const relativePaths = [
     'basic-gates/state-flip.qni',
+    'superposition/all-basis-vector-with-phase-flip-two-qubits.qni',
+    'superposition/all-basis-vectors-with-phases-two-qubits.qni',
     'superposition/bell-state.qni',
     'superposition/plus-state.qni'
   ];
@@ -136,6 +138,14 @@ async function prepareQuantumKatasSubmissions(
 function quantumKatasSubmissionContent(status: UnsuccessfulResearchStatus, relativePath: string): string {
   const passedSubmissions = new Map<string, string>([
     ['basic-gates/state-flip.qni', 'qni add X --qubit 0 --step 0\n'],
+    [
+      'superposition/all-basis-vector-with-phase-flip-two-qubits.qni',
+      'qni add H --qubit 0 --step 0\nqni add H --qubit 1 --step 0\nqni add Z --control 0 --qubit 1 --step 1\n'
+    ],
+    [
+      'superposition/all-basis-vectors-with-phases-two-qubits.qni',
+      'qni add H --qubit 0 --step 0\nqni add H --qubit 1 --step 0\nqni add Z --qubit 0 --step 1\nqni add S --qubit 1 --step 1\n'
+    ],
     ['superposition/bell-state.qni', 'qni add H --qubit 0 --step 0\nqni add X --control 0 --qubit 1 --step 1\n'],
     ['superposition/plus-state.qni', 'qni add H --qubit 0 --step 0\n']
   ]);
@@ -748,8 +758,8 @@ describe('research command TypeScript route', () => {
       assert.match(String(metadata.createdAt), /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.000Z$/u);
       assert.equal(gradingResult.status, 'passed');
       assert.deepStrictEqual(gradingResult.summary, {
-        total: 3,
-        passed: 3,
+        total: 5,
+        passed: 5,
         failed: 0,
         disallowed: 0,
         error: 0


### PR DESCRIPTION
## 概要

Quantum Katas Preparing Quantum States の位相付き二量子ビット重ね合わせ課題として、AllBasisVectorWithPhaseFlip_TwoQubits と AllBasisVectorsWithPhases_TwoQubits を追加しました。
複素振幅を `real` / `imaginary` で明示した課題定義と標準解を追加し、run-all の仕様、TypeScript テスト、研究試行用の補助データ、`docs/benchmark.md` を追加課題込みのスイートに更新しています。

Closes #312

## 変更内容

- `benchmarks/quantum-katas/superposition/` に位相付き二量子ビット重ね合わせ課題2件を追加
- `benchmarks/solutions/quantum-katas/superposition/` に controlled-Z / Z+S を使う標準解 `.qni` を追加
- `features/cli/benchmark_run.feature.md` と TypeScript の benchmark/evaluation/research テストを追加課題込みの run-all 結果に更新
- `features/step_definitions/cli_steps.js` の提出物生成と `docs/benchmark.md` の例を拡張

## 確認

- `npm run check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 量子カタ向けの新しい課題を2件追加し、2量子ビットの重ね合わせ状態を扱うベンチマークが増えました。
  * 対応する標準解も追加され、提出・採点の流れが利用できるようになりました。

* **Documentation**
  * ベンチマーク実行例の結果表示を更新し、追加された課題を反映しました。

* **Tests**
  * ベンチマーク実行、JSON出力、採点結果のテストを新しい課題数に合わせて更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->