### PR TITLE
GHZState の固定サイズベンチマークを追加する

### DIFF
--- a/benchmarks/quantum-katas/superposition/ghz-state.md
+++ b/benchmarks/quantum-katas/superposition/ghz-state.md
@@ -1,0 +1,27 @@
+---
+id: superposition/ghz-state
+title: GHZState
+source: Microsoft Quantum Katas / Superposition
+difficulty: smoke
+allowed_commands:
+  - qni add
+checks:
+  tolerance: 1e-9
+  items:
+    - type: run
+      expected:
+        - basis: "|000>"
+          amplitude:
+            real: 0.7071067811865476
+            imaginary: 0
+        - basis: "|111>"
+          amplitude:
+            real: 0.7071067811865476
+            imaginary: 0
+---
+
+このベンチマーク課題は、`N = 3` に固定した GHZState です。
+3量子ビットを `|000>` から GHZ 状態 `( |000> + |111> ) / sqrt(2)` に変える量子回路を、`qni` コマンド列として作成してください。
+
+任意の `N` に対応する必要はありません。
+提出物は `.qni` 形式で、1行に1つずつ完全な `qni` コマンドを書いてください。

--- a/benchmarks/solutions/quantum-katas/superposition/ghz-state.qni
+++ b/benchmarks/solutions/quantum-katas/superposition/ghz-state.qni
@@ -1,0 +1,3 @@
+qni add H --qubit 0 --step 0
+qni add X --control 0 --qubit 1 --step 1
+qni add X --control 0 --qubit 2 --step 2

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -14,7 +14,7 @@
 
 提出物には回路を作るコマンドだけを書きます。`qni run` や `qni expect` などの検証コマンドは書きません。
 
-## 5問の標準解を実行する
+## 6問の標準解を実行する
 
 ### StateFlip
 
@@ -55,6 +55,14 @@ qni benchmark run benchmarks/quantum-katas/superposition/bell-state.md benchmark
 ```
 
 期待される結果は `PASS BellState` です。
+
+### GHZState
+
+```bash
+qni benchmark run benchmarks/quantum-katas/superposition/ghz-state.md benchmarks/solutions/quantum-katas/superposition/ghz-state.qni
+```
+
+期待される結果は `PASS GHZState` です。
 
 ## 不正解サンプルを実行する
 
@@ -110,15 +118,16 @@ qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/
 qni benchmark run-all benchmarks/quantum-katas benchmarks/solutions/quantum-katas
 ```
 
-期待される結果は、5問すべてが `passed` になり、終了コードが `0` になることです。
+期待される結果は、6問すべてが `passed` になり、終了コードが `0` になることです。
 
 ```text
 PASS benchmark suite
-tasks: 5
-passed: 5, failed: 0, disallowed: 0, error: 0
+tasks: 6
+passed: 6, failed: 0, disallowed: 0, error: 0
 - passed basic-gates/state-flip StateFlip
 - passed superposition/all-basis-vectors-two-qubits AllBasisVectors_TwoQubits
 - passed superposition/bell-state BellState
+- passed superposition/ghz-state GHZState
 - passed superposition/minus-state MinusState
 - passed superposition/plus-state PlusState
 ```

