### PR TITLE
BasisChange を複数採点ケースのベンチマーク課題に追加する

### DIFF
--- a/benchmarks/incorrect/quantum-katas/basic-gates/basis-change-zero-only.qni
+++ b/benchmarks/incorrect/quantum-katas/basic-gates/basis-change-zero-only.qni
@@ -1,0 +1,2 @@
+qni add H --qubit 0 --step 0
+qni add X --qubit 0 --step 1

--- a/benchmarks/quantum-katas/basic-gates/basis-change.md
+++ b/benchmarks/quantum-katas/basic-gates/basis-change.md
@@ -1,0 +1,44 @@
+---
+id: basic-gates/basis-change
+title: BasisChange
+source: Microsoft Quantum Katas / BasicGates
+difficulty: smoke
+allowed_commands:
+  - qni add
+grading_cases:
+  - id: zero-input
+    checks:
+      tolerance: 1e-15
+      items:
+        - type: run
+          expected:
+            - basis: "|0>"
+              amplitude:
+                real: 0.7071067811865476
+                imaginary: 0
+            - basis: "|1>"
+              amplitude:
+                real: 0.7071067811865476
+                imaginary: 0
+  - id: one-input
+    setup_commands:
+      - qni state set "1|1>"
+    checks:
+      tolerance: 1e-15
+      items:
+        - type: run
+          expected:
+            - basis: "|0>"
+              amplitude:
+                real: 0.7071067811865476
+                imaginary: 0
+            - basis: "|1>"
+              amplitude:
+                real: -0.7071067811865476
+                imaginary: 0
+---
+
+1量子ビットに対して、`|0>` を `|+>` に、`|1>` を `|->` に変える量子回路を、`qni` コマンド列として作成してください。
+
+`|+>` は `( |0> + |1> ) / sqrt(2)`、`|->` は `( |0> - |1> ) / sqrt(2)` の状態です。
+提出物は `.qni` 形式で、1行に1つずつ完全な `qni` コマンドを書いてください。

--- a/benchmarks/solutions/quantum-katas/basic-gates/basis-change.qni
+++ b/benchmarks/solutions/quantum-katas/basic-gates/basis-change.qni
@@ -1,0 +1,1 @@
+qni add H --qubit 0 --step 0

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -14,7 +14,7 @@
 
 提出物には回路を作るコマンドだけを書きます。`qni run` や `qni expect` などの検証コマンドは書きません。
 
-## 8問の標準解を実行する
+## 9問の標準解を実行する
 
 ### StateFlip
 
@@ -23,6 +23,14 @@ qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/
 ```
 
 期待される結果は `PASS StateFlip` です。
+
+### BasisChange
+
+```bash
+qni benchmark run benchmarks/quantum-katas/basic-gates/basis-change.md benchmarks/solutions/quantum-katas/basic-gates/basis-change.qni
+```
+
+期待される結果は `PASS BasisChange` です。BasisChange は複数の採点ケースを持ち、既定の `|0>` 入力と `setup_commands` で準備した `|1>` 入力を別々に検証します。
 
 ### PlusState
 
@@ -90,6 +98,14 @@ qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/
 
 期待される結果は `FAIL StateFlip` です。
 
+BasisChange には、`|0>` 入力だけに合う不正解サンプルがあります。`|1>` 入力の採点ケースで失敗するため、終了コードは `1` です。
+
+```bash
+qni benchmark run benchmarks/quantum-katas/basic-gates/basis-change.md benchmarks/incorrect/quantum-katas/basic-gates/basis-change-zero-only.qni
+```
+
+期待される結果は `FAIL BasisChange` です。
+
 ## 不許可サンプルを実行する
 
 不許可サンプルは、課題ファイルの `allowed_commands` にない `qni run` を提出物に含みます。終了コードは `2` です。
@@ -126,6 +142,46 @@ qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/
 }
 ```
 
