### PR TITLE
採点ケースごとに setup_commands と提出物を実行できるようにする

### DIFF
--- a/features/cli/benchmark_grading_cases.feature.md
+++ b/features/cli/benchmark_grading_cases.feature.md
@@ -49,3 +49,140 @@ qni-cli の評価ランナー利用者として
 
 - When "qni benchmark run task.md submission.qni" を実行
 - Then 終了コードは 3
+
+## Scenario: 複数の採点ケースをすべて合格できる
+
+- Given 作業ディレクトリに "task.md" を作る:
+
+  ```markdown
+  ---
+  id: grading-cases/x-on-zero-and-one
+  title: XOnZeroAndOne
+  source: test
+  difficulty: smoke
+  allowed_commands:
+    - qni add
+  grading_cases:
+    - id: zero-input
+      checks:
+        tolerance: 1e-9
+        items:
+          - type: run
+            expected:
+              - basis: "|1>"
+                amplitude:
+                  real: 1
+                  imaginary: 0
+    - id: one-input
+      setup_commands:
+        - qni state set "|1>"
+      checks:
+        tolerance: 1e-9
+        items:
+          - type: run
+            expected:
+              - basis: "|0>"
+                amplitude:
+                  real: 1
+                  imaginary: 0
+  ---
+
+  X 回路を複数の入力で採点する課題です。
+  ```
+
+- Given 作業ディレクトリに "submission.qni" を作る:
+
+  ```text
+  qni add X --qubit 0 --step 0
+  ```
+
+- When "qni benchmark run task.md submission.qni" を実行
+- Then コマンドは成功
+
+## Scenario: いずれかの採点ケースが失敗すると不合格になる
+
+- Given 作業ディレクトリに "task.md" を作る:
+
+  ```markdown
+  ---
+  id: grading-cases/x-on-zero-and-one
+  title: XOnZeroAndOne
+  source: test
+  difficulty: smoke
+  allowed_commands:
+    - qni add
+  grading_cases:
+    - id: zero-input
+      checks:
+        tolerance: 1e-9
+        items:
+          - type: run
+            expected:
+              - basis: "|1>"
+                amplitude:
+                  real: 1
+                  imaginary: 0
+    - id: one-input
+      setup_commands:
+        - qni state set "|1>"
+      checks:
+        tolerance: 1e-9
+        items:
+          - type: run
+            expected:
+              - basis: "|1>"
+                amplitude:
+                  real: 1
+                  imaginary: 0
+  ---
+
+  片方の採点ケースだけが失敗する課題です。
+  ```
+
+- Given 作業ディレクトリに "submission.qni" を作る:
+
+  ```text
+  qni add X --qubit 0 --step 0
+  ```
+
+- When "qni benchmark run task.md submission.qni" を実行
+- Then 終了コードは 1
+
+## Scenario: setup_commands の失敗は実行エラーになる
+
+- Given 作業ディレクトリに "task.md" を作る:
+
+  ```markdown
+  ---
+  id: grading-cases/setup-error
+  title: SetupError
+  source: test
+  difficulty: smoke
+  allowed_commands:
+    - qni add
+  grading_cases:
+    - id: bad-setup
+      setup_commands:
+        - qni state set ""
+      checks:
+        tolerance: 1e-9
+        items:
+          - type: run
+            expected:
+              - basis: "|0>"
+                amplitude:
+                  real: 1
+                  imaginary: 0
+  ---
+
+  setup_commands が失敗する課題です。
+  ```
+
+- Given 作業ディレクトリに "submission.qni" を作る:
+
+  ```text
+
+  ```
+
+- When "qni benchmark run task.md submission.qni" を実行
+- Then 終了コードは 3