--- a/features/cli/benchmark_run.feature.md
+++ b/features/cli/benchmark_run.feature.md
@@ -152,6 +152,37 @@ qni benchmark run で最小の合格判定を実行したい。
   "type": "expect"
   ```
 
+## Scenario: GHZState 課題ファイルがある
+
+- Then リポジトリファイル "benchmarks/quantum-katas/superposition/ghz-state.md" は存在する
+
+## Scenario: GHZState 標準解がある
+
+- Then リポジトリファイル "benchmarks/solutions/quantum-katas/superposition/ghz-state.qni" は存在する
+
+## Scenario: GHZState 標準解は合格する
+
+- When "qni benchmark run benchmarks/quantum-katas/superposition/ghz-state.md benchmarks/solutions/quantum-katas/superposition/ghz-state.qni" を実行
+- Then コマンドは成功
+
+## Scenario: GHZState 標準解の合格が表示される
+
+- When "qni benchmark run benchmarks/quantum-katas/superposition/ghz-state.md benchmarks/solutions/quantum-katas/superposition/ghz-state.qni" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  PASS GHZState
+  ```
+
+## Scenario: GHZState 標準解の JSON は run 検証を含む
+
+- When "qni benchmark run benchmarks/quantum-katas/superposition/ghz-state.md benchmarks/solutions/quantum-katas/superposition/ghz-state.qni --json" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  "type": "run"
+  ```
+
 ## Scenario: StateFlip の不許可サンプルがある
 
 - Then リポジトリファイル "benchmarks/disallowed/quantum-katas/basic-gates/state-flip-disallowed.qni" は存在する
@@ -345,6 +376,10 @@ qni benchmark run で最小の合格判定を実行したい。
 
 - Then リポジトリファイル "docs/benchmark.md" は "qni benchmark run benchmarks/quantum-katas/superposition/bell-state.md benchmarks/solutions/quantum-katas/superposition/bell-state.qni" を含む
 
+## Scenario: MVP手順は GHZState 標準解の実行例を示す
+
+- Then リポジトリファイル "docs/benchmark.md" は "qni benchmark run benchmarks/quantum-katas/superposition/ghz-state.md benchmarks/solutions/quantum-katas/superposition/ghz-state.qni" を含む
+
 ## Scenario: MVP手順は MinusState 標準解の実行例を示す
 
 - Then リポジトリファイル "docs/benchmark.md" は "qni benchmark run benchmarks/quantum-katas/superposition/minus-state.md benchmarks/solutions/quantum-katas/superposition/minus-state.qni" を含む
@@ -377,11 +412,12 @@ qni benchmark run で最小の合格判定を実行したい。
 
   ```text
   PASS benchmark suite
-  tasks: 5
-  passed: 5, failed: 0, disallowed: 0, error: 0
+  tasks: 6
+  passed: 6, failed: 0, disallowed: 0, error: 0
   - passed basic-gates/state-flip StateFlip
   - passed superposition/all-basis-vectors-two-qubits AllBasisVectors_TwoQubits
   - passed superposition/bell-state BellState