+## 複数採点ケースを持つ課題を書く
+
+`grading_cases` を使うと、同じ提出物を複数の初期条件で採点できます。各ケースは独立した一時作業ディレクトリで実行されます。`setup_commands` は採点ケースごとの初期状態準備に使い、提出物の `allowed_commands` とは別に評価ランナーが実行します。
+
+BasisChange では、既定の `|0>` 入力と、`qni state set "1|1>"` で準備する `|1>` 入力を分けています。
+
+```yaml
+grading_cases:
+  - id: zero-input
+    checks:
+      tolerance: 1e-15
+      items:
+        - type: run
+          expected:
+            - basis: "|0>"
+              amplitude:
+                real: 0.7071067811865476
+                imaginary: 0
+            - basis: "|1>"
+              amplitude:
+                real: 0.7071067811865476
+                imaginary: 0
+  - id: one-input
+    setup_commands:
+      - qni state set "1|1>"
+    checks:
+      tolerance: 1e-15
+      items:
+        - type: run
+          expected:
+            - basis: "|0>"
+              amplitude:
+                real: 0.7071067811865476
+                imaginary: 0
+            - basis: "|1>"
+              amplitude:
+                real: -0.7071067811865476
+                imaginary: 0
+```
+
 ## スモークセットを一括実行する
 
 `qni benchmark run-all` を使うと、ベンチマークディレクトリ内の課題をまとめて評価できます。第1引数に課題ディレクトリ、第2引数に対応する提出物ディレクトリを指定します。
@@ -134,12 +190,13 @@ qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/
 qni benchmark run-all benchmarks/quantum-katas benchmarks/solutions/quantum-katas
 ```
 
-期待される結果は、8問すべてが `passed` になり、終了コードが `0` になることです。
+期待される結果は、9問すべてが `passed` になり、終了コードが `0` になることです。
 
 ```text
 PASS benchmark suite
-tasks: 8
-passed: 8, failed: 0, disallowed: 0, error: 0
+tasks: 9
+passed: 9, failed: 0, disallowed: 0, error: 0
+- passed basic-gates/basis-change BasisChange
 - passed basic-gates/state-flip StateFlip
 - passed superposition/all-basis-vector-with-phase-flip-two-qubits AllBasisVectorWithPhaseFlip_TwoQubits
 - passed superposition/all-basis-vectors-two-qubits AllBasisVectors_TwoQubits

--- a/features/cli/benchmark_run.feature.md
+++ b/features/cli/benchmark_run.feature.md
@@ -77,6 +77,28 @@ qni benchmark run で最小の合格判定を実行したい。
   PASS PlusState
   ```
 
+## Scenario: BasisChange 課題ファイルがある
+
+- Then リポジトリファイル "benchmarks/quantum-katas/basic-gates/basis-change.md" は存在する
+
+## Scenario: BasisChange 標準解がある
+
+- Then リポジトリファイル "benchmarks/solutions/quantum-katas/basic-gates/basis-change.qni" は存在する
+
+## Scenario: BasisChange 標準解は合格する
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/basis-change.md benchmarks/solutions/quantum-katas/basic-gates/basis-change.qni" を実行
+- Then コマンドは成功
+
+## Scenario: BasisChange 標準解の合格が表示される
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/basis-change.md benchmarks/solutions/quantum-katas/basic-gates/basis-change.qni" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  PASS BasisChange
+  ```
+
 ## Scenario: MinusState 課題ファイルがある
 
 - Then リポジトリファイル "benchmarks/quantum-katas/superposition/minus-state.md" は存在する
@@ -338,6 +360,24 @@ qni benchmark run で最小の合格判定を実行したい。
   }
   ```
 
+## Scenario: BasisChange の片方の入力だけに合う不正解サンプルがある
+
+- Then リポジトリファイル "benchmarks/incorrect/quantum-katas/basic-gates/basis-change-zero-only.qni" は存在する
+
+## Scenario: BasisChange の片方の入力だけに合う不正解サンプルは不合格になる
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/basis-change.md benchmarks/incorrect/quantum-katas/basic-gates/basis-change-zero-only.qni" を実行
+- Then 終了コードは 1
+
+## Scenario: BasisChange の片方の入力だけに合う不正解サンプルは失敗した採点ケースを表示する
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/basis-change.md benchmarks/incorrect/quantum-katas/basic-gates/basis-change-zero-only.qni" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  - case one-input run #1: state vector did not match expected amplitudes
+  ```
+
 ## Scenario: frontmatter 不備の課題ファイルは終了コード 3 になる
 
 - When "qni benchmark run benchmarks/invalid/quantum-katas/basic-gates/state-flip-missing-allowed-commands.md benchmarks/solutions/quantum-katas/basic-gates/state-flip.qni" を実行
