### PR TITLE
複数採点ケースの結果を run / run-all 出力で追跡できるようにする

### DIFF
--- a/features/cli/benchmark_grading_case_output.feature.md
+++ b/features/cli/benchmark_grading_case_output.feature.md
@@ -1,0 +1,217 @@
+# Feature: qni benchmark grading case output
+
+qni-cli の評価ランナー利用者として
+複数の採点ケースを持つ課題の失敗箇所を調査できるように
+ケース ID と検証条件種別を出力から追跡したい。
+
+## Scenario: 複数採点ケースの JSON 出力で case ID を確認できる
+
+- Given 作業ディレクトリに "task.md" を作る:
+
+  ```markdown
+  ---
+  id: grading-cases/x-on-zero-and-one
+  title: XOnZeroAndOne
+  source: test
+  difficulty: smoke
+  allowed_commands:
+    - qni add
+  grading_cases:
+    - id: zero-input
+      checks:
+        tolerance: 1e-9
+        items:
+          - type: run
+            expected:
+              - basis: "|1>"
+                amplitude:
+                  real: 1
+                  imaginary: 0
+    - id: one-input
+      setup_commands:
+        - qni state set "|1>"
+      checks:
+        tolerance: 1e-9
+        items:
+          - type: run
+            expected:
+              - basis: "|1>"
+                amplitude:
+                  real: 1
+                  imaginary: 0
+  ---
+
+  片方の採点ケースだけが失敗する課題です。
+  ```
+
+- Given 作業ディレクトリに "submission.qni" を作る:
+
+  ```text
+  qni add X --qubit 0 --step 0
+  ```
+
+- When "qni benchmark run task.md submission.qni --json" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  "caseId": "one-input"
+  ```
+
+## Scenario: 複数採点ケースの人間向け出力で失敗 case ID と検証条件種別を確認できる
+
+- Given 作業ディレクトリに "task.md" を作る:
+
+  ```markdown
+  ---
+  id: grading-cases/x-on-zero-and-one
+  title: XOnZeroAndOne
+  source: test
+  difficulty: smoke
+  allowed_commands:
+    - qni add
+  grading_cases:
+    - id: zero-input
+      checks:
+        tolerance: 1e-9
+        items:
+          - type: run
+            expected:
+              - basis: "|1>"
+                amplitude:
+                  real: 1
+                  imaginary: 0
+    - id: one-input
+      setup_commands:
+        - qni state set "|1>"
+      checks:
+        tolerance: 1e-9
+        items:
+          - type: run
+            expected:
+              - basis: "|1>"
+                amplitude:
+                  real: 1
+                  imaginary: 0
+  ---
+
+  片方の採点ケースだけが失敗する課題です。
+  ```
+
+- Given 作業ディレクトリに "submission.qni" を作る:
+
+  ```text
+  qni add X --qubit 0 --step 0
+  ```
+
+- When "qni benchmark run task.md submission.qni" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  - case one-input run #1: state vector did not match expected amplitudes
+  ```
+
+## Scenario: run-all の JSON 出力でもケース別結果を確認できる
+
+- Given 作業ディレクトリに "benchmarks/grading-cases/x-on-zero-and-one.md" を作る:
+
+  ```markdown
+  ---
+  id: grading-cases/x-on-zero-and-one
+  title: XOnZeroAndOne
+  source: test
+  difficulty: smoke
+  allowed_commands:
+    - qni add
+  grading_cases:
+    - id: zero-input
+      checks:
+        tolerance: 1e-9
+        items:
+          - type: run
+            expected:
+              - basis: "|1>"
+                amplitude:
+                  real: 1
+                  imaginary: 0
+    - id: one-input
+      setup_commands:
+        - qni state set "|1>"
+      checks:
+        tolerance: 1e-9
+        items:
+          - type: run
+            expected:
+              - basis: "|1>"
+                amplitude:
+                  real: 1
+                  imaginary: 0
+  ---
+
+  片方の採点ケースだけが失敗する課題です。
+  ```
+
+- Given 作業ディレクトリに "solutions/grading-cases/x-on-zero-and-one.qni" を作る:
+
+  ```text
+  qni add X --qubit 0 --step 0
+  ```
+
+- When "qni benchmark run-all benchmarks solutions --json" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  "caseId": "one-input"
+  ```
+
+## Scenario: run-all の人間向け出力でも失敗 case ID と検証条件種別を確認できる
+
+- Given 作業ディレクトリに "benchmarks/grading-cases/x-on-zero-and-one.md" を作る:
+
+  ```markdown
+  ---
+  id: grading-cases/x-on-zero-and-one
+  title: XOnZeroAndOne
+  source: test
+  difficulty: smoke
+  allowed_commands:
+    - qni add
+  grading_cases:
+    - id: zero-input
+      checks:
+        tolerance: 1e-9
+        items:
+          - type: run
+            expected:
+              - basis: "|1>"
+                amplitude:
+                  real: 1
+                  imaginary: 0
+    - id: one-input
+      setup_commands:
+        - qni state set "|1>"
+      checks:
+        tolerance: 1e-9
+        items:
+          - type: run
+            expected:
+              - basis: "|1>"
+                amplitude:
+                  real: 1
+                  imaginary: 0
+  ---
+
+  片方の採点ケースだけが失敗する課題です。
+  ```
+
+- Given 作業ディレクトリに "solutions/grading-cases/x-on-zero-and-one.qni" を作る:
+
+  ```text
+  qni add X --qubit 0 --step 0
+  ```
+
+- When "qni benchmark run-all benchmarks solutions" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  - case one-input run #1: failed
+  ```