+  - passed superposition/ghz-state GHZState
   - passed superposition/minus-state MinusState
   - passed superposition/plus-state PlusState
   ```
@@ -396,8 +432,8 @@ qni benchmark run で最小の合格判定を実行したい。
     "status": "passed",
     "exitCode": 0,
     "summary": {
-      "total": 5,
-      "passed": 5,
+      "total": 6,
+      "passed": 6,
       "failed": 0,
       "disallowed": 0,
       "error": 0
@@ -441,6 +477,20 @@ qni benchmark run で最小の合格判定を実行したい。
         "checks": [
           {
             "type": "expect",
+            "status": "passed"
+          }
+        ]
+      },
+      {
+        "taskId": "superposition/ghz-state",
+        "title": "GHZState",
+        "task": "benchmarks/quantum-katas/superposition/ghz-state.md",
+        "submission": "benchmarks/solutions/quantum-katas/superposition/ghz-state.qni",
+        "status": "passed",
+        "exitCode": 0,
+        "checks": [
+          {
+            "type": "run",
             "status": "passed"
           }
         ]

--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -218,6 +218,7 @@ function quantumKatasSubmissionContent(status, relativePath) {
     ['basic-gates/state-flip.qni', 'qni add X --qubit 0 --step 0\n'],
     ['superposition/all-basis-vectors-two-qubits.qni', 'qni add H --qubit 0 --step 0\nqni add H --qubit 1 --step 0\n'],
     ['superposition/bell-state.qni', 'qni add H --qubit 0 --step 0\nqni add X --control 0 --qubit 1 --step 1\n'],
+    ['superposition/ghz-state.qni', 'qni add H --qubit 0 --step 0\nqni add X --control 0 --qubit 1 --step 1\nqni add X --control 0 --qubit 2 --step 2\n'],
     ['superposition/minus-state.qni', 'qni add X --qubit 0 --step 0\nqni add H --qubit 0 --step 1\n'],
     ['superposition/plus-state.qni', 'qni add H --qubit 0 --step 0\n']
   ]);
@@ -249,6 +250,7 @@ function writeQuantumKatasSubmissions(scenarioDir, status, submissionsDir) {
     'basic-gates/state-flip.qni',
     'superposition/all-basis-vectors-two-qubits.qni',
     'superposition/bell-state.qni',
+    'superposition/ghz-state.qni',
     'superposition/minus-state.qni',
     'superposition/plus-state.qni'
   ];

--- a/test/typescript/benchmark_command.test.ts
+++ b/test/typescript/benchmark_command.test.ts
@@ -633,8 +633,8 @@ describe('benchmark command TypeScript route', () => {
       assert.equal(captured.value.status, 'passed');
       assert.equal(captured.value.exitCode, 0);
       assert.deepStrictEqual(captured.value.summary, {
-        total: 5,
-        passed: 5,
+        total: 6,
+        passed: 6,
         failed: 0,
         disallowed: 0,
         error: 0
@@ -664,6 +664,12 @@ describe('benchmark command TypeScript route', () => {
           checks: [{ type: 'expect', status: 'passed' }]
         },
         {
+          taskId: 'superposition/ghz-state',
+          status: 'passed',
+          exitCode: 0,
+          checks: [{ type: 'run', status: 'passed' }]
+        },
+        {
           taskId: 'superposition/minus-state',
           status: 'passed',
           exitCode: 0,
@@ -691,11 +697,12 @@ describe('benchmark command TypeScript route', () => {
       assert.equal(result.exitStatus, 0, result.stderr);
       assert.equal(result.stdout, [
         'PASS benchmark suite',
-        'tasks: 5',
-        'passed: 5, failed: 0, disallowed: 0, error: 0',
+        'tasks: 6',
+        'passed: 6, failed: 0, disallowed: 0, error: 0',
         '- passed basic-gates/state-flip StateFlip',
         '- passed superposition/all-basis-vectors-two-qubits AllBasisVectors_TwoQubits',
         '- passed superposition/bell-state BellState',
+        '- passed superposition/ghz-state GHZState',
         '- passed superposition/minus-state MinusState',
         '- passed superposition/plus-state PlusState',
         ''
@@ -720,8 +727,8 @@ describe('benchmark command TypeScript route', () => {
         status: 'passed',
         exitCode: 0,
         summary: {
-          total: 5,
-          passed: 5,
+          total: 6,
+          passed: 6,
           failed: 0,
           disallowed: 0,
           error: 0
@@ -753,6 +760,15 @@ describe('benchmark command TypeScript route', () => {
             status: 'passed',
             exitCode: 0,
             checks: [{ type: 'expect', status: 'passed' }]
+          },
+          {
+            taskId: 'superposition/ghz-state',
+            title: 'GHZState',
+            task: 'benchmarks/quantum-katas/superposition/ghz-state.md',
+            submission: 'benchmarks/solutions/quantum-katas/superposition/ghz-state.qni',
+            status: 'passed',
+            exitCode: 0,
+            checks: [{ type: 'run', status: 'passed' }]
           },
           {
             taskId: 'superposition/minus-state',

--- a/test/typescript/evaluation_runner.test.ts
+++ b/test/typescript/evaluation_runner.test.ts
@@ -184,8 +184,8 @@ describe('evaluation runner public entrypoints', () => {
       assert.equal(captured.value.status, 'passed');
       assert.equal(captured.value.exitCode, 0);
       assert.deepStrictEqual(captured.value.summary, {
-        total: 5,
-        passed: 5,
+        total: 6,
+        passed: 6,
         failed: 0,
         disallowed: 0,
         error: 0
@@ -210,19 +210,20 @@ describe('evaluation runner public entrypoints', () => {
       assert.equal(output.exitCode, 0);
       assert.equal(output.humanOutput, [
         'PASS benchmark suite',
-        'tasks: 5',
-        'passed: 5, failed: 0, disallowed: 0, error: 0',
+        'tasks: 6',
+        'passed: 6, failed: 0, disallowed: 0, error: 0',
         '- passed basic-gates/state-flip StateFlip',
         '- passed superposition/all-basis-vectors-two-qubits AllBasisVectors_TwoQubits',
         '- passed superposition/bell-state BellState',
+        '- passed superposition/ghz-state GHZState',
         '- passed superposition/minus-state MinusState',
         '- passed superposition/plus-state PlusState',
         ''
       ].join('\n'));
       assert.equal(output.jsonOutput.status, 'passed');
       assert.deepStrictEqual(output.jsonOutput.summary, {
-        total: 5,
-        passed: 5,
+        total: 6,
+        passed: 6,
         failed: 0,
         disallowed: 0,
         error: 0

--- a/test/typescript/research_command.test.ts
+++ b/test/typescript/research_command.test.ts
@@ -123,6 +123,7 @@ async function prepareQuantumKatasSubmissions(
     'basic-gates/state-flip.qni',
     'superposition/all-basis-vectors-two-qubits.qni',
     'superposition/bell-state.qni',
+    'superposition/ghz-state.qni',
     'superposition/minus-state.qni',
     'superposition/plus-state.qni'
   ];
@@ -140,6 +141,7 @@ function quantumKatasSubmissionContent(status: UnsuccessfulResearchStatus, relat
     ['basic-gates/state-flip.qni', 'qni add X --qubit 0 --step 0\n'],
     ['superposition/all-basis-vectors-two-qubits.qni', 'qni add H --qubit 0 --step 0\nqni add H --qubit 1 --step 0\n'],
     ['superposition/bell-state.qni', 'qni add H --qubit 0 --step 0\nqni add X --control 0 --qubit 1 --step 1\n'],
+    ['superposition/ghz-state.qni', 'qni add H --qubit 0 --step 0\nqni add X --control 0 --qubit 1 --step 1\nqni add X --control 0 --qubit 2 --step 2\n'],
     ['superposition/minus-state.qni', 'qni add X --qubit 0 --step 0\nqni add H --qubit 0 --step 1\n'],
     ['superposition/plus-state.qni', 'qni add H --qubit 0 --step 0\n']
   ]);
@@ -752,8 +754,8 @@ describe('research command TypeScript route', () => {
       assert.match(String(metadata.createdAt), /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.000Z$/u);
       assert.equal(gradingResult.status, 'passed');
       assert.deepStrictEqual(gradingResult.summary, {
-        total: 5,
-        passed: 5,
+        total: 6,
+        passed: 6,
         failed: 0,
         disallowed: 0,
         error: 0


### PR DESCRIPTION
## 概要

Quantum Katas Preparing Quantum States の GHZ_State を、現行の `.qni` 提出物で扱える `N = 3` 固定ベンチマークとして追加します。
標準解は `H` と制御 `X` 列で `(|000> + |111>) / sqrt(2)` を作り、既存の一括実行と研究試行用のテストデータも新課題を含む形に更新します。

Closes #313

## 変更内容

- `benchmarks/quantum-katas/superposition/ghz-state.md` に `N = 3` 固定の GHZState 課題を追加し、`|000>` と `|111>` の振幅を数値で検証する条件を定義
- `benchmarks/solutions/quantum-katas/superposition/ghz-state.qni` に `H` と制御 `X` 列の標準解を追加
- `features/cli/benchmark_run.feature.md`、ステップ定義、TypeScript テストで `run` / `run-all` の期待値を新課題込みに更新
- `docs/benchmark.md` と研究試行テストデータで、6課題構成と GHZState 標準解を反映

## 確認

- `npm run check`