### PR TITLE
controlled-SWAP を add/run/view/export で扱えるようにする

### DIFF
--- a/features/cli/add/add_controlled_swap_gate.feature.md
+++ b/features/cli/add/add_controlled_swap_gate.feature.md
@@ -1,0 +1,83 @@
+# Feature: qni add/run/view の controlled-SWAP
+
+qni-cli の利用者として、Fredkin gate を含む回路を組み立てて確認するために、
+qni add SWAP に制御量子ビットを指定したい。
+
+## Scenario: qni add SWAP は --control 付きで成功
+
+- When "qni add SWAP --control 0 --qubit 1,2 --step 0" を実行
+- Then コマンドは成功
+
+## Scenario: qni add SWAP は controlled-SWAP を circuit.json に保存
+
+- When "qni add SWAP --control 0 --qubit 1,2 --step 0" を実行
+- Then "circuit.json" の JSON 内容:
+
+  ```json
+  {
+    "qubits": 3,
+    "cols": [
+      ["•", "Swap", "Swap"]
+    ]
+  }
+  ```
+
+## Scenario: qni view は controlled-SWAP を表示
+
+- Given "qni add SWAP --control 0 --qubit 1,2 --step 0" を実行
+- When "qni view" を実行
+- Then 回路図:
+
+  ```text
+  q0: ─■─
+       │
+  q1: ─X─
+       │
+  q2: ─X─
+  ```
+
+## Scenario: qni run は制御量子ビットが 1 の controlled-SWAP を適用
+
+- Given "qni state set \"|101>\"" を実行
+- And "qni add SWAP --control 0 --qubit 1,2 --step 0" を実行
+- When "qni run" を実行
+- Then 標準出力:
+
+  ```text
+  0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0
+  ```
+
+## Scenario: qni run は制御量子ビットが 0 の controlled-SWAP を適用しない
+
+- Given "qni state set \"|001>\"" を実行
+- And "qni add SWAP --control 0 --qubit 1,2 --step 0" を実行
+- When "qni run" を実行
+- Then 標準出力:
+
+  ```text
+  0.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0
+  ```
+
+## Scenario: qni export --latex-source は controlled-SWAP の制御点を出力
+
+- Given "qni add SWAP --control 0 --qubit 1,2 --step 0" を実行
+- When "qni export --latex-source" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  \ctrl{1}
+  ```
+
+## Scenario: qni add SWAP は制御量子ビットと対象量子ビットが同じだと失敗
+
+- When "qni add SWAP --control 0 --qubit 0,1 --step 0" を実行
+- Then コマンドは失敗
+
+## Scenario: qni add SWAP は制御量子ビットと対象量子ビットが同じだと標準エラーを表示
+
+- When "qni add SWAP --control 0 --qubit 0,1 --step 0" を実行
+- Then 標準エラー:
+
+  ```text
+  control and target must be different
+  ```

--- a/features/cli/add/help.feature.md
+++ b/features/cli/add/help.feature.md
@@ -20,6 +20,7 @@ qni-cli の利用者として、add コマンドの使い方を確認するた�
     qni add ANGLED_GATE --angle=ANGLE --qubit=N --step=N
     qni add ANGLED_GATE --angle=ANGLE --control=CONTROL --qubit=N --step=N
     qni add SWAP --qubit=N,N --step=N
+    qni add SWAP --control=CONTROL --qubit=N,N --step=N
 
   Overview:
     Add a gate to ./circuit.json.
@@ -30,6 +31,7 @@ qni-cli の利用者として、add コマンドの使い方を確認するた�
     CNOT is written as qni add X --control 0 --qubit 1 --step 0.
     ANGLED_GATE can be P, Rx, Ry, or Rz and is saved as GATE(angle).
     SWAP uses exactly two target qubits and writes "Swap" to both slots.
+    With --control, SWAP becomes controlled-SWAP and writes "•" to each control slot.
 
   Options:
     --step=N             # 0-based step index
@@ -48,6 +50,7 @@ qni-cli の利用者として、add コマンドの使い方を確認するた�
     qni add Rx --angle π/2 --qubit 0 --step 2
     qni add Rz --angle pi/4 --control 0 --qubit 1 --step 3
     qni add SWAP --qubit 0,1 --step 0
+    qni add SWAP --control 0 --qubit 1,2 --step 0
   ```
 
 ## Scenario: qni add --help は成功する