@@ -416,6 +456,14 @@ qni benchmark run で最小の合格判定を実行したい。
 
 - Then リポジトリファイル "docs/benchmark.md" は "qni benchmark run benchmarks/quantum-katas/superposition/plus-state.md benchmarks/solutions/quantum-katas/superposition/plus-state.qni" を含む
 
+## Scenario: MVP手順は BasisChange 標準解の実行例を示す
+
+- Then リポジトリファイル "docs/benchmark.md" は "qni benchmark run benchmarks/quantum-katas/basic-gates/basis-change.md benchmarks/solutions/quantum-katas/basic-gates/basis-change.qni" を含む
+
+## Scenario: MVP手順は複数採点ケースの説明を示す
+
+- Then リポジトリファイル "docs/benchmark.md" は "複数採点ケース" を含む
+
 ## Scenario: MVP手順は BellState 標準解の実行例を示す
 
 - Then リポジトリファイル "docs/benchmark.md" は "qni benchmark run benchmarks/quantum-katas/superposition/bell-state.md benchmarks/solutions/quantum-katas/superposition/bell-state.qni" を含む
@@ -456,8 +504,9 @@ qni benchmark run で最小の合格判定を実行したい。
 
   ```text
   PASS benchmark suite
-  tasks: 8
-  passed: 8, failed: 0, disallowed: 0, error: 0
+  tasks: 9
+  passed: 9, failed: 0, disallowed: 0, error: 0
+  - passed basic-gates/basis-change BasisChange
   - passed basic-gates/state-flip StateFlip
   - passed superposition/all-basis-vector-with-phase-flip-two-qubits AllBasisVectorWithPhaseFlip_TwoQubits
   - passed superposition/all-basis-vectors-two-qubits AllBasisVectors_TwoQubits
@@ -478,13 +527,53 @@ qni benchmark run で最小の合格判定を実行したい。
     "status": "passed",
     "exitCode": 0,
     "summary": {
-      "total": 8,
-      "passed": 8,
+      "total": 9,
+      "passed": 9,
       "failed": 0,
       "disallowed": 0,
       "error": 0
     },
     "results": [
+      {
+        "taskId": "basic-gates/basis-change",
+        "title": "BasisChange",
+        "task": "benchmarks/quantum-katas/basic-gates/basis-change.md",
+        "submission": "benchmarks/solutions/quantum-katas/basic-gates/basis-change.qni",
+        "status": "passed",
+        "exitCode": 0,
+        "gradingCases": [
+          {
+            "caseId": "zero-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          },
+          {
+            "caseId": "one-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          }
+        ],
+        "checks": [
+          {
+            "type": "run",
+            "status": "passed"
+          },
+          {
+            "type": "run",
+            "status": "passed"
+          }
+        ]
+      },
       {
         "taskId": "basic-gates/state-flip",
         "title": "StateFlip",

--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -215,6 +215,7 @@ function writeCircuitJson(scenarioDir, data) {
 
 function quantumKatasSubmissionContent(status, relativePath) {
   const passedSubmissions = new Map([
+    ['basic-gates/basis-change.qni', 'qni add H --qubit 0 --step 0\n'],
     ['basic-gates/state-flip.qni', 'qni add X --qubit 0 --step 0\n'],
     [
       'superposition/all-basis-vector-with-phase-flip-two-qubits.qni',
@@ -255,6 +256,7 @@ function quantumKatasSubmissionContent(status, relativePath) {
 
 function writeQuantumKatasSubmissions(scenarioDir, status, submissionsDir) {
   const relativePaths = [
+    'basic-gates/basis-change.qni',
     'basic-gates/state-flip.qni',
     'superposition/all-basis-vector-with-phase-flip-two-qubits.qni',
     'superposition/all-basis-vectors-two-qubits.qni',

--- a/test/typescript/benchmark_command.test.ts
+++ b/test/typescript/benchmark_command.test.ts
@@ -419,6 +419,21 @@ describe('benchmark command TypeScript route', () => {
     });
   });
 
+  it('passes the BasisChange solution using explicit grading cases', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, [
+        'benchmark',
+        'run',
+        'benchmarks/quantum-katas/basic-gates/basis-change.md',
+        'benchmarks/solutions/quantum-katas/basic-gates/basis-change.qni'
+      ]);
+
+      assert.equal(result.exitStatus, 0, result.stderr);
+      assert.equal(result.stdout, 'PASS BasisChange\nchecks: 2\n');
+      assert.equal(result.stderr, '');
+    });
+  });
+
   it('passes the MinusState solution using a run check', async () => {
     await withTempDir(async (dir) => {
       const result = captureDispatcherRun(dir, [
@@ -575,6 +590,30 @@ describe('benchmark command TypeScript route', () => {
         '  expected / actual mismatches:',
         '  - |0>: expected 0, actual 0.7071067811865475',
         '  - |1>: expected 1, actual 0.7071067811865475',
+        ''
+      ].join('\n'));
+      assert.equal(result.stderr, '');
+    });
+  });
+
+  it('fails the BasisChange zero-input-only incorrect sample in the one-input grading case', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, [
+        'benchmark',
+        'run',
+        'benchmarks/quantum-katas/basic-gates/basis-change.md',
+        'benchmarks/incorrect/quantum-katas/basic-gates/basis-change-zero-only.qni'
+      ]);
+
+      assert.equal(result.exitStatus, 1, result.stderr);
+      assert.equal(result.stdout, [
+        'FAIL BasisChange',
+        'checks: 2',
+        'failed checks:',
+        '- case one-input run #1: state vector did not match expected amplitudes',
+        '  expected / actual mismatches:',
+        '  - |0>: expected 0.7071067811865476, actual -0.7071067811865475',
+        '  - |1>: expected -0.7071067811865476, actual 0.7071067811865475',
         ''
       ].join('\n'));
       assert.equal(result.stderr, '');
@@ -761,8 +800,8 @@ describe('benchmark command TypeScript route', () => {
       assert.equal(captured.value.status, 'passed');
       assert.equal(captured.value.exitCode, 0);
       assert.deepStrictEqual(captured.value.summary, {
-        total: 8,
-        passed: 8,
+        total: 9,
+        passed: 9,
         failed: 0,
         disallowed: 0,
         error: 0
@@ -773,6 +812,15 @@ describe('benchmark command TypeScript route', () => {
         exitCode: result.exitCode,
         checks: result.checks
       })), [
+        {
+          taskId: 'basic-gates/basis-change',
+          status: 'passed',
+          exitCode: 0,
+          checks: [
+            { type: 'run', status: 'passed' },
+            { type: 'run', status: 'passed' }
+          ]
+        },
         {
           taskId: 'basic-gates/state-flip',
           status: 'passed',
@@ -837,8 +885,9 @@ describe('benchmark command TypeScript route', () => {
       assert.equal(result.exitStatus, 0, result.stderr);
       assert.equal(result.stdout, [
         'PASS benchmark suite',
-        'tasks: 8',
-        'passed: 8, failed: 0, disallowed: 0, error: 0',
+        'tasks: 9',
+        'passed: 9, failed: 0, disallowed: 0, error: 0',
+        '- passed basic-gates/basis-change BasisChange',
         '- passed basic-gates/state-flip StateFlip',
         '- passed superposition/all-basis-vector-with-phase-flip-two-qubits AllBasisVectorWithPhaseFlip_TwoQubits',
         '- passed superposition/all-basis-vectors-two-qubits AllBasisVectors_TwoQubits',
@@ -869,13 +918,37 @@ describe('benchmark command TypeScript route', () => {
         status: 'passed',
         exitCode: 0,
         summary: {
-          total: 8,
-          passed: 8,
+          total: 9,
+          passed: 9,
           failed: 0,
           disallowed: 0,
           error: 0
         },
         results: [
+          {
+            taskId: 'basic-gates/basis-change',
+            title: 'BasisChange',
+            task: 'benchmarks/quantum-katas/basic-gates/basis-change.md',
+            submission: 'benchmarks/solutions/quantum-katas/basic-gates/basis-change.qni',
+            status: 'passed',
+            exitCode: 0,
+            gradingCases: [
+              {
+                caseId: 'zero-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              },
+              {
+                caseId: 'one-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              }
+            ],
+            checks: [
+              { type: 'run', status: 'passed' },
+              { type: 'run', status: 'passed' }
+            ]
+          },
           {
             taskId: 'basic-gates/state-flip',
             title: 'StateFlip',

--- a/test/typescript/evaluation_runner.test.ts
+++ b/test/typescript/evaluation_runner.test.ts
@@ -402,8 +402,8 @@ describe('evaluation runner public entrypoints', () => {
       assert.equal(captured.value.status, 'passed');
       assert.equal(captured.value.exitCode, 0);
       assert.deepStrictEqual(captured.value.summary, {
-        total: 8,
-        passed: 8,
+        total: 9,
+        passed: 9,
         failed: 0,
         disallowed: 0,
         error: 0
@@ -428,8 +428,9 @@ describe('evaluation runner public entrypoints', () => {
       assert.equal(output.exitCode, 0);
       assert.equal(output.humanOutput, [
         'PASS benchmark suite',
-        'tasks: 8',
-        'passed: 8, failed: 0, disallowed: 0, error: 0',
+        'tasks: 9',
+        'passed: 9, failed: 0, disallowed: 0, error: 0',
+        '- passed basic-gates/basis-change BasisChange',
         '- passed basic-gates/state-flip StateFlip',
         '- passed superposition/all-basis-vector-with-phase-flip-two-qubits AllBasisVectorWithPhaseFlip_TwoQubits',
         '- passed superposition/all-basis-vectors-two-qubits AllBasisVectors_TwoQubits',
@@ -442,8 +443,8 @@ describe('evaluation runner public entrypoints', () => {
       ].join('\n'));
       assert.equal(output.jsonOutput.status, 'passed');
       assert.deepStrictEqual(output.jsonOutput.summary, {
-        total: 8,
-        passed: 8,
+        total: 9,
+        passed: 9,
         failed: 0,
         disallowed: 0,
         error: 0

--- a/test/typescript/research_command.test.ts
+++ b/test/typescript/research_command.test.ts
@@ -120,6 +120,7 @@ async function prepareQuantumKatasSubmissions(
   status: UnsuccessfulResearchStatus
 ): Promise<void> {
   const relativePaths = [
+    'basic-gates/basis-change.qni',
     'basic-gates/state-flip.qni',
     'superposition/all-basis-vector-with-phase-flip-two-qubits.qni',
     'superposition/all-basis-vectors-two-qubits.qni',
@@ -140,6 +141,7 @@ async function prepareQuantumKatasSubmissions(
 
 function quantumKatasSubmissionContent(status: UnsuccessfulResearchStatus, relativePath: string): string {
   const passedSubmissions = new Map<string, string>([
+    ['basic-gates/basis-change.qni', 'qni add H --qubit 0 --step 0\n'],
     ['basic-gates/state-flip.qni', 'qni add X --qubit 0 --step 0\n'],
     [
       'superposition/all-basis-vector-with-phase-flip-two-qubits.qni',
@@ -764,8 +766,8 @@ describe('research command TypeScript route', () => {
       assert.match(String(metadata.createdAt), /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.000Z$/u);
       assert.equal(gradingResult.status, 'passed');
       assert.deepStrictEqual(gradingResult.summary, {
-        total: 8,
-        passed: 8,
+        total: 9,
+        passed: 9,
         failed: 0,
         disallowed: 0,
         error: 0


### PR DESCRIPTION
## 概要

Quantum Katas BasicGates の BasisChange を、`grading_cases` と `setup_commands` を使うベンチマーク実例として追加しました。`|0>` と `|1>` の入力を別々の採点ケースで評価し、片方だけに合う提出物を失敗として検出できるようにしています。

Closes #309

## 変更内容

- `benchmarks/quantum-katas/basic-gates/basis-change.md` に `zero-input` / `one-input` の採点ケースを定義し、標準解と `|0>` だけに合う不正解サンプルを追加。
- `docs/benchmark.md` と `features/cli/benchmark_run.feature.md` を 9 問のスモークセットと BasisChange の実行例に更新。
- TypeScript / Cucumber のベンチマーク・研究記録テストを、BasisChange を含む 9 問構成と複数採点ケースの出力に合わせて更新。

## 確認

- `npm run check`