--- a/src/commands/benchmark_output.ts
+++ b/src/commands/benchmark_output.ts
@@ -2,7 +2,9 @@ import type { BenchmarkTask, ComplexAmplitude } from '../evaluation_runner/bench
 import type {
   AmplitudeMismatch,
   BenchmarkCheckResult,
+  BenchmarkCheckSummary,
   BenchmarkGradingCaseResult,
+  BenchmarkGradingCaseSummary,
   BenchmarkResult,
   BenchmarkSuiteGradingResult,
   BenchmarkSuiteTaskGradingResult,
@@ -23,6 +25,12 @@ class BenchmarkReportError extends Error {}
 
 const MAX_FAILED_AMPLITUDE_DETAILS = 16;
 const MAX_FAILED_EXPECTATION_DETAILS = 16;
+
+type FailedGradingCaseCheck<TCheck extends BenchmarkCheckResult | BenchmarkCheckSummary> = {
+  readonly caseId: string;
+  readonly check: TCheck;
+  readonly index: number;
+};
 
 export function benchmarkTaskCommandReport(
   report: BenchmarkTaskGradingReport
@@ -77,10 +85,15 @@ function formatBenchmarkSuiteTaskLines(item: BenchmarkSuiteTaskGradingResult): s
 }
 
 function suiteTaskFailedCheckLines(item: BenchmarkSuiteTaskGradingResult): string[] {
-  return item.gradingCases?.flatMap((gradingCase) => gradingCase.checks
-    .map((check, index) => ({ caseId: gradingCase.caseId, check, index }))
-    .filter((entry) => entry.check.status === 'failed')
-    .map((entry) => `  - case ${entry.caseId} ${entry.check.type} #${entry.index + 1}: failed`)) ?? [];
+  if (!item.gradingCases) {
+    return [];
+  }
+
+  return [
+    ...failedGradingCaseChecks(item.gradingCases)
+      .map((entry) => `  - case ${entry.caseId} ${entry.check.type} #${entry.index + 1}: failed`),
+    ...suiteTaskGradingCaseErrorLines(item.gradingCases)
+  ];
 }
 
 function formatHumanResult(task: BenchmarkTask | undefined, result: BenchmarkResult): string {
@@ -132,9 +145,7 @@ function failedCheckDetailsLines(result: BenchmarkResult): string[] {
 }
 
 function failedGradingCaseDetailsLines(gradingCases: readonly BenchmarkGradingCaseResult[]): string[] {
-  const failedChecks = gradingCases.flatMap((gradingCase) => gradingCase.checks
-    .map((check, index) => ({ caseId: gradingCase.caseId, check, index }))
-    .filter((item) => item.check.status === 'failed'));
+  const failedChecks = failedGradingCaseChecks(gradingCases);
 
   if (failedChecks.length === 0) {
     return [];
@@ -148,6 +159,29 @@ function failedGradingCaseDetailsLines(gradingCases: readonly BenchmarkGradingCa
       failedCheck.caseId
     ))
   ];
+}
+
+function failedGradingCaseChecks<TCheck extends BenchmarkCheckResult | BenchmarkCheckSummary>(
+  gradingCases: readonly { readonly caseId: string; readonly checks: readonly TCheck[] }[]
+): FailedGradingCaseCheck<TCheck>[] {
+  return gradingCases.flatMap((gradingCase) => gradingCase.checks
+    .map((check, index) => ({ caseId: gradingCase.caseId, check, index }))
+    .filter((entry) => entry.check.status === 'failed'));
+}
+
+function suiteTaskGradingCaseErrorLines(gradingCases: readonly BenchmarkGradingCaseSummary[]): string[] {
+  return gradingCases.flatMap((gradingCase) => {
+    if (gradingCase.error === undefined) {
+      return [];
+    }
+
+    const [firstLine = '', ...additionalLines] = gradingCase.error.split(/\r?\n/u);
+
+    return [
+      `  - case ${gradingCase.caseId} error: ${firstLine}`,
+      ...additionalLines.map((line) => `    ${line}`)
+    ];
+  });
 }
 
 function failedCheckLines(check: BenchmarkCheckResult, index: number, caseId?: string): string[] {

--- a/src/commands/benchmark_output.ts
+++ b/src/commands/benchmark_output.ts
@@ -89,10 +89,14 @@ function suiteTaskFailedCheckLines(item: BenchmarkSuiteTaskGradingResult): strin
     return [];
   }
 
+  if (!hasMultipleGradingCases(item.gradingCases)) {
+    return suiteTaskGradingCaseErrorLines(item.gradingCases, false);
+  }
+
   return [
     ...failedGradingCaseChecks(item.gradingCases)
       .map((entry) => `  - case ${entry.caseId} ${entry.check.type} #${entry.index + 1}: failed`),
-    ...suiteTaskGradingCaseErrorLines(item.gradingCases)
+    ...suiteTaskGradingCaseErrorLines(item.gradingCases, true)
   ];
 }
 
@@ -126,7 +130,7 @@ function formatErrorResult(task: BenchmarkTask | undefined, result: BenchmarkRes
 }
 
 function failedCheckDetailsLines(result: BenchmarkResult): string[] {
-  if (result.gradingCases) {
+  if (result.gradingCases && hasMultipleGradingCases(result.gradingCases)) {
     return failedGradingCaseDetailsLines(result.gradingCases);
   }
 
@@ -169,16 +173,24 @@ function failedGradingCaseChecks<TCheck extends BenchmarkCheckResult | Benchmark
     .filter((entry) => entry.check.status === 'failed'));
 }
 
-function suiteTaskGradingCaseErrorLines(gradingCases: readonly BenchmarkGradingCaseSummary[]): string[] {
+function hasMultipleGradingCases(gradingCases: readonly unknown[]): boolean {
+  return gradingCases.length > 1;
+}
+
+function suiteTaskGradingCaseErrorLines(
+  gradingCases: readonly BenchmarkGradingCaseSummary[],
+  includeCaseId: boolean
+): string[] {
   return gradingCases.flatMap((gradingCase) => {
     if (gradingCase.error === undefined) {
       return [];
     }
 
     const [firstLine = '', ...additionalLines] = gradingCase.error.split(/\r?\n/u);
+    const label = includeCaseId ? `case ${gradingCase.caseId} error` : 'error';
 
     return [
-      `  - case ${gradingCase.caseId} error: ${firstLine}`,
+      `  - ${label}: ${firstLine}`,
       ...additionalLines.map((line) => `    ${line}`)
     ];
   });

--- a/src/commands/benchmark_output.ts
+++ b/src/commands/benchmark_output.ts
@@ -2,8 +2,10 @@ import type { BenchmarkTask, ComplexAmplitude } from '../evaluation_runner/bench
 import type {
   AmplitudeMismatch,
   BenchmarkCheckResult,
+  BenchmarkGradingCaseResult,
   BenchmarkResult,
   BenchmarkSuiteGradingResult,
+  BenchmarkSuiteTaskGradingResult,
   BenchmarkTaskGradingResult,
   BenchmarkTaskGradingReport,
   ExpectationMismatch,
@@ -63,8 +65,22 @@ function formatBenchmarkSuiteHumanOutput(suite: BenchmarkSuiteGradingResult): st
       `disallowed: ${suite.summary.disallowed}`,
       `error: ${suite.summary.error}`
     ].join(', '),
-    ...suite.results.map((item) => `- ${item.status} ${item.taskId ?? item.task} ${item.title ?? '(unavailable)'}`)
+    ...suite.results.flatMap(formatBenchmarkSuiteTaskLines)
   ]);