@@ -67,6 +70,7 @@ qni-cli の利用者として、add コマンドの使い方を確認するた�
     qni add ANGLED_GATE --angle=ANGLE --qubit=N --step=N
     qni add ANGLED_GATE --angle=ANGLE --control=CONTROL --qubit=N --step=N
     qni add SWAP --qubit=N,N --step=N
+    qni add SWAP --control=CONTROL --qubit=N,N --step=N
 
   Overview:
     Add a gate to ./circuit.json.
@@ -77,6 +81,7 @@ qni-cli の利用者として、add コマンドの使い方を確認するた�
     CNOT is written as qni add X --control 0 --qubit 1 --step 0.
     ANGLED_GATE can be P, Rx, Ry, or Rz and is saved as GATE(angle).
     SWAP uses exactly two target qubits and writes "Swap" to both slots.
+    With --control, SWAP becomes controlled-SWAP and writes "•" to each control slot.
 
   Options:
     --step=N             # 0-based step index
@@ -95,4 +100,5 @@ qni-cli の利用者として、add コマンドの使い方を確認するた�
     qni add Rx --angle π/2 --qubit 0 --step 2
     qni add Rz --angle pi/4 --control 0 --qubit 1 --step 3
     qni add SWAP --qubit 0,1 --step 0
+    qni add SWAP --control 0 --qubit 1,2 --step 0
   ```

--- a/features/cli/export/help.feature.md
+++ b/features/cli/export/help.feature.md
@@ -31,7 +31,7 @@ qni export のヘルプで利用できる出力形式とオプションを確認
     --no-transparent writes an opaque PNG background, useful for light circuit lines on dark note themes.
     --state-vector renders the symbolic state vector as LaTeX and converts it to PNG.
     --circle-notation renders the final computational-basis state as a circle-notation PNG.
-    qni export follows qni's step constraints, so one step can contain simple 1-qubit gates, one controlled gate, or one 2-qubit SWAP.
+    qni export follows qni's step constraints, so one step can contain simple 1-qubit gates, one controlled gate, one 2-qubit SWAP, or one controlled 2-qubit SWAP.
 
   Options:
     --latex-source  # write qcircuit LaTeX
@@ -87,7 +87,7 @@ qni export のヘルプで利用できる出力形式とオプションを確認
     --no-transparent writes an opaque PNG background, useful for light circuit lines on dark note themes.
     --state-vector renders the symbolic state vector as LaTeX and converts it to PNG.
     --circle-notation renders the final computational-basis state as a circle-notation PNG.
-    qni export follows qni's step constraints, so one step can contain simple 1-qubit gates, one controlled gate, or one 2-qubit SWAP.
+    qni export follows qni's step constraints, so one step can contain simple 1-qubit gates, one controlled gate, one 2-qubit SWAP, or one controlled 2-qubit SWAP.
 
   Options:
     --latex-source  # write qcircuit LaTeX

--- a/src/circuit_file.ts
+++ b/src/circuit_file.ts
@@ -75,20 +75,25 @@ export class CircuitFile {
   }
 
   addControlledGate(gate: string, step: number, controls: number[], target: number): void {
-    validateControls(controls, target);
+    validateControls(controls, [target]);
     this.addPlacement(step, new Map([...controls.map((control) => [control, CONTROL_SYMBOL] as const), [target, gate]]));
   }
 
   addSwapGate(step: number, targets: number[]): void {
-    if (targets.length !== 2) {
-      throw new CircuitFileError('SWAP requires exactly 2 target qubits');
-    }
-
-    if (new Set(targets).size !== targets.length) {
-      throw new CircuitFileError('SWAP target qubits must be different');
-    }
-
+    validateSwapTargets(targets);
     this.addPlacement(step, new Map(targets.map((target) => [target, SWAP_SYMBOL] as const)));
+  }
+
+  addControlledSwapGate(step: number, controls: number[], targets: number[]): void {
+    validateSwapTargets(targets);
+    validateControls(controls, targets);
+    this.addPlacement(
+      step,
+      new Map([
+        ...controls.map((control) => [control, CONTROL_SYMBOL] as const),
+        ...targets.map((target) => [target, SWAP_SYMBOL] as const)
+      ])
+    );
   }
 
   initialStateText(): string {
@@ -234,6 +239,16 @@ export class CircuitFile {
   }
 }
 
+function validateSwapTargets(targets: number[]): void {
+  if (targets.length !== 2) {
+    throw new CircuitFileError('SWAP requires exactly 2 target qubits');
+  }
+
+  if (new Set(targets).size !== targets.length) {
+    throw new CircuitFileError('SWAP target qubits must be different');
+  }
+}
+
 function emptyCircuit(step: number, qubit: number): CircuitData {
   const qubits = qubit + 1;
 
@@ -271,7 +286,7 @@ function ensureAddSlotAvailable(circuit: CircuitData, step: number, qubit: numbe
   }
 }
 
-function validateControls(controls: number[], target: number): void {
+function validateControls(controls: number[], targets: number[]): void {
   if (controls.length === 0) {
     throw new CircuitFileError('control must not be empty');
   }
@@ -280,7 +295,7 @@ function validateControls(controls: number[], target: number): void {
     throw new CircuitFileError('control must not contain duplicates');
   }
 
-  if (controls.includes(target)) {
+  if (controls.some((control) => targets.includes(control))) {
     throw new CircuitFileError('control and target must be different');
   }
 }
@@ -301,6 +316,10 @@ function removableQubits(
   step: number,
   qubit: number
 ): number[] {
+  if (controlledSwapSlot(col, selectedSlot)) {
+    return controlledSwapQubits(col, step);
+  }
+
   if (selectedSlot === SWAP_SYMBOL) {
     return swapQubits(col, step);
   }
@@ -310,6 +329,25 @@ function removableQubits(
   }
 
   return [qubit];
+}
+
+function controlledSwapSlot(col: unknown[], selectedSlot: unknown): boolean {
+  return (
+    col.includes(CONTROL_SYMBOL) &&
+    col.includes(SWAP_SYMBOL) &&
+    (selectedSlot === CONTROL_SYMBOL || selectedSlot === SWAP_SYMBOL)
+  );
+}
+
+function controlledSwapQubits(col: unknown[], step: number): number[] {
+  const controls = slotIndices(col, CONTROL_SYMBOL);
+  const swaps = swapQubits(col, step);
+
+  if (!col.every((slot) => slot === EMPTY_SLOT || slot === CONTROL_SYMBOL || slot === SWAP_SYMBOL)) {
+    throw new CircuitFileError(`unsupported controlled swap step: cols[${step}] = ${JSON.stringify(col)}`);
+  }
+
+  return [...controls, ...swaps];
 }
 
 function controlledSlot(col: unknown[], selectedSlot: unknown, qubit: number): boolean {

--- a/src/commands/add_command.ts
+++ b/src/commands/add_command.ts
@@ -9,6 +9,7 @@ const HELP_TEXT = `Usage:
   qni add ANGLED_GATE --angle=ANGLE --qubit=N --step=N
   qni add ANGLED_GATE --angle=ANGLE --control=CONTROL --qubit=N --step=N
   qni add SWAP --qubit=N,N --step=N