--- a/features/cli/benchmark_grading_cases.feature.md
+++ b/features/cli/benchmark_grading_cases.feature.md
@@ -105,8 +105,8 @@ qni-cli の評価ランナー利用者として
 
   ```markdown
   ---
-  id: grading-cases/x-on-zero-and-one
-  title: XOnZeroAndOne
+  id: grading-cases/one-case-fails
+  title: OneCaseFails
   source: test
   difficulty: smoke
   allowed_commands:

--- a/libexec/qni_symbolic_run.py
+++ b/libexec/qni_symbolic_run.py
@@ -129,6 +129,8 @@ def parse_state_coefficient(raw_value: str, variables: dict[str, str]):
     imaginary_numeric = IMAGINARY_NUMERIC_PATTERN.match(normalized)
     if imaginary_numeric:
         return I * symbolic_scalar(imaginary_numeric.group("real"))
+    if NUMERIC_PATTERN.match(normalized):
+        return symbolic_scalar(normalized)
 
     return parse_angle(normalized, variables).symbolic
 

--- a/src/evaluation_runner/benchmark_grading.ts
+++ b/src/evaluation_runner/benchmark_grading.ts
@@ -6,9 +6,13 @@ import type { CommandHandler, CommandHandlerContext } from '../dispatcher';
 import { runAddCommand } from '../commands/add_command';
 import { runExpectCommand } from '../commands/expect_command';
 import { runRunCommand } from '../commands/run_command';
+import { runStateCommand } from '../commands/state_command';
 import {
   loadBenchmarkTask,
   type BenchmarkCheck,
+  type BenchmarkChecks,
+  type BenchmarkGradingCase,
+  type BenchmarkSetupCommand,
   type BenchmarkTask,
   type ComplexAmplitude,
   type ExpectedAmplitude,
@@ -30,6 +34,11 @@ interface ExpectedStateVector {
 interface BasisMetadata {
   readonly index: number;
   readonly vectorLength: number;
+}
+
+interface BenchmarkCheckContext {
+  readonly checks: BenchmarkChecks;
+  readonly taskId: string;
 }
 
 interface QniCommandResult {
@@ -161,7 +170,8 @@ class BenchmarkError extends Error {}
 const QNI_COMMAND_HANDLERS = new Map<string, CommandHandler>([
   ['add', runAddCommand],
   ['expect', runExpectCommand],
-  ['run', runRunCommand]
+  ['run', runRunCommand],
+  ['state', runStateCommand]
 ]);
 const MAX_FAILED_AMPLITUDE_DETAILS = 16;
 const MAX_FAILED_EXPECTATION_DETAILS = 16;
@@ -283,16 +293,37 @@ function evaluateBenchmark(options: {
     };
   }
 
+  const checks = options.task.gradingCases.flatMap((gradingCase) => evaluateGradingCase({
+    context: options.context,
+    gradingCase,
+    submissionCommands: submission.commands,
+    task: options.task
+  }));
+
+  return {
+    checks,
+    status: checks.every((check) => check.status === 'passed') ? 'passed' : 'failed'
+  };
+}
+
+function evaluateGradingCase(options: {
+  readonly context: CommandHandlerContext;
+  readonly gradingCase: BenchmarkGradingCase;
+  readonly submissionCommands: readonly SubmissionCommand[];
+  readonly task: BenchmarkTask;
+}): BenchmarkCheckResult[] {
   const workDir = mkdtempSync(path.join(tmpdir(), 'qni-benchmark-'));
 
   try {
-    runSubmission(submission.commands, workDir, options.context);
-    const checks = options.task.checks.items.map((check) => runBenchmarkCheck(check, options.task, workDir, options.context));
+    runSetupCommands(options.gradingCase, workDir, options.context);
+    runSubmission(options.submissionCommands, workDir, options.context);
 
-    return {
-      checks,
-      status: checks.every((check) => check.status === 'passed') ? 'passed' : 'failed'
+    const checkContext: BenchmarkCheckContext = {
+      checks: options.gradingCase.checks,
+      taskId: options.task.id
     };
+
+    return options.gradingCase.checks.items.map((check) => runBenchmarkCheck(check, checkContext, workDir, options.context));
   } finally {
     rmSync(workDir, { force: true, recursive: true });
   }
@@ -469,35 +500,61 @@ function runSubmission(commands: readonly SubmissionCommand[], workDir: string, 
   }
 }
 
+function runSetupCommands(
+  gradingCase: BenchmarkGradingCase,
+  workDir: string,
+  context: CommandHandlerContext
+): void {
+  for (const command of gradingCase.setupCommands) {
+    runSetupCommand(command, gradingCase, workDir, context);
+  }
+}
+
+function runSetupCommand(
+  command: BenchmarkSetupCommand,
+  gradingCase: BenchmarkGradingCase,
+  workDir: string,
+  context: CommandHandlerContext
+): void {
+  const result = runQni(command.argv, workDir, context);
+
+  if (result.exitStatus !== 0) {
+    throw new BenchmarkError([
+      `setup command failed in grading case ${gradingCase.id}: ${command.source}`,
+      result.stderr.trimEnd()
+    ].filter(Boolean).join('\n'));
+  }
+}
+
 function runBenchmarkCheck(
   check: BenchmarkCheck,
-  task: BenchmarkTask,
+  checkContext: BenchmarkCheckContext,
   workDir: string,
   context: CommandHandlerContext
 ): BenchmarkCheckResult {
   switch (check.type) {
     case 'expect':
-      return runExpectCheck(check, task, workDir, context);
+      return runExpectCheck(check, checkContext, workDir, context);
     case 'run':
-      return runRunCheck(check, task, workDir, context);
+      return runRunCheck(check, checkContext, workDir, context);
   }
 }
 
 function runRunCheck(
   check: RunCheck,
-  task: BenchmarkTask,
+  checkContext: BenchmarkCheckContext,
   workDir: string,
   context: CommandHandlerContext
 ): RunCheckResult {
   const result = runQni(['run'], workDir, context);
 
   if (result.exitStatus !== 0) {
-    throw new BenchmarkError(`run check failed to execute for ${task.id}: ${result.stderr.trimEnd()}`);
+    throw new BenchmarkError(`run check failed to execute for ${checkContext.taskId}: ${result.stderr.trimEnd()}`);
   }
 
   const actual = parseStateVector(result.stdout);
   const expected = expectedStateVector(check.expected);
-  const mismatches = stateVectorMismatchSummary(actual, expected, task.checks.tolerance);
+  const mismatches = stateVectorMismatchSummary(actual, expected, checkContext.checks.tolerance);
 
   return {
     mismatches,
@@ -508,18 +565,18 @@ function runRunCheck(
 
 function runExpectCheck(
   check: ExpectCheck,
-  task: BenchmarkTask,
+  checkContext: BenchmarkCheckContext,
   workDir: string,
   context: CommandHandlerContext
 ): ExpectCheckResult {
   const result = runQni(['expect', ...check.expected.map((item) => item.pauli)], workDir, context);
 
   if (result.exitStatus !== 0) {
-    throw new BenchmarkError(`expect check failed to execute for ${task.id}: ${result.stderr.trimEnd()}`);
+    throw new BenchmarkError(`expect check failed to execute for ${checkContext.taskId}: ${result.stderr.trimEnd()}`);
   }
 
   const actual = parseExpectationValues(result.stdout);
-  const mismatches = expectationMismatchSummary(actual, check.expected, task.checks.tolerance);
+  const mismatches = expectationMismatchSummary(actual, check.expected, checkContext.checks.tolerance);
 
   return {
     mismatches,

--- a/src/initial_state.ts
+++ b/src/initial_state.ts
@@ -136,6 +136,15 @@ function parseTerm(rawValue: string): InitialStateTerm {
 
 function specialInitialState(rawValue: unknown): InitialStateData | undefined {
   const text = String(rawValue).trim();
+  const computationalBasis = computationalBasisShorthand(text);
+
+  if (computationalBasis) {
+    return {
+      format: FORMAT,
+      terms: [{ basis: computationalBasis, coefficient: '1' }]
+    };
+  }
+
   const oneQubitCoefficient = ONE_QUBIT_SPECIAL_STATES.get(text);
 
   if (oneQubitCoefficient) {
@@ -158,6 +167,12 @@ function specialInitialState(rawValue: unknown): InitialStateData | undefined {
   }
 
   return undefined;
+}
+
+function computationalBasisShorthand(text: string): string | undefined {
+  const match = /^\|(?<basis>[01]+)>$/u.exec(text);
+
+  return match?.groups?.basis;
 }
 
 function normalizedText(rawValue: unknown): string {

--- a/test/typescript/evaluation_runner.test.ts
+++ b/test/typescript/evaluation_runner.test.ts
@@ -132,6 +132,189 @@ describe('evaluation runner public entrypoints', () => {
     });
   });
 
+  it('grades every grading case in an isolated work directory', async () => {
+    await withTempDir(async (dir) => {
+      await writeFile(path.join(dir, 'task.md'), [
+        '---',
+        'id: grading-cases/x-on-zero-and-one',
+        'title: XOnZeroAndOne',
+        'source: test',
+        'difficulty: smoke',
+        'allowed_commands:',
+        '  - qni add',
+        'grading_cases:',
+        '  - id: zero-input',
+        '    checks:',
+        '      tolerance: 1e-9',
+        '      items:',
+        '        - type: run',
+        '          expected:',
+        '            - basis: "|1>"',
+        '              amplitude:',
+        '                real: 1',
+        '                imaginary: 0',
+        '  - id: one-input',
+        '    setup_commands:',
+        '      - qni state set "|1>"',
+        '    checks:',
+        '      tolerance: 1e-9',
+        '      items:',
+        '        - type: run',
+        '          expected:',
+        '            - basis: "|0>"',
+        '              amplitude:',
+        '                real: 1',
+        '                imaginary: 0',
+        '---',
+        '',
+        'Apply X to both basis inputs.'
+      ].join('\n'));
+      await writeFile(path.join(dir, 'submission.qni'), 'qni add X --qubit 0 --step 0\n');
+
+      const captured = captureProcessWrites(() => gradeBenchmarkTask({
+        taskFile: 'task.md',
+        submissionFile: 'submission.qni'
+      }, {
+        cwd: dir,
+        env: { PATH: '' },
+        projectRoot: process.cwd()
+      }));
+
+      assert.equal(captured.stdout, '');
+      assert.equal(captured.stderr, '');
+      assert.deepStrictEqual(captured.value, {
+        taskId: 'grading-cases/x-on-zero-and-one',
+        title: 'XOnZeroAndOne',
+        submission: 'submission.qni',
+        status: 'passed',
+        exitCode: 0,
+        checks: [
+          { type: 'run', status: 'passed' },
+          { type: 'run', status: 'passed' }
+        ]
+      });
+    });
+  });
+
+  it('fails the task when any grading case check fails', async () => {
+    await withTempDir(async (dir) => {
+      await writeFile(path.join(dir, 'task.md'), [
+        '---',
+        'id: grading-cases/one-case-fails',
+        'title: OneCaseFails',
+        'source: test',
+        'difficulty: smoke',
+        'allowed_commands:',
+        '  - qni add',
+        'grading_cases:',
+        '  - id: zero-input',
+        '    checks:',
+        '      tolerance: 1e-9',
+        '      items:',
+        '        - type: run',
+        '          expected:',
+        '            - basis: "|1>"',
+        '              amplitude:',
+        '                real: 1',
+        '                imaginary: 0',
+        '  - id: one-input',
+        '    setup_commands:',
+        '      - qni state set "|1>"',
+        '    checks:',
+        '      tolerance: 1e-9',
+        '      items:',
+        '        - type: run',
+        '          expected:',
+        '            - basis: "|1>"',
+        '              amplitude:',
+        '                real: 1',
+        '                imaginary: 0',
+        '---',
+        '',
+        'One case should fail.'
+      ].join('\n'));
+      await writeFile(path.join(dir, 'submission.qni'), 'qni add X --qubit 0 --step 0\n');
+
+      const captured = captureProcessWrites(() => gradeBenchmarkTask({
+        taskFile: 'task.md',
+        submissionFile: 'submission.qni'
+      }, {
+        cwd: dir,
+        env: { PATH: '' },
+        projectRoot: process.cwd()
+      }));
+
+      assert.equal(captured.stdout, '');
+      assert.equal(captured.stderr, '');
+      assert.deepStrictEqual(captured.value, {
+        taskId: 'grading-cases/one-case-fails',
+        title: 'OneCaseFails',
+        submission: 'submission.qni',
+        status: 'failed',
+        exitCode: 1,
+        checks: [
+          { type: 'run', status: 'passed' },
+          { type: 'run', status: 'failed' }
+        ]
+      });
+    });
+  });
+
+  it('classifies setup command failures as benchmark errors', async () => {
+    await withTempDir(async (dir) => {
+      await writeFile(path.join(dir, 'task.md'), [
+        '---',
+        'id: grading-cases/setup-error',
+        'title: SetupError',
+        'source: test',
+        'difficulty: smoke',
+        'allowed_commands:',
+        '  - qni add',
+        'grading_cases:',
+        '  - id: bad-setup',
+        '    setup_commands:',
+        '      - qni state set ""',
+        '    checks:',
+        '      tolerance: 1e-9',
+        '      items:',
+        '        - type: run',
+        '          expected:',
+        '            - basis: "|0>"',
+        '              amplitude:',
+        '                real: 1',
+        '                imaginary: 0',
+        '---',
+        '',
+        'Setup should fail before checks run.'
+      ].join('\n'));
+      await writeFile(path.join(dir, 'submission.qni'), '');
+
+      const captured = captureProcessWrites(() => gradeBenchmarkTask({
+        taskFile: 'task.md',
+        submissionFile: 'submission.qni'
+      }, {
+        cwd: dir,
+        env: { PATH: '' },
+        projectRoot: process.cwd()
+      }));
+
+      assert.equal(captured.stdout, '');
+      assert.equal(captured.stderr, '');
+      assert.deepStrictEqual(captured.value, {
+        taskId: 'grading-cases/setup-error',
+        title: 'SetupError',
+        submission: 'submission.qni',
+        status: 'error',
+        exitCode: 3,
+        checks: [],
+        error: [
+          'setup command failed in grading case bad-setup: qni state set ',
+          'initial state expression is required'
+        ].join('\n')
+      });
+    });
+  });
+
   it('provides a single-task report that the benchmark adapter formats without regrading', async () => {
     await withTempDir(async (dir) => {
       const captured = captureProcessWrites(() => gradeBenchmarkTaskForReport({


### PR DESCRIPTION
## 概要

ベンチマーク課題の `grading_cases` を、ケースごとに独立した一時作業場所で採点できるようにしました。各ケースでは `setup_commands`、提出 `.qni`、`checks` の順に実行し、セットアップ失敗とチェック失敗を既存の評価結果へ反映します。

`qni state set "|1>"` のような基底状態の短縮表記も扱えるようにし、記号表示に不要な `1*` が混入しないよう Python ヘルパーも調整しています。

Closes #307

## 変更内容

- `features/cli/benchmark_grading_cases.feature.md` に、複数ケース成功・一部ケース失敗・セットアップ失敗の受け入れシナリオを追加しました。
- `src/evaluation_runner/benchmark_grading.ts` で `grading_cases` をケース単位に隔離して実行し、`setup_commands` と提出コマンド、チェック結果を順序どおり評価するようにしました。
- `src/initial_state.ts` と `libexec/qni_symbolic_run.py` で `|0>` / `|1>` 形式の状態指定と記号表示の係数正規化を扱えるようにしました。
- `test/typescript/evaluation_runner.test.ts` に評価ランナー単体の回帰テストを追加しました。

## 確認

- `npm run check`