+}
+
+function formatBenchmarkSuiteTaskLines(item: BenchmarkSuiteTaskGradingResult): string[] {
+  return [
+    `- ${item.status} ${item.taskId ?? item.task} ${item.title ?? '(unavailable)'}`,
+    ...suiteTaskFailedCheckLines(item)
+  ];
+}
+
+function suiteTaskFailedCheckLines(item: BenchmarkSuiteTaskGradingResult): string[] {
+  return item.gradingCases?.flatMap((gradingCase) => gradingCase.checks
+    .map((check, index) => ({ caseId: gradingCase.caseId, check, index }))
+    .filter((entry) => entry.check.status === 'failed')
+    .map((entry) => `  - case ${entry.caseId} ${entry.check.type} #${entry.index + 1}: failed`)) ?? [];
 }
 
 function formatHumanResult(task: BenchmarkTask | undefined, result: BenchmarkResult): string {
@@ -97,6 +113,10 @@ function formatErrorResult(task: BenchmarkTask | undefined, result: BenchmarkRes
 }
 
 function failedCheckDetailsLines(result: BenchmarkResult): string[] {
+  if (result.gradingCases) {
+    return failedGradingCaseDetailsLines(result.gradingCases);
+  }
+
   const failedChecks = result.checks
     .map((check, index) => ({ check, index }))
     .filter((item) => item.check.status === 'failed');
@@ -111,31 +131,56 @@ function failedCheckDetailsLines(result: BenchmarkResult): string[] {
   ];
 }
 
-function failedCheckLines(check: BenchmarkCheckResult, index: number): string[] {
+function failedGradingCaseDetailsLines(gradingCases: readonly BenchmarkGradingCaseResult[]): string[] {
+  const failedChecks = gradingCases.flatMap((gradingCase) => gradingCase.checks
+    .map((check, index) => ({ caseId: gradingCase.caseId, check, index }))
+    .filter((item) => item.check.status === 'failed'));
+
+  if (failedChecks.length === 0) {
+    return [];
+  }
+
+  return [
+    'failed checks:',
+    ...failedChecks.flatMap((failedCheck) => failedCheckLines(
+      failedCheck.check,
+      failedCheck.index,
+      failedCheck.caseId
+    ))
+  ];
+}
+
+function failedCheckLines(check: BenchmarkCheckResult, index: number, caseId?: string): string[] {
   switch (check.type) {
     case 'expect':
-      return failedExpectationCheckLines(check, index);
+      return failedExpectationCheckLines(check, index, caseId);
     case 'run':
-      return failedRunCheckLines(check, index);
+      return failedRunCheckLines(check, index, caseId);
   }
 }
 
-function failedRunCheckLines(check: RunCheckResult, index: number): string[] {
+function failedRunCheckLines(check: RunCheckResult, index: number, caseId?: string): string[] {
   return [
-    `- ${check.type} #${index + 1}: state vector did not match expected amplitudes`,
+    `- ${failedCheckLabel(check, index, caseId)}: state vector did not match expected amplitudes`,
     '  expected / actual mismatches:',
     ...displayedAmplitudeMismatches(check.mismatches.displayed),
     ...omittedAmplitudeMismatchLines(check.mismatches.omittedCount)
   ];
 }
 
-function failedExpectationCheckLines(check: ExpectCheckResult, index: number): string[] {
+function failedExpectationCheckLines(check: ExpectCheckResult, index: number, caseId?: string): string[] {
   return [
-    `- ${check.type} #${index + 1}: expectation values did not match expected values`,
+    `- ${failedCheckLabel(check, index, caseId)}: expectation values did not match expected values`,
     '  expected / actual mismatches:',
     ...displayedExpectationMismatches(check.mismatches.displayed),
     ...omittedExpectationMismatchLines(check.mismatches.omittedCount)
   ];
+}
+
+function failedCheckLabel(check: BenchmarkCheckResult, index: number, caseId: string | undefined): string {
+  const checkLabel = `${check.type} #${index + 1}`;
+
+  return caseId === undefined ? checkLabel : `case ${caseId} ${checkLabel}`;
 }
 
 function displayedAmplitudeMismatches(mismatches: readonly AmplitudeMismatch[]): string[] {

--- a/src/evaluation_runner.ts
+++ b/src/evaluation_runner.ts
@@ -3,6 +3,8 @@ export {
   gradeBenchmarkTask,
   gradeBenchmarkTaskForReport,
   type BenchmarkCheckSummary,
+  type BenchmarkGradingCaseStatus,
+  type BenchmarkGradingCaseSummary,
   type BenchmarkStatus,
   type BenchmarkSuiteGradingRequest,
   type BenchmarkSuiteGradingResult,

--- a/src/evaluation_runner/benchmark_grading.ts
+++ b/src/evaluation_runner/benchmark_grading.ts
@@ -48,6 +48,7 @@ interface QniCommandResult {
 }
 
 export type BenchmarkStatus = 'passed' | 'failed' | 'disallowed' | 'error';
+export type BenchmarkGradingCaseStatus = 'passed' | 'failed' | 'error';
 
 export interface BenchmarkTaskGradingRequest {
   readonly submissionFile: string;
@@ -64,10 +65,18 @@ export interface BenchmarkCheckSummary {
   readonly type: 'expect' | 'run';
 }
 
+export interface BenchmarkGradingCaseSummary {
+  readonly caseId: string;
+  readonly checks: readonly BenchmarkCheckSummary[];
+  readonly error?: string;
+  readonly status: BenchmarkGradingCaseStatus;
+}
+
 export interface BenchmarkTaskGradingResult {
   readonly checks: readonly BenchmarkCheckSummary[];
   readonly error?: string;
   readonly exitCode: number;
+  readonly gradingCases?: readonly BenchmarkGradingCaseSummary[];
   readonly status: BenchmarkStatus;
   readonly submission: string;
   readonly taskId: string | null;
@@ -90,6 +99,7 @@ export interface BenchmarkResult {
   readonly checks: readonly BenchmarkCheckResult[];
   readonly disallowedSubmission?: DisallowedSubmission;
   readonly errorMessage?: string;
+  readonly gradingCases?: readonly BenchmarkGradingCaseResult[];
   readonly status: BenchmarkStatus;
 }
 
@@ -130,6 +140,13 @@ export interface BenchmarkSuiteSummary {
 }
 
 export type BenchmarkCheckResult = ExpectCheckResult | RunCheckResult;
+
+export interface BenchmarkGradingCaseResult {
+  readonly caseId: string;
+  readonly checks: readonly BenchmarkCheckResult[];
+  readonly errorMessage?: string;
+  readonly status: BenchmarkGradingCaseStatus;
+}
 
 export interface RunCheckResult {
   readonly mismatches: MismatchSummary;
@@ -280,10 +297,16 @@ function evaluateBenchmark(options: {
   readonly submissionPath: string;
   readonly task: BenchmarkTask;
 }): BenchmarkResult {
-  const submission = readBenchmarkSubmission({
-    allowedCommands: options.task.allowedCommands,
-    submissionPath: options.submissionPath
-  });
+  let submission: ReturnType<typeof readBenchmarkSubmission>;
+
+  try {
+    submission = readBenchmarkSubmission({
+      allowedCommands: options.task.allowedCommands,
+      submissionPath: options.submissionPath
+    });
+  } catch (error) {
+    return benchmarkErrorResultForTask(options.task, errorMessage(error));
+  }
 
   if (submission.kind === 'disallowed') {
     return {
@@ -293,16 +316,20 @@ function evaluateBenchmark(options: {
     };
   }
 
-  const checks = options.task.gradingCases.flatMap((gradingCase) => evaluateGradingCase({
+  const gradingCases = options.task.gradingCases.map((gradingCase) => evaluateGradingCase({
     context: options.context,
     gradingCase,
     submissionCommands: submission.commands,
     task: options.task
   }));
+  const checks = gradingCases.flatMap((gradingCase) => gradingCase.checks);
+  const firstCaseError = gradingCases.find((gradingCase) => gradingCase.status === 'error')?.errorMessage;
 
   return {
     checks,
-    status: checks.every((check) => check.status === 'passed') ? 'passed' : 'failed'
+    ...explicitGradingCasesResult(options.task, gradingCases),
+    ...optionalErrorMessage(firstCaseError),
+    status: benchmarkStatusForGradingCases(gradingCases)
   };
 }
 
@@ -311,7 +338,7 @@ function evaluateGradingCase(options: {
   readonly gradingCase: BenchmarkGradingCase;
   readonly submissionCommands: readonly SubmissionCommand[];
   readonly task: BenchmarkTask;
-}): BenchmarkCheckResult[] {
+}): BenchmarkGradingCaseResult {
   const workDir = mkdtempSync(path.join(tmpdir(), 'qni-benchmark-'));
 
   try {
@@ -322,11 +349,71 @@ function evaluateGradingCase(options: {
       checks: options.gradingCase.checks,
       taskId: options.task.id
     };
+    const checks = runBenchmarkChecks(options.gradingCase.checks.items, checkContext, workDir, options.context);
 
-    return options.gradingCase.checks.items.map((check) => runBenchmarkCheck(check, checkContext, workDir, options.context));
+    return {
+      caseId: options.gradingCase.id,
+      checks,
+      status: checks.every((check) => check.status === 'passed') ? 'passed' : 'failed'
+    };
+  } catch (error) {
+    return {
+      caseId: options.gradingCase.id,
+      checks: [],
+      errorMessage: errorMessage(error),
+      status: 'error'
+    };
   } finally {
     rmSync(workDir, { force: true, recursive: true });
   }
+}
+
+function runBenchmarkChecks(
+  checks: readonly BenchmarkCheck[],
+  checkContext: BenchmarkCheckContext,
+  workDir: string,
+  context: CommandHandlerContext
+): BenchmarkCheckResult[] {
+  return checks.map((check) => runBenchmarkCheck(check, checkContext, workDir, context));
+}
+
+function benchmarkErrorResultForTask(task: BenchmarkTask, error: string): BenchmarkResult {
+  const gradingCases = task.gradingCases.map((gradingCase) => ({
+    caseId: gradingCase.id,
+    checks: [],
+    errorMessage: error,
+    status: 'error' as const
+  }));
+
+  return {
+    checks: [],
+    ...explicitGradingCasesResult(task, gradingCases),
+    errorMessage: error,
+    status: 'error'
+  };
+}
+
+function explicitGradingCasesResult(
+  task: BenchmarkTask,
+  gradingCases: readonly BenchmarkGradingCaseResult[]
+): Pick<BenchmarkResult, 'gradingCases'> {
+  return task.hasExplicitGradingCases ? { gradingCases } : {};
+}
+
+function optionalErrorMessage(errorMessage: string | undefined): Pick<BenchmarkResult, 'errorMessage'> {
+  return errorMessage === undefined ? {} : { errorMessage };
+}
+
+function benchmarkStatusForGradingCases(gradingCases: readonly BenchmarkGradingCaseResult[]): BenchmarkStatus {
+  if (gradingCases.some((gradingCase) => gradingCase.status === 'error')) {
+    return 'error';
+  }
+
+  if (gradingCases.some((gradingCase) => gradingCase.status === 'failed')) {
+    return 'failed';
+  }
+
+  return 'passed';
 }
 
 function benchmarkSuiteEntries(options: {
@@ -846,6 +933,7 @@ function benchmarkResultPayload(
     submission,
     status: result.status,
     exitCode: exitCodeForResult(result),
+    ...explicitGradingCasesPayload(task, result.gradingCases),
     checks: result.checks.map((check) => ({
       type: check.type,
       status: check.status
@@ -860,6 +948,31 @@ function benchmarkResultPayload(
   }
 
   return payload;
+}
+
+function explicitGradingCasesPayload(
+  task: BenchmarkTask | undefined,
+  gradingCases: readonly BenchmarkGradingCaseResult[] | undefined
+): Pick<BenchmarkTaskGradingResult, 'gradingCases'> {
+  if (!task?.hasExplicitGradingCases || !gradingCases) {
+    return {};
+  }
+
+  return {
+    gradingCases: gradingCases.map((gradingCase) => ({
+      caseId: gradingCase.caseId,
+      status: gradingCase.status,
+      checks: gradingCase.checks.map((check) => ({
+        type: check.type,
+        status: check.status
+      })),
+      ...optionalCaseError(gradingCase.errorMessage)
+    }))
+  };
+}
+
+function optionalCaseError(error: string | undefined): Pick<BenchmarkGradingCaseSummary, 'error'> {
+  return error === undefined ? {} : { error };
 }
 
 function exitCodeForResult(result: BenchmarkResult): number {

--- a/src/evaluation_runner/benchmark_grading.ts
+++ b/src/evaluation_runner/benchmark_grading.ts
@@ -323,12 +323,11 @@ function evaluateBenchmark(options: {
     task: options.task
   }));
   const checks = gradingCases.flatMap((gradingCase) => gradingCase.checks);
-  const firstCaseError = gradingCases.find((gradingCase) => gradingCase.status === 'error')?.errorMessage;
 
   return {
     checks,
     ...explicitGradingCasesResult(options.task, gradingCases),
-    ...optionalErrorMessage(firstCaseError),
+    ...optionalErrorMessage(firstGradingCaseErrorMessage(options.task, gradingCases)),
     status: benchmarkStatusForGradingCases(gradingCases)
   };
 }
@@ -402,6 +401,23 @@ function explicitGradingCasesResult(
 
 function optionalErrorMessage(errorMessage: string | undefined): Pick<BenchmarkResult, 'errorMessage'> {
   return errorMessage === undefined ? {} : { errorMessage };
+}
+
+function firstGradingCaseErrorMessage(
+  task: BenchmarkTask,
+  gradingCases: readonly BenchmarkGradingCaseResult[]
+): string | undefined {
+  const gradingCase = gradingCases.find((item) => item.status === 'error' && item.errorMessage !== undefined);
+
+  if (!gradingCase?.errorMessage) {
+    return undefined;
+  }
+
+  if (!task.hasExplicitGradingCases) {
+    return gradingCase.errorMessage;
+  }
+
+  return `case ${gradingCase.caseId} error: ${gradingCase.errorMessage}`;
 }
 
 function benchmarkStatusForGradingCases(gradingCases: readonly BenchmarkGradingCaseResult[]): BenchmarkStatus {

--- a/src/evaluation_runner/benchmark_task.ts
+++ b/src/evaluation_runner/benchmark_task.ts
@@ -7,6 +7,7 @@ export interface BenchmarkTask {
   readonly allowedCommands: readonly AllowedCommand[];
   readonly checks: BenchmarkChecks;
   readonly gradingCases: readonly BenchmarkGradingCase[];
+  readonly hasExplicitGradingCases: boolean;
   readonly id: string;
   readonly title: string;
 }
@@ -73,12 +74,14 @@ const IMPLICIT_GRADING_CASE_ID = 'default';
 export function loadBenchmarkTask(taskPath: string): BenchmarkTask {
   const frontmatter = frontmatterRecord(frontmatterOf(readFileSync(taskPath, 'utf8')));
   const allowedCommands = parseAllowedCommands(frontmatter);
+  const hasExplicitGradingCases = hasValue(frontmatter, 'grading_cases');
   const gradingCases = parseGradingCases(frontmatter);
 
   return {
     allowedCommands,
     checks: compatibleChecks(gradingCases),
     gradingCases,
+    hasExplicitGradingCases,
     id: scalarValue(frontmatter, 'id'),
     title: scalarValue(frontmatter, 'title')
   };

--- a/src/evaluation_runner/benchmark_task.ts
+++ b/src/evaluation_runner/benchmark_task.ts
@@ -7,7 +7,7 @@ export interface BenchmarkTask {
   readonly allowedCommands: readonly AllowedCommand[];
   readonly checks: BenchmarkChecks;
   readonly gradingCases: readonly BenchmarkGradingCase[];
-  readonly hasExplicitGradingCases: boolean;
+  readonly hasExplicitGradingCases?: boolean;
   readonly id: string;
   readonly title: string;
 }

--- a/src/evaluation_runner/benchmark_task.ts
+++ b/src/evaluation_runner/benchmark_task.ts
@@ -75,7 +75,7 @@ export function loadBenchmarkTask(taskPath: string): BenchmarkTask {
   const frontmatter = frontmatterRecord(frontmatterOf(readFileSync(taskPath, 'utf8')));
   const allowedCommands = parseAllowedCommands(frontmatter);
   const hasExplicitGradingCases = hasValue(frontmatter, 'grading_cases');
-  const gradingCases = parseGradingCases(frontmatter);
+  const gradingCases = parseGradingCases(frontmatter, hasExplicitGradingCases);
 
   return {
     allowedCommands,
@@ -150,9 +150,11 @@ function parseChecks(frontmatter: FrontmatterRecord): BenchmarkChecks {
   };
 }
 
-function parseGradingCases(frontmatter: FrontmatterRecord): BenchmarkGradingCase[] {
+function parseGradingCases(
+  frontmatter: FrontmatterRecord,
+  hasExplicitGradingCases: boolean
+): BenchmarkGradingCase[] {
   const hasRootChecks = hasValue(frontmatter, 'checks');
-  const hasExplicitGradingCases = hasValue(frontmatter, 'grading_cases');
 
   if (hasRootChecks && hasExplicitGradingCases) {
     throw new BenchmarkTaskError('checks and grading_cases must not both be specified');

--- a/test/typescript/benchmark_command.test.ts
+++ b/test/typescript/benchmark_command.test.ts
@@ -969,6 +969,32 @@ describe('benchmark command TypeScript route', () => {
     });
   });
 
+  it('prints grading case error messages in run-all human-readable task lines', async () => {
+    await withTempDir(async (dir) => {
+      await mkdir(path.join(dir, 'benchmarks', 'grading-cases'), { recursive: true });
+      await mkdir(path.join(dir, 'solutions', 'grading-cases'), { recursive: true });
+      await writeFile(
+        path.join(dir, 'benchmarks', 'grading-cases', 'setup-error.md'),
+        setupErrorGradingCasesTask()
+      );
+      await writeFile(path.join(dir, 'solutions', 'grading-cases', 'setup-error.qni'), '');
+
+      const result = captureDispatcherRun(dir, ['benchmark', 'run-all', 'benchmarks', 'solutions']);
+
+      assert.equal(result.exitStatus, 3, result.stderr);
+      assert.equal(result.stdout, [
+        'FAIL benchmark suite',
+        'tasks: 1',
+        'passed: 0, failed: 0, disallowed: 0, error: 1',
+        '- error grading-cases/setup-error SetupError',
+        '  - case bad-setup error: setup command failed in grading case bad-setup: qni state set ',
+        '    initial state expression is required',
+        ''
+      ].join('\n'));
+      assert.equal(result.stderr, '');
+    });
+  });
+
   it('keeps grading case results in run-all JSON without inflating task summary counts', async () => {
     await withTempDir(async (dir) => {
       await mkdir(path.join(dir, 'benchmarks', 'grading-cases'), { recursive: true });
@@ -1063,5 +1089,33 @@ function xOnZeroAndOneGradingCasesTask(): string {
     '---',
     '',
     'Apply X to both basis inputs.'
+  ].join('\n');
+}
+
+function setupErrorGradingCasesTask(): string {
+  return [
+    '---',
+    'id: grading-cases/setup-error',
+    'title: SetupError',
+    'source: test',
+    'difficulty: smoke',
+    'allowed_commands:',
+    '  - qni add',
+    'grading_cases:',
+    '  - id: bad-setup',
+    '    setup_commands:',
+    '      - qni state set ""',
+    '    checks:',
+    '      tolerance: 1e-9',
+    '      items:',
+    '        - type: run',
+    '          expected:',
+    '            - basis: "|0>"',
+    '              amplitude:',
+    '                real: 1',
+    '                imaginary: 0',
+    '---',
+    '',
+    'Setup should fail before checks run.'
   ].join('\n');
 }

--- a/test/typescript/benchmark_command.test.ts
+++ b/test/typescript/benchmark_command.test.ts
@@ -563,6 +563,64 @@ describe('benchmark command TypeScript route', () => {
     });
   });
 
+  it('prints failed grading case ids in human-readable check details', async () => {
+    await withTempDir(async (dir) => {
+      await writeFile(path.join(dir, 'task.md'), xOnZeroAndOneGradingCasesTask());
+      await writeFile(path.join(dir, 'submission.qni'), 'qni add X --qubit 0 --step 0\n');
+
+      const result = captureDispatcherRun(dir, ['benchmark', 'run', 'task.md', 'submission.qni']);
+
+      assert.equal(result.exitStatus, 1, result.stderr);
+      assert.equal(result.stdout, [
+        'FAIL XOnZeroAndOne',
+        'checks: 2',
+        'failed checks:',
+        '- case one-input run #1: state vector did not match expected amplitudes',
+        '  expected / actual mismatches:',
+        '  - |0>: expected 0, actual 1',
+        '  - |1>: expected 1, actual 0',
+        ''
+      ].join('\n'));
+      assert.equal(result.stderr, '');
+    });
+  });
+
+  it('writes JSON grading case results for explicit grading cases', async () => {
+    await withTempDir(async (dir) => {
+      await writeFile(path.join(dir, 'task.md'), xOnZeroAndOneGradingCasesTask());
+      await writeFile(path.join(dir, 'submission.qni'), 'qni add X --qubit 0 --step 0\n');
+
+      const result = captureDispatcherRun(dir, ['benchmark', 'run', 'task.md', 'submission.qni', '--json']);
+      const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+      assert.equal(result.exitStatus, 1, result.stderr);
+      assert.deepStrictEqual(payload, {
+        taskId: 'grading-cases/x-on-zero-and-one',
+        title: 'XOnZeroAndOne',
+        submission: 'submission.qni',
+        status: 'failed',
+        exitCode: 1,
+        gradingCases: [
+          {
+            caseId: 'zero-input',
+            status: 'passed',
+            checks: [{ type: 'run', status: 'passed' }]
+          },
+          {
+            caseId: 'one-input',
+            status: 'failed',
+            checks: [{ type: 'run', status: 'failed' }]
+          }
+        ],
+        checks: [
+          { type: 'run', status: 'passed' },
+          { type: 'run', status: 'failed' }
+        ]
+      });
+      assert.equal(result.stderr, '');
+    });
+  });
+
   it('limits failed check details to mismatched amplitudes that fit human-readable output', async () => {
     await withTempDir(async (dir) => {
       await writeFile(path.join(dir, 'task.md'), [
@@ -882,4 +940,128 @@ describe('benchmark command TypeScript route', () => {
       assert.equal(result.stderr, '');
     });
   });
+
+  it('prints failed grading case ids in run-all human-readable task lines', async () => {
+    await withTempDir(async (dir) => {
+      await mkdir(path.join(dir, 'benchmarks', 'grading-cases'), { recursive: true });
+      await mkdir(path.join(dir, 'solutions', 'grading-cases'), { recursive: true });
+      await writeFile(
+        path.join(dir, 'benchmarks', 'grading-cases', 'x-on-zero-and-one.md'),
+        xOnZeroAndOneGradingCasesTask()
+      );
+      await writeFile(
+        path.join(dir, 'solutions', 'grading-cases', 'x-on-zero-and-one.qni'),
+        'qni add X --qubit 0 --step 0\n'
+      );
+
+      const result = captureDispatcherRun(dir, ['benchmark', 'run-all', 'benchmarks', 'solutions']);
+
+      assert.equal(result.exitStatus, 1, result.stderr);
+      assert.equal(result.stdout, [
+        'FAIL benchmark suite',
+        'tasks: 1',
+        'passed: 0, failed: 1, disallowed: 0, error: 0',
+        '- failed grading-cases/x-on-zero-and-one XOnZeroAndOne',
+        '  - case one-input run #1: failed',
+        ''
+      ].join('\n'));
+      assert.equal(result.stderr, '');
+    });
+  });
+
+  it('keeps grading case results in run-all JSON without inflating task summary counts', async () => {
+    await withTempDir(async (dir) => {
+      await mkdir(path.join(dir, 'benchmarks', 'grading-cases'), { recursive: true });
+      await mkdir(path.join(dir, 'solutions', 'grading-cases'), { recursive: true });
+      await writeFile(
+        path.join(dir, 'benchmarks', 'grading-cases', 'x-on-zero-and-one.md'),
+        xOnZeroAndOneGradingCasesTask()
+      );
+      await writeFile(
+        path.join(dir, 'solutions', 'grading-cases', 'x-on-zero-and-one.qni'),
+        'qni add X --qubit 0 --step 0\n'
+      );
+
+      const result = captureDispatcherRun(dir, ['benchmark', 'run-all', 'benchmarks', 'solutions', '--json']);
+      const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+      assert.equal(result.exitStatus, 1, result.stderr);
+      assert.deepStrictEqual(payload, {
+        status: 'failed',
+        exitCode: 1,
+        summary: {
+          total: 1,
+          passed: 0,
+          failed: 1,
+          disallowed: 0,
+          error: 0
+        },
+        results: [
+          {
+            taskId: 'grading-cases/x-on-zero-and-one',
+            title: 'XOnZeroAndOne',
+            task: 'benchmarks/grading-cases/x-on-zero-and-one.md',
+            submission: 'solutions/grading-cases/x-on-zero-and-one.qni',
+            status: 'failed',
+            exitCode: 1,
+            gradingCases: [
+              {
+                caseId: 'zero-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              },
+              {
+                caseId: 'one-input',
+                status: 'failed',
+                checks: [{ type: 'run', status: 'failed' }]
+              }
+            ],
+            checks: [
+              { type: 'run', status: 'passed' },
+              { type: 'run', status: 'failed' }
+            ]
+          }
+        ]
+      });
+      assert.equal(result.stderr, '');
+    });
+  });
 });
+
+function xOnZeroAndOneGradingCasesTask(): string {
+  return [
+    '---',
+    'id: grading-cases/x-on-zero-and-one',
+    'title: XOnZeroAndOne',
+    'source: test',
+    'difficulty: smoke',
+    'allowed_commands:',
+    '  - qni add',
+    'grading_cases:',
+    '  - id: zero-input',
+    '    checks:',
+    '      tolerance: 1e-9',
+    '      items:',
+    '        - type: run',
+    '          expected:',
+    '            - basis: "|1>"',
+    '              amplitude:',
+    '                real: 1',
+    '                imaginary: 0',
+    '  - id: one-input',
+    '    setup_commands:',
+    '      - qni state set "|1>"',
+    '    checks:',
+    '      tolerance: 1e-9',
+    '      items:',
+    '        - type: run',
+    '          expected:',
+    '            - basis: "|1>"',
+    '              amplitude:',
+    '                real: 1',
+    '                imaginary: 0',
+    '---',
+    '',
+    'Apply X to both basis inputs.'
+  ].join('\n');
+}

--- a/test/typescript/benchmark_command.test.ts
+++ b/test/typescript/benchmark_command.test.ts
@@ -585,6 +585,28 @@ describe('benchmark command TypeScript route', () => {
     });
   });
 
+  it('keeps single grading case human-readable check details generic', async () => {
+    await withTempDir(async (dir) => {
+      await writeFile(path.join(dir, 'task.md'), singleXGradingCaseTask());
+      await writeFile(path.join(dir, 'submission.qni'), 'qni add X --qubit 0 --step 0\n');
+
+      const result = captureDispatcherRun(dir, ['benchmark', 'run', 'task.md', 'submission.qni']);
+
+      assert.equal(result.exitStatus, 1, result.stderr);
+      assert.equal(result.stdout, [
+        'FAIL XOnZero',
+        'checks: 1',
+        'failed checks:',
+        '- run #1: state vector did not match expected amplitudes',
+        '  expected / actual mismatches:',
+        '  - |0>: expected 1, actual 0',
+        '  - |1>: expected 0, actual 1',
+        ''
+      ].join('\n'));
+      assert.equal(result.stderr, '');
+    });
+  });
+
   it('writes JSON grading case results for explicit grading cases', async () => {
     await withTempDir(async (dir) => {
       await writeFile(path.join(dir, 'task.md'), xOnZeroAndOneGradingCasesTask());
@@ -969,6 +991,33 @@ describe('benchmark command TypeScript route', () => {
     });
   });
 
+  it('keeps single grading case ids out of run-all human-readable task lines', async () => {
+    await withTempDir(async (dir) => {
+      await mkdir(path.join(dir, 'benchmarks', 'grading-cases'), { recursive: true });
+      await mkdir(path.join(dir, 'solutions', 'grading-cases'), { recursive: true });
+      await writeFile(
+        path.join(dir, 'benchmarks', 'grading-cases', 'x-on-zero.md'),
+        singleXGradingCaseTask()
+      );
+      await writeFile(
+        path.join(dir, 'solutions', 'grading-cases', 'x-on-zero.qni'),
+        'qni add X --qubit 0 --step 0\n'
+      );
+
+      const result = captureDispatcherRun(dir, ['benchmark', 'run-all', 'benchmarks', 'solutions']);
+
+      assert.equal(result.exitStatus, 1, result.stderr);
+      assert.equal(result.stdout, [
+        'FAIL benchmark suite',
+        'tasks: 1',
+        'passed: 0, failed: 1, disallowed: 0, error: 0',
+        '- failed grading-cases/x-on-zero XOnZero',
+        ''
+      ].join('\n'));
+      assert.equal(result.stderr, '');
+    });
+  });
+
   it('prints grading case error messages in run-all human-readable task lines', async () => {
     await withTempDir(async (dir) => {
       await mkdir(path.join(dir, 'benchmarks', 'grading-cases'), { recursive: true });
@@ -987,7 +1036,7 @@ describe('benchmark command TypeScript route', () => {
         'tasks: 1',
         'passed: 0, failed: 0, disallowed: 0, error: 1',
         '- error grading-cases/setup-error SetupError',
-        '  - case bad-setup error: setup command failed in grading case bad-setup: qni state set ',
+        '  - error: setup command failed in grading case bad-setup: qni state set ',
         '    initial state expression is required',
         ''
       ].join('\n'));
@@ -1089,6 +1138,32 @@ function xOnZeroAndOneGradingCasesTask(): string {
     '---',
     '',
     'Apply X to both basis inputs.'
+  ].join('\n');
+}
+
+function singleXGradingCaseTask(): string {
+  return [
+    '---',
+    'id: grading-cases/x-on-zero',
+    'title: XOnZero',
+    'source: test',
+    'difficulty: smoke',
+    'allowed_commands:',
+    '  - qni add',
+    'grading_cases:',
+    '  - id: zero-input',
+    '    checks:',
+    '      tolerance: 1e-9',
+    '      items:',
+    '        - type: run',
+    '          expected:',
+    '            - basis: "|0>"',
+    '              amplitude:',
+    '                real: 1',
+    '                imaginary: 0',
+    '---',
+    '',
+    'Keep zero unchanged.'
   ].join('\n');
 }
 

--- a/test/typescript/benchmark_command.test.ts
+++ b/test/typescript/benchmark_command.test.ts
@@ -122,6 +122,24 @@ describe('benchmark command TypeScript route', () => {
     });
   });
 
+  it('prints the grading case id for grading case command execution errors', async () => {
+    await withTempDir(async (dir) => {
+      await writeFile(path.join(dir, 'task.md'), xOnZeroAndOneGradingCasesTask());
+      await writeFile(path.join(dir, 'submission.qni'), 'qni add X --qubit nope --step 0\n');
+
+      const result = captureDispatcherRun(dir, ['benchmark', 'run', 'task.md', 'submission.qni']);
+
+      assert.equal(result.exitStatus, 3);
+      assert.equal(result.stdout, [
+        'ERROR XOnZeroAndOne',
+        'error: case zero-input error: submission command failed at line 1: qni add X --qubit nope --step 0',
+        'qubit must be an integer',
+        ''
+      ].join('\n'));
+      assert.equal(result.stderr, '');
+    });
+  });
+
   it('classifies submission lines that do not start with qni as error results', async () => {
     await withTempDir(async (dir) => {
       await writeFile(path.join(dir, 'submission.qni'), 'echo not-qni\n');

--- a/test/typescript/benchmark_task.test.ts
+++ b/test/typescript/benchmark_task.test.ts
@@ -3,10 +3,25 @@ import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 
-import { loadBenchmarkTask } from '../../src/evaluation_runner/benchmark_task';
+import { loadBenchmarkTask, type BenchmarkTask } from '../../src/evaluation_runner/benchmark_task';
 import { withTempDir } from './helpers/command';
 
 describe('benchmark task frontmatter parser', () => {
+  it('keeps the explicit grading cases marker optional on the exported task type', () => {
+    const task: BenchmarkTask = {
+      allowedCommands: [{ argv: ['add'], source: 'qni add' }],
+      checks: {
+        tolerance: 1e-9,
+        items: []
+      },
+      gradingCases: [],
+      id: 'compat/manual-task',
+      title: 'ManualTask'
+    };
+
+    assert.equal(task.hasExplicitGradingCases, undefined);
+  });
+
   it('normalizes root checks into an implicit grading case', async () => {
     await withTempDir(async (dir) => {
       const taskPath = path.join(dir, 'task.md');

--- a/test/typescript/evaluation_runner.test.ts
+++ b/test/typescript/evaluation_runner.test.ts
@@ -343,7 +343,7 @@ describe('evaluation runner public entrypoints', () => {
         ],
         checks: [],
         error: [
-          'setup command failed in grading case bad-setup: qni state set ',
+          'case bad-setup error: setup command failed in grading case bad-setup: qni state set ',
           'initial state expression is required'
         ].join('\n')
       });

--- a/test/typescript/evaluation_runner.test.ts
+++ b/test/typescript/evaluation_runner.test.ts
@@ -188,6 +188,18 @@ describe('evaluation runner public entrypoints', () => {
         submission: 'submission.qni',
         status: 'passed',
         exitCode: 0,
+        gradingCases: [
+          {
+            caseId: 'zero-input',
+            status: 'passed',
+            checks: [{ type: 'run', status: 'passed' }]
+          },
+          {
+            caseId: 'one-input',
+            status: 'passed',
+            checks: [{ type: 'run', status: 'passed' }]
+          }
+        ],
         checks: [
           { type: 'run', status: 'passed' },
           { type: 'run', status: 'passed' }
@@ -252,6 +264,18 @@ describe('evaluation runner public entrypoints', () => {
         submission: 'submission.qni',
         status: 'failed',
         exitCode: 1,
+        gradingCases: [
+          {
+            caseId: 'zero-input',
+            status: 'passed',
+            checks: [{ type: 'run', status: 'passed' }]
+          },
+          {
+            caseId: 'one-input',
+            status: 'failed',
+            checks: [{ type: 'run', status: 'failed' }]
+          }
+        ],
         checks: [
           { type: 'run', status: 'passed' },
           { type: 'run', status: 'failed' }
@@ -306,6 +330,17 @@ describe('evaluation runner public entrypoints', () => {
         submission: 'submission.qni',
         status: 'error',
         exitCode: 3,
+        gradingCases: [
+          {
+            caseId: 'bad-setup',
+            status: 'error',
+            checks: [],
+            error: [
+              'setup command failed in grading case bad-setup: qni state set ',
+              'initial state expression is required'
+            ].join('\n')
+          }
+        ],
         checks: [],
         error: [
           'setup command failed in grading case bad-setup: qni state set ',


### PR DESCRIPTION
## 概要

`grading_cases` を持つベンチマーク課題で、ケースごとの結果を `qni benchmark run` / `qni benchmark run-all` の JSON と人間向け出力から追跡できるようにしました。
採点の意味や課題単位の suite summary は変えず、新形式課題だけにケース別情報を追加しています。
既存の `checks` 形式だけの課題は、従来の JSON 形と人間向け出力を維持します。

Closes #308

## 変更内容

- `features/cli/benchmark_grading_case_output.feature.md` を追加し、ケース別 JSON、人間向け失敗表示、run-all 出力での追跡を仕様化しました。
- 評価ランナーで明示的な `grading_cases` の有無を保持し、ケースごとの `caseId` / `status` / `checks` / `error` を結果に含めるようにしました。
- `benchmark_output.ts` で、明示的な複数採点ケースの失敗時だけ case ID と検証条件種別を人間向け出力に表示するようにしました。
- TypeScript テストで、既存 `checks` 形式の互換出力、複数ケース課題の JSON、人間向け出力、run-all summary が課題単位のまま維持されることを確認しました。

## 確認

- `npm run check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ベンチマーク実行結果で、採点ケースごとの状態やチェック内容を確認できるようになりました。
  * JSON 出力と人間向け出力の両方で、失敗したケース ID と判定条件の種別が表示されます。

* **Bug Fixes**
  * `run-all` の集計が、採点ケースを持つタスクでも正しく表示されるようになりました。
  * 失敗詳細に、どのケースで問題が起きたかが分かりやすく反映されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->