+  qni add SWAP --control=CONTROL --qubit=N,N --step=N
 
 Overview:
   Add a gate to ./circuit.json.
@@ -19,6 +20,7 @@ Overview:
   CNOT is written as qni add X --control 0 --qubit 1 --step 0.
   ANGLED_GATE can be P, Rx, Ry, or Rz and is saved as GATE(angle).
   SWAP uses exactly two target qubits and writes "Swap" to both slots.
+  With --control, SWAP becomes controlled-SWAP and writes "•" to each control slot.
 
 Options:
   --step=N             # 0-based step index
@@ -36,7 +38,8 @@ Examples:
   qni add P --angle π/3 --qubit 0 --step 1
   qni add Rx --angle π/2 --qubit 0 --step 2
   qni add Rz --angle pi/4 --control 0 --qubit 1 --step 3
-  qni add SWAP --qubit 0,1 --step 0`;
+  qni add SWAP --qubit 0,1 --step 0
+  qni add SWAP --control 0 --qubit 1,2 --step 0`;
 
 const FIXED_GATES = new Map<string, string>([
   ['H', 'H'],
@@ -82,10 +85,10 @@ export function runAddCommand(argv: string[], context: CommandHandlerContext): n
 
     if (gate === SWAP_GATE) {
       if (controlled(options)) {
-        throw new CircuitFileError('SWAP does not support --control yet');
+        circuitFile.addControlledSwapGate(options.step, options.controls, options.qubits);
+      } else {
+        circuitFile.addSwapGate(options.step, options.qubits);
       }
-
-      circuitFile.addSwapGate(options.step, options.qubits);
     } else if (controlled(options)) {
       circuitFile.addControlledGate(serializedGate(gate, options), options.step, options.controls, singleQubit(options));
     } else {

--- a/src/commands/export_command.ts
+++ b/src/commands/export_command.ts
@@ -32,7 +32,7 @@ Overview:
   --no-transparent writes an opaque PNG background, useful for light circuit lines on dark note themes.
   --state-vector renders the symbolic state vector as LaTeX and converts it to PNG.
   --circle-notation renders the final computational-basis state as a circle-notation PNG.
-  qni export follows qni's step constraints, so one step can contain simple 1-qubit gates, one controlled gate, or one 2-qubit SWAP.
+  qni export follows qni's step constraints, so one step can contain simple 1-qubit gates, one controlled gate, one 2-qubit SWAP, or one controlled 2-qubit SWAP.
 
 Options:
   --latex-source  # write qcircuit LaTeX

--- a/src/export/qcircuit_latex.ts
+++ b/src/export/qcircuit_latex.ts
@@ -283,15 +283,23 @@ class QCircuitColumn {
     }
 
     const [topQubit, bottomQubit] = this.swapQubits.sort((a, b) => a - b);
-
-    return new Map<number, string>([
+    const cells = new Map<number, string>([
       [topQubit, '\\qswap'],
       [bottomQubit, `\\qswap \\qwx[${topQubit - bottomQubit}]`]
     ]);
+
+    for (const controlQubit of this.controlQubits) {
+      cells.set(controlQubit, `\\ctrl{${this.controlledSwapTarget(controlQubit) - controlQubit}}`);
+    }
+
+    return cells;
   }
 
   private get validSwapStep(): boolean {
-    return this.swapQubits.length === 2 && this.slots.every((slot) => emptySlot(slot) || slot === SWAP_SYMBOL);
+    return (
+      this.swapQubits.length === 2 &&
+      this.slots.every((slot) => emptySlot(slot) || slot === CONTROL_SYMBOL || slot === SWAP_SYMBOL)
+    );
   }
 
   private get swapQubits(): number[] {
@@ -299,6 +307,12 @@ class QCircuitColumn {
       .map((slot, index) => ({ index, slot }))
       .filter(({ slot }) => slot === SWAP_SYMBOL)
       .map(({ index }) => index);
+  }
+
+  private controlledSwapTarget(controlQubit: number): number {
+    return this.swapQubits.reduce((nearest, swapQubit) =>
+      Math.abs(swapQubit - controlQubit) < Math.abs(nearest - controlQubit) ? swapQubit : nearest
+    );
   }
 }
 

--- a/src/simulator.ts
+++ b/src/simulator.ts
@@ -169,13 +169,21 @@ class StateVector {
   }
 
   applySwap(firstQubit: number, secondQubit: number): StateVector {
+    return this.applyControlledSwap([], firstQubit, secondQubit);
+  }
+
+  applyControlledSwap(controls: readonly number[], firstQubit: number, secondQubit: number): StateVector {
     const firstMask = bitMask(this.qubits, firstQubit);
     const secondMask = bitMask(this.qubits, secondQubit);
+    const controlMasks = controls.map((control) => bitMask(this.qubits, control));
     const result = Array.from({ length: this.amplitudes.length }, () => new Complex(0));
 
     this.amplitudes.forEach((amplitude, index) => {
+      const inactiveControl = controlMasks.some((controlMask) => !bitSet(index, controlMask));
       const destination =
-        bitSet(index, firstMask) === bitSet(index, secondMask) ? index : index ^ firstMask ^ secondMask;
+        inactiveControl || bitSet(index, firstMask) === bitSet(index, secondMask)
+          ? index
+          : index ^ firstMask ^ secondMask;
       result[destination] = amplitude;
     });
 
@@ -302,7 +310,11 @@ class StepOperation {
     }
 
     const swapQubits = this.slotIndices(SWAP_SYMBOL);
-    return stateVector.applySwap(swapQubits[0] ?? 0, swapQubits[1] ?? 0);
+    return stateVector.applyControlledSwap(
+      this.slotIndices(CONTROL_SYMBOL),
+      swapQubits[0] ?? 0,
+      swapQubits[1] ?? 0
+    );
   }
 
   private applyControlled(stateVector: StateVector): StateVector {
@@ -346,7 +358,10 @@ class StepOperation {
   }
 
   private validSwapStep(): boolean {
-    return this.slotIndices(SWAP_SYMBOL).length === 2 && this.col.every((slot) => slot === EMPTY_SLOT || slot === SWAP_SYMBOL);
+    return (
+      this.slotIndices(SWAP_SYMBOL).length === 2 &&
+      this.col.every((slot) => slot === EMPTY_SLOT || slot === CONTROL_SYMBOL || slot === SWAP_SYMBOL)
+    );
   }
 
   private slotIndices(symbol: string): number[] {

--- a/src/view/text_renderer.ts
+++ b/src/view/text_renderer.ts
@@ -398,13 +398,33 @@ class TextLayer {
     this.cells[qubit] = cell;
   }
 
-  placeSwapEndpoints(topQubit: number, bottomQubit: number): void {
-    this.place(topQubit, new Ex({ botConnect: '│' }));
-    this.place(bottomQubit, new Ex({ topConnect: '│' }));
+  placeSwapEndpoint(qubit: number, options: { botConnect?: string; topConnect?: string } = {}): void {
+    this.place(qubit, new Ex(options));
   }
 
   toArray(): DrawElement[] {
     return this.cells;
+  }
+}
+
+class VerticalConnectionSpan {
+  private readonly maxQubit: number;
+  private readonly minQubit: number;
+
+  constructor(qubits: number[]) {
+    this.minQubit = Math.min(...qubits);
+    this.maxQubit = Math.max(...qubits);
+  }
+
+  bridgeQubits(): number[] {
+    return range(this.minQubit + 1, this.maxQubit);
+  }
+
+  connectorsFor(qubit: number): { botConnect: string; topConnect: string } {
+    return {
+      botConnect: qubit < this.maxQubit ? '│' : ' ',
+      topConnect: qubit > this.minQubit ? '│' : ' '
+    };
   }
 }
 
@@ -505,12 +525,19 @@ class TextStepLayerBuilder {
     }
 
     const [topQubit, bottomQubit] = swapPair;
-    layer.placeSwapEndpoints(topQubit, bottomQubit);
-    this.placeSwapBridges(layer, topQubit, bottomQubit);
+    const span = new VerticalConnectionSpan([...this.step.controlQubits(), topQubit, bottomQubit]);
+
+    for (const controlQubit of this.step.controlQubits()) {
+      layer.place(controlQubit, new Bullet(span.connectorsFor(controlQubit)));
+    }
+
+    layer.placeSwapEndpoint(topQubit, span.connectorsFor(topQubit));
+    layer.placeSwapEndpoint(bottomQubit, span.connectorsFor(bottomQubit));
+    this.placeSwapBridges(layer, span);
   }
 
-  private placeSwapBridges(layer: TextLayer, topQubit: number, bottomQubit: number): void {
-    for (const qubit of range(topQubit + 1, bottomQubit)) {
+  private placeSwapBridges(layer: TextLayer, span: VerticalConnectionSpan): void {
+    for (const qubit of span.bridgeQubits()) {
       if (this.step.emptySlot(qubit)) {
         layer.place(qubit, new VerticalBridge());
       }
@@ -861,7 +888,7 @@ function rjust(value: string, width: number, pad = ' '): string {
 }
 
 function trimmedLines(lines: string[]): string[] {
-  return trimTrailingBlankLines(trimLeadingBlankLines(lines));
+  return trimTrailingBlankLines(trimLeadingBlankLines(lines)).map((line) => line.replace(/\s+$/u, ''));
 }
 
 function trimLeadingBlankLines(lines: string[]): string[] {

--- a/test/typescript/add_command.test.ts
+++ b/test/typescript/add_command.test.ts
@@ -260,6 +260,20 @@ describe('add command TypeScript route', () => {
     });
   });
 
+  it('adds controlled SWAP through the TypeScript route', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, ['add', 'SWAP', '--control', '0', '--qubit', '1,2', '--step', '0']);
+
+      assert.equal(result.exitStatus, 0);
+      assert.equal(result.stdout, '');
+      assert.equal(result.stderr, '');
+      assert.deepEqual(await readCircuit(path.join(dir, 'circuit.json')), {
+        qubits: 3,
+        cols: [['•', 'Swap', 'Swap']]
+      });
+    });
+  });
+
   it('accepts decimal numeric step values like Ruby for migrated gate variants', async () => {
     const examples = [
       {
@@ -350,6 +364,21 @@ describe('add command TypeScript route', () => {
       assert.equal(duplicatedTargets.exitStatus, 1);
       assert.equal(duplicatedTargets.stdout, '');
       assert.equal(duplicatedTargets.stderr, 'SWAP target qubits must be different\n');
+
+      const overlappingControl = captureDispatcherRun(dir, [
+        'add',
+        'SWAP',
+        '--control',
+        '0',
+        '--qubit',
+        '0,1',
+        '--step',
+        '0'
+      ]);
+
+      assert.equal(overlappingControl.exitStatus, 1);
+      assert.equal(overlappingControl.stdout, '');
+      assert.equal(overlappingControl.stderr, 'control and target must be different\n');
     });
   });
 

--- a/test/typescript/export_command.test.ts
+++ b/test/typescript/export_command.test.ts
@@ -151,10 +151,11 @@ describe('export command TypeScript route', () => {
   it('renders qcircuit LaTeX source for controlled and swap operations', async () => {
     await withTempDir(async (dir) => {
       await writeCircuit(dir, {
-        qubits: 2,
+        qubits: 3,
         cols: [
-          ['•', 'X'],
-          ['Swap', 'Swap']
+          ['•', 'X', 1],
+          [1, 'Swap', 'Swap'],
+          ['•', 'Swap', 'Swap']
         ]
       });
 
@@ -165,6 +166,7 @@ describe('export command TypeScript route', () => {
       assert.match(result.stdout, /\\Qcircuit/u);
       assert.match(result.stdout, /\\ctrl\{1\}/u);
       assert.match(result.stdout, /\\qswap/u);
+      assert.match(result.stdout, /\\qwx\[-1\]/u);
     });
   });
 

--- a/test/typescript/numeric_runtime_compatibility.test.ts
+++ b/test/typescript/numeric_runtime_compatibility.test.ts
@@ -58,6 +58,34 @@ describe('TypeScript numeric simulator compatibility', () => {
     assert.equal(simulator.renderExpectationValues(['IZ']), 'IZ=-1.0');
   });
 
+  it('applies controlled SWAP only when all controls are active', () => {
+    const controlledSwap = [['•', 'Swap', 'Swap']];
+
+    assert.equal(
+      new Simulator({
+        cols: controlledSwap,
+        initial_state: {
+          format: 'ket_sum_v1',
+          terms: [{ basis: '101', coefficient: '1' }]
+        },
+        qubits: 3
+      }).renderStateVector(),
+      '0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0'
+    );
+
+    assert.equal(
+      new Simulator({
+        cols: controlledSwap,
+        initial_state: {
+          format: 'ket_sum_v1',
+          terms: [{ basis: '001', coefficient: '1' }]
+        },
+        qubits: 3
+      }).renderStateVector(),
+      '0.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0'
+    );
+  });
+
   it('rejects qubit counts that would overflow JavaScript bitwise state indexing', () => {
     const circuit: CircuitData = {
       cols: [],

--- a/test/typescript/view_command.test.ts
+++ b/test/typescript/view_command.test.ts
@@ -160,6 +160,31 @@ describe('view command TypeScript route', () => {
     });
   });
 
+  it('renders controlled SWAP with stable ASCII art', async () => {
+    await withTempDir(async (dir) => {
+      await writeCircuit(dir, {
+        qubits: 3,
+        cols: [['•', 'Swap', 'Swap']]
+      });
+
+      const result = captureDispatcherRun(dir, ['view']);
+
+      assert.equal(result.exitStatus, 0);
+      assert.equal(result.stderr, '');
+      assert.equal(
+        result.stdout,
+        [
+          'q0: ─■─',
+          '     │',
+          'q1: ─X─',
+          '     │',
+          'q2: ─X─',
+          ''
+        ].join('\n')
+      );
+    });
+  });
+
   it('uses dim suffix color for compact TTY labels', async () => {
     await withTempDir(async (dir) => {
       await writeCircuit(dir, {


### PR DESCRIPTION
## 概要

`qni add SWAP --control ...` を受け付け、controlled-SWAP を qni の既存回路表現で扱えるようにしました。
制御スロット `•` と 2 つの `Swap` スロットを同じ列に保存し、`qni run`、`qni view`、`qni export --latex-source` の主要経路を対応させています。
通常の `qni add SWAP --qubit ...` の挙動は維持しています。

Closes #320

## 変更内容

- controlled-SWAP 用の Cucumber feature を追加し、成功、保存形式、実行結果、表示、エラーを検証しました。
- `qni add SWAP --control ...` から `circuit.json` に `['•', 'Swap', 'Swap']` 形式で保存できるようにしました。
- 数値シミュレータで、制御量子ビットが有効な場合だけ SWAP を適用するようにしました。
- `qni view` の ASCII 表示と `qni export --latex-source` の qcircuit 出力で controlled-SWAP を扱えるようにしました。
- TypeScript テストに add/run/view/export の主要経路を追加し、関連ヘルプ文言も更新しました。

## 確認

- `npm run check`
