### PR TITLE
BasicGates に複数採点ケースの単一量子ビット課題を追加する

### DIFF
--- a/benchmarks/incorrect/quantum-katas/basic-gates/phase-flip-zero-only.qni
+++ b/benchmarks/incorrect/quantum-katas/basic-gates/phase-flip-zero-only.qni
@@ -1,0 +1,1 @@
+qni add Z --qubit 0 --step 0

--- a/benchmarks/quantum-katas/basic-gates/phase-change-pi-over-3.md
+++ b/benchmarks/quantum-katas/basic-gates/phase-change-pi-over-3.md
@@ -1,0 +1,38 @@
+---
+id: basic-gates/phase-change-pi-over-3
+title: PhaseChangePiOver3
+source: Microsoft Quantum Katas / BasicGates
+difficulty: smoke
+allowed_commands:
+  - qni add
+grading_cases:
+  - id: zero-input
+    setup_commands:
+      - qni state set "|0>"
+    checks:
+      tolerance: 1e-15
+      items:
+        - type: run
+          expected:
+            - basis: "|0>"
+              amplitude:
+                real: 1
+                imaginary: 0
+  - id: one-input
+    setup_commands:
+      - qni state set "|1>"
+    checks:
+      tolerance: 1e-15
+      items:
+        - type: run
+          expected:
+            - basis: "|1>"
+              amplitude:
+                real: 0.5000000000000001
+                imaginary: 0.8660254037844386
+---
+
+1量子ビットに対して、`|0>` を変えず、`|1>` の振幅にだけ位相 `exp(i*pi/3)` を掛ける量子回路を、`qni` コマンド列として作成してください。
+
+これは Quantum Katas BasicGates の `PhaseChange` を、固定角度 `pi/3` で評価する課題です。
+提出物は `.qni` 形式で、1行に1つずつ完全な `qni` コマンドを書いてください。

--- a/benchmarks/quantum-katas/basic-gates/phase-flip.md
+++ b/benchmarks/quantum-katas/basic-gates/phase-flip.md
@@ -1,0 +1,38 @@
+---
+id: basic-gates/phase-flip
+title: PhaseFlip
+source: Microsoft Quantum Katas / BasicGates
+difficulty: smoke
+allowed_commands:
+  - qni add
+grading_cases:
+  - id: zero-input
+    setup_commands:
+      - qni state set "|0>"
+    checks:
+      tolerance: 1e-15
+      items:
+        - type: run
+          expected:
+            - basis: "|0>"
+              amplitude:
+                real: 1
+                imaginary: 0
+  - id: one-input
+    setup_commands:
+      - qni state set "|1>"
+    checks:
+      tolerance: 1e-15
+      items:
+        - type: run
+          expected:
+            - basis: "|1>"
+              amplitude:
+                real: 0
+                imaginary: 1
+---
+
+1量子ビットに対して、`|0>` を変えず、`|1>` の振幅にだけ位相 `i` を掛ける量子回路を、`qni` コマンド列として作成してください。
+
+これは一般に、`alpha|0> + beta|1>` を `alpha|0> + i beta|1>` に変える操作です。
+提出物は `.qni` 形式で、1行に1つずつ完全な `qni` コマンドを書いてください。

--- a/benchmarks/quantum-katas/basic-gates/sign-flip.md
+++ b/benchmarks/quantum-katas/basic-gates/sign-flip.md
@@ -1,0 +1,46 @@
+---
+id: basic-gates/sign-flip
+title: SignFlip
+source: Microsoft Quantum Katas / BasicGates
+difficulty: smoke
+allowed_commands:
+  - qni add
+grading_cases:
+  - id: plus-input
+    setup_commands:
+      - qni state set "|+>"
+    checks:
+      tolerance: 1e-15
+      items:
+        - type: run
+          expected:
+            - basis: "|0>"
+              amplitude:
+                real: 0.7071067811865476
+                imaginary: 0
+            - basis: "|1>"
+              amplitude:
+                real: -0.7071067811865476
+                imaginary: 0
+  - id: minus-input
+    setup_commands:
+      - qni state set "|->"
+    checks:
+      tolerance: 1e-15
+      items:
+        - type: run
+          expected:
+            - basis: "|0>"
+              amplitude:
+                real: 0.7071067811865476
+                imaginary: 0
+            - basis: "|1>"
+              amplitude:
+                real: 0.7071067811865476
+                imaginary: 0
+---
+
+1量子ビットに対して、`|+>` を `|->` に、`|->` を `|+>` に変える量子回路を、`qni` コマンド列として作成してください。
+
+これは一般に、`alpha|0> + beta|1>` を `alpha|0> - beta|1>` に変える操作です。
+提出物は `.qni` 形式で、1行に1つずつ完全な `qni` コマンドを書いてください。

--- a/benchmarks/solutions/quantum-katas/basic-gates/phase-change-pi-over-3.qni
+++ b/benchmarks/solutions/quantum-katas/basic-gates/phase-change-pi-over-3.qni
@@ -1,0 +1,1 @@
+qni add P --angle pi/3 --qubit 0 --step 0

--- a/benchmarks/solutions/quantum-katas/basic-gates/phase-flip.qni
+++ b/benchmarks/solutions/quantum-katas/basic-gates/phase-flip.qni
@@ -1,0 +1,1 @@
+qni add S --qubit 0 --step 0

--- a/benchmarks/solutions/quantum-katas/basic-gates/sign-flip.qni
+++ b/benchmarks/solutions/quantum-katas/basic-gates/sign-flip.qni
@@ -1,0 +1,1 @@
+qni add Z --qubit 0 --step 0

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -14,7 +14,7 @@
 
 提出物には回路を作るコマンドだけを書きます。`qni run` や `qni expect` などの検証コマンドは書きません。
 
-## 9問の標準解を実行する
+## 12問の標準解を実行する
 
 ### StateFlip
 
@@ -31,6 +31,30 @@ qni benchmark run benchmarks/quantum-katas/basic-gates/basis-change.md benchmark
 ```
 
 期待される結果は `PASS BasisChange` です。BasisChange は複数の採点ケースを持ち、既定の `|0>` 入力と `setup_commands` で準備した `|1>` 入力を別々に検証します。
+
+### SignFlip
+
+```bash
+qni benchmark run benchmarks/quantum-katas/basic-gates/sign-flip.md benchmarks/solutions/quantum-katas/basic-gates/sign-flip.qni
+```
+
+期待される結果は `PASS SignFlip` です。SignFlip は複数の採点ケースを持ち、`setup_commands` で準備した `|+>` 入力と `|->` 入力を別々に検証します。
+
+### PhaseFlip
+
+```bash
+qni benchmark run benchmarks/quantum-katas/basic-gates/phase-flip.md benchmarks/solutions/quantum-katas/basic-gates/phase-flip.qni
+```
+
+期待される結果は `PASS PhaseFlip` です。PhaseFlip は複数の採点ケースを持ち、`setup_commands` で準備した `|0>` 入力と `|1>` 入力を別々に検証します。
+
+### PhaseChangePiOver3
+
+```bash
+qni benchmark run benchmarks/quantum-katas/basic-gates/phase-change-pi-over-3.md benchmarks/solutions/quantum-katas/basic-gates/phase-change-pi-over-3.qni
+```
+
+期待される結果は `PASS PhaseChangePiOver3` です。PhaseChangePiOver3 は Quantum Katas BasicGates の PhaseChange を固定角度 `pi/3` で評価し、`|0>` 入力と `|1>` 入力を別々に検証します。
 
 ### PlusState
 
@@ -105,6 +129,14 @@ qni benchmark run benchmarks/quantum-katas/basic-gates/basis-change.md benchmark
 ```
 
 期待される結果は `FAIL BasisChange` です。
+
+PhaseFlip には、`|0>` 入力だけに合う不正解サンプルがあります。`|1>` 入力の採点ケースで失敗するため、終了コードは `1` です。
+
+```bash
+qni benchmark run benchmarks/quantum-katas/basic-gates/phase-flip.md benchmarks/incorrect/quantum-katas/basic-gates/phase-flip-zero-only.qni
+```
+
+期待される結果は `FAIL PhaseFlip` です。
 
 ## 不許可サンプルを実行する
 
@@ -190,13 +222,16 @@ grading_cases:
 qni benchmark run-all benchmarks/quantum-katas benchmarks/solutions/quantum-katas
 ```
 
-期待される結果は、9問すべてが `passed` になり、終了コードが `0` になることです。
+期待される結果は、12問すべてが `passed` になり、終了コードが `0` になることです。
 
 ```text
 PASS benchmark suite
-tasks: 9
-passed: 9, failed: 0, disallowed: 0, error: 0
+tasks: 12
+passed: 12, failed: 0, disallowed: 0, error: 0
 - passed basic-gates/basis-change BasisChange
+- passed basic-gates/phase-change-pi-over-3 PhaseChangePiOver3
+- passed basic-gates/phase-flip PhaseFlip
+- passed basic-gates/sign-flip SignFlip
 - passed basic-gates/state-flip StateFlip
 - passed superposition/all-basis-vector-with-phase-flip-two-qubits AllBasisVectorWithPhaseFlip_TwoQubits
 - passed superposition/all-basis-vectors-two-qubits AllBasisVectors_TwoQubits

--- a/features/cli/benchmark_run.feature.md
+++ b/features/cli/benchmark_run.feature.md
@@ -99,6 +99,72 @@ qni benchmark run で最小の合格判定を実行したい。
   PASS BasisChange
   ```
 
+## Scenario: SignFlip 課題ファイルがある
+
+- Then リポジトリファイル "benchmarks/quantum-katas/basic-gates/sign-flip.md" は存在する
+
+## Scenario: SignFlip 標準解がある
+
+- Then リポジトリファイル "benchmarks/solutions/quantum-katas/basic-gates/sign-flip.qni" は存在する
+
+## Scenario: SignFlip 標準解は合格する
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/sign-flip.md benchmarks/solutions/quantum-katas/basic-gates/sign-flip.qni" を実行
+- Then コマンドは成功
+
+## Scenario: SignFlip 標準解の合格が表示される
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/sign-flip.md benchmarks/solutions/quantum-katas/basic-gates/sign-flip.qni" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  PASS SignFlip
+  ```
+
+## Scenario: PhaseFlip 課題ファイルがある
+
+- Then リポジトリファイル "benchmarks/quantum-katas/basic-gates/phase-flip.md" は存在する
+
+## Scenario: PhaseFlip 標準解がある
+
+- Then リポジトリファイル "benchmarks/solutions/quantum-katas/basic-gates/phase-flip.qni" は存在する
+
+## Scenario: PhaseFlip 標準解は合格する
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/phase-flip.md benchmarks/solutions/quantum-katas/basic-gates/phase-flip.qni" を実行
+- Then コマンドは成功
+
+## Scenario: PhaseFlip 標準解の合格が表示される
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/phase-flip.md benchmarks/solutions/quantum-katas/basic-gates/phase-flip.qni" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  PASS PhaseFlip
+  ```
+
+## Scenario: PhaseChangePiOver3 課題ファイルがある
+
+- Then リポジトリファイル "benchmarks/quantum-katas/basic-gates/phase-change-pi-over-3.md" は存在する
+
+## Scenario: PhaseChangePiOver3 標準解がある
+
+- Then リポジトリファイル "benchmarks/solutions/quantum-katas/basic-gates/phase-change-pi-over-3.qni" は存在する
+
+## Scenario: PhaseChangePiOver3 標準解は合格する
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/phase-change-pi-over-3.md benchmarks/solutions/quantum-katas/basic-gates/phase-change-pi-over-3.qni" を実行
+- Then コマンドは成功
+
+## Scenario: PhaseChangePiOver3 標準解の合格が表示される
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/phase-change-pi-over-3.md benchmarks/solutions/quantum-katas/basic-gates/phase-change-pi-over-3.qni" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  PASS PhaseChangePiOver3
+  ```
+
 ## Scenario: MinusState 課題ファイルがある
 
 - Then リポジトリファイル "benchmarks/quantum-katas/superposition/minus-state.md" は存在する
@@ -378,6 +444,24 @@ qni benchmark run で最小の合格判定を実行したい。
   - case one-input run #1: state vector did not match expected amplitudes
   ```
 
+## Scenario: PhaseFlip の片方の入力だけに合う不正解サンプルがある
+
+- Then リポジトリファイル "benchmarks/incorrect/quantum-katas/basic-gates/phase-flip-zero-only.qni" は存在する
+
+## Scenario: PhaseFlip の片方の入力だけに合う不正解サンプルは不合格になる
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/phase-flip.md benchmarks/incorrect/quantum-katas/basic-gates/phase-flip-zero-only.qni" を実行
+- Then 終了コードは 1
+
+## Scenario: PhaseFlip の片方の入力だけに合う不正解サンプルは失敗した採点ケースを表示する
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/phase-flip.md benchmarks/incorrect/quantum-katas/basic-gates/phase-flip-zero-only.qni" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  - case one-input run #1: state vector did not match expected amplitudes
+  ```
+
 ## Scenario: frontmatter 不備の課題ファイルは終了コード 3 になる
 
 - When "qni benchmark run benchmarks/invalid/quantum-katas/basic-gates/state-flip-missing-allowed-commands.md benchmarks/solutions/quantum-katas/basic-gates/state-flip.qni" を実行
@@ -460,6 +544,18 @@ qni benchmark run で最小の合格判定を実行したい。
 
 - Then リポジトリファイル "docs/benchmark.md" は "qni benchmark run benchmarks/quantum-katas/basic-gates/basis-change.md benchmarks/solutions/quantum-katas/basic-gates/basis-change.qni" を含む
 
+## Scenario: MVP手順は SignFlip 標準解の実行例を示す
+
+- Then リポジトリファイル "docs/benchmark.md" は "qni benchmark run benchmarks/quantum-katas/basic-gates/sign-flip.md benchmarks/solutions/quantum-katas/basic-gates/sign-flip.qni" を含む
+
+## Scenario: MVP手順は PhaseFlip 標準解の実行例を示す
+
+- Then リポジトリファイル "docs/benchmark.md" は "qni benchmark run benchmarks/quantum-katas/basic-gates/phase-flip.md benchmarks/solutions/quantum-katas/basic-gates/phase-flip.qni" を含む
+
+## Scenario: MVP手順は PhaseChangePiOver3 標準解の実行例を示す
+
+- Then リポジトリファイル "docs/benchmark.md" は "qni benchmark run benchmarks/quantum-katas/basic-gates/phase-change-pi-over-3.md benchmarks/solutions/quantum-katas/basic-gates/phase-change-pi-over-3.qni" を含む
+
 ## Scenario: MVP手順は複数採点ケースの説明を示す
 
 - Then リポジトリファイル "docs/benchmark.md" は "複数採点ケース" を含む
@@ -504,9 +600,12 @@ qni benchmark run で最小の合格判定を実行したい。
 
   ```text
   PASS benchmark suite
-  tasks: 9
-  passed: 9, failed: 0, disallowed: 0, error: 0
+  tasks: 12
+  passed: 12, failed: 0, disallowed: 0, error: 0
   - passed basic-gates/basis-change BasisChange
+  - passed basic-gates/phase-change-pi-over-3 PhaseChangePiOver3
+  - passed basic-gates/phase-flip PhaseFlip
+  - passed basic-gates/sign-flip SignFlip
   - passed basic-gates/state-flip StateFlip
   - passed superposition/all-basis-vector-with-phase-flip-two-qubits AllBasisVectorWithPhaseFlip_TwoQubits
   - passed superposition/all-basis-vectors-two-qubits AllBasisVectors_TwoQubits
@@ -527,8 +626,8 @@ qni benchmark run で最小の合格判定を実行したい。
     "status": "passed",
     "exitCode": 0,
     "summary": {
-      "total": 9,
-      "passed": 9,
+      "total": 12,
+      "passed": 12,
       "failed": 0,
       "disallowed": 0,
       "error": 0
@@ -554,6 +653,126 @@ qni benchmark run で最小の合格判定を実行したい。
           },
           {
             "caseId": "one-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          }
+        ],
+        "checks": [
+          {
+            "type": "run",
+            "status": "passed"
+          },
+          {
+            "type": "run",
+            "status": "passed"
+          }
+        ]
+      },
+      {
+        "taskId": "basic-gates/phase-change-pi-over-3",
+        "title": "PhaseChangePiOver3",
+        "task": "benchmarks/quantum-katas/basic-gates/phase-change-pi-over-3.md",
+        "submission": "benchmarks/solutions/quantum-katas/basic-gates/phase-change-pi-over-3.qni",
+        "status": "passed",
+        "exitCode": 0,
+        "gradingCases": [
+          {
+            "caseId": "zero-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          },
+          {
+            "caseId": "one-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          }
+        ],
+        "checks": [
+          {
+            "type": "run",
+            "status": "passed"
+          },
+          {
+            "type": "run",
+            "status": "passed"
+          }
+        ]
+      },
+      {
+        "taskId": "basic-gates/phase-flip",
+        "title": "PhaseFlip",
+        "task": "benchmarks/quantum-katas/basic-gates/phase-flip.md",
+        "submission": "benchmarks/solutions/quantum-katas/basic-gates/phase-flip.qni",
+        "status": "passed",
+        "exitCode": 0,
+        "gradingCases": [
+          {
+            "caseId": "zero-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          },
+          {
+            "caseId": "one-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          }
+        ],
+        "checks": [
+          {
+            "type": "run",
+            "status": "passed"
+          },
+          {
+            "type": "run",
+            "status": "passed"
+          }
+        ]
+      },
+      {
+        "taskId": "basic-gates/sign-flip",
+        "title": "SignFlip",
+        "task": "benchmarks/quantum-katas/basic-gates/sign-flip.md",
+        "submission": "benchmarks/solutions/quantum-katas/basic-gates/sign-flip.qni",
+        "status": "passed",
+        "exitCode": 0,
+        "gradingCases": [
+          {
+            "caseId": "plus-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          },
+          {
+            "caseId": "minus-input",
             "status": "passed",
             "checks": [
               {

--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -216,6 +216,9 @@ function writeCircuitJson(scenarioDir, data) {
 function quantumKatasSubmissionContent(status, relativePath) {
   const passedSubmissions = new Map([
     ['basic-gates/basis-change.qni', 'qni add H --qubit 0 --step 0\n'],
+    ['basic-gates/phase-change-pi-over-3.qni', 'qni add P --angle pi/3 --qubit 0 --step 0\n'],
+    ['basic-gates/phase-flip.qni', 'qni add S --qubit 0 --step 0\n'],
+    ['basic-gates/sign-flip.qni', 'qni add Z --qubit 0 --step 0\n'],
     ['basic-gates/state-flip.qni', 'qni add X --qubit 0 --step 0\n'],
     [
       'superposition/all-basis-vector-with-phase-flip-two-qubits.qni',
@@ -257,6 +260,9 @@ function quantumKatasSubmissionContent(status, relativePath) {
 function writeQuantumKatasSubmissions(scenarioDir, status, submissionsDir) {
   const relativePaths = [
     'basic-gates/basis-change.qni',
+    'basic-gates/phase-change-pi-over-3.qni',
+    'basic-gates/phase-flip.qni',
+    'basic-gates/sign-flip.qni',
     'basic-gates/state-flip.qni',
     'superposition/all-basis-vector-with-phase-flip-two-qubits.qni',
     'superposition/all-basis-vectors-two-qubits.qni',

--- a/test/typescript/benchmark_command.test.ts
+++ b/test/typescript/benchmark_command.test.ts
@@ -434,6 +434,51 @@ describe('benchmark command TypeScript route', () => {
     });
   });
 
+  it('passes the SignFlip solution using explicit grading cases', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, [
+        'benchmark',
+        'run',
+        'benchmarks/quantum-katas/basic-gates/sign-flip.md',
+        'benchmarks/solutions/quantum-katas/basic-gates/sign-flip.qni'
+      ]);
+
+      assert.equal(result.exitStatus, 0, result.stderr);
+      assert.equal(result.stdout, 'PASS SignFlip\nchecks: 2\n');
+      assert.equal(result.stderr, '');
+    });
+  });
+
+  it('passes the PhaseFlip solution using explicit grading cases', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, [
+        'benchmark',
+        'run',
+        'benchmarks/quantum-katas/basic-gates/phase-flip.md',
+        'benchmarks/solutions/quantum-katas/basic-gates/phase-flip.qni'
+      ]);
+
+      assert.equal(result.exitStatus, 0, result.stderr);
+      assert.equal(result.stdout, 'PASS PhaseFlip\nchecks: 2\n');
+      assert.equal(result.stderr, '');
+    });
+  });
+
+  it('passes the fixed-angle PhaseChange solution using explicit grading cases', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, [
+        'benchmark',
+        'run',
+        'benchmarks/quantum-katas/basic-gates/phase-change-pi-over-3.md',
+        'benchmarks/solutions/quantum-katas/basic-gates/phase-change-pi-over-3.qni'
+      ]);
+
+      assert.equal(result.exitStatus, 0, result.stderr);
+      assert.equal(result.stdout, 'PASS PhaseChangePiOver3\nchecks: 2\n');
+      assert.equal(result.stderr, '');
+    });
+  });
+
   it('passes the MinusState solution using a run check', async () => {
     await withTempDir(async (dir) => {
       const result = captureDispatcherRun(dir, [
@@ -620,6 +665,29 @@ describe('benchmark command TypeScript route', () => {
     });
   });
 
+  it('fails the PhaseFlip zero-input-only incorrect sample in the one-input grading case', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, [
+        'benchmark',
+        'run',
+        'benchmarks/quantum-katas/basic-gates/phase-flip.md',
+        'benchmarks/incorrect/quantum-katas/basic-gates/phase-flip-zero-only.qni'
+      ]);
+
+      assert.equal(result.exitStatus, 1, result.stderr);
+      assert.equal(result.stdout, [
+        'FAIL PhaseFlip',
+        'checks: 2',
+        'failed checks:',
+        '- case one-input run #1: state vector did not match expected amplitudes',
+        '  expected / actual mismatches:',
+        '  - |1>: expected 1i, actual -1',
+        ''
+      ].join('\n'));
+      assert.equal(result.stderr, '');
+    });
+  });
+
   it('prints failed grading case ids in human-readable check details', async () => {
     await withTempDir(async (dir) => {
       await writeFile(path.join(dir, 'task.md'), xOnZeroAndOneGradingCasesTask());
@@ -800,8 +868,8 @@ describe('benchmark command TypeScript route', () => {
       assert.equal(captured.value.status, 'passed');
       assert.equal(captured.value.exitCode, 0);
       assert.deepStrictEqual(captured.value.summary, {
-        total: 9,
-        passed: 9,
+        total: 12,
+        passed: 12,
         failed: 0,
         disallowed: 0,
         error: 0
@@ -814,6 +882,33 @@ describe('benchmark command TypeScript route', () => {
       })), [
         {
           taskId: 'basic-gates/basis-change',
+          status: 'passed',
+          exitCode: 0,
+          checks: [
+            { type: 'run', status: 'passed' },
+            { type: 'run', status: 'passed' }
+          ]
+        },
+        {
+          taskId: 'basic-gates/phase-change-pi-over-3',
+          status: 'passed',
+          exitCode: 0,
+          checks: [
+            { type: 'run', status: 'passed' },
+            { type: 'run', status: 'passed' }
+          ]
+        },
+        {
+          taskId: 'basic-gates/phase-flip',
+          status: 'passed',
+          exitCode: 0,
+          checks: [
+            { type: 'run', status: 'passed' },
+            { type: 'run', status: 'passed' }
+          ]
+        },
+        {
+          taskId: 'basic-gates/sign-flip',
           status: 'passed',
           exitCode: 0,
           checks: [
@@ -885,9 +980,12 @@ describe('benchmark command TypeScript route', () => {
       assert.equal(result.exitStatus, 0, result.stderr);
       assert.equal(result.stdout, [
         'PASS benchmark suite',
-        'tasks: 9',
-        'passed: 9, failed: 0, disallowed: 0, error: 0',
+        'tasks: 12',
+        'passed: 12, failed: 0, disallowed: 0, error: 0',
         '- passed basic-gates/basis-change BasisChange',
+        '- passed basic-gates/phase-change-pi-over-3 PhaseChangePiOver3',
+        '- passed basic-gates/phase-flip PhaseFlip',
+        '- passed basic-gates/sign-flip SignFlip',
         '- passed basic-gates/state-flip StateFlip',
         '- passed superposition/all-basis-vector-with-phase-flip-two-qubits AllBasisVectorWithPhaseFlip_TwoQubits',
         '- passed superposition/all-basis-vectors-two-qubits AllBasisVectors_TwoQubits',
@@ -918,8 +1016,8 @@ describe('benchmark command TypeScript route', () => {
         status: 'passed',
         exitCode: 0,
         summary: {
-          total: 9,
-          passed: 9,
+          total: 12,
+          passed: 12,
           failed: 0,
           disallowed: 0,
           error: 0
@@ -940,6 +1038,78 @@ describe('benchmark command TypeScript route', () => {
               },
               {
                 caseId: 'one-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              }
+            ],
+            checks: [
+              { type: 'run', status: 'passed' },
+              { type: 'run', status: 'passed' }
+            ]
+          },
+          {
+            taskId: 'basic-gates/phase-change-pi-over-3',
+            title: 'PhaseChangePiOver3',
+            task: 'benchmarks/quantum-katas/basic-gates/phase-change-pi-over-3.md',
+            submission: 'benchmarks/solutions/quantum-katas/basic-gates/phase-change-pi-over-3.qni',
+            status: 'passed',
+            exitCode: 0,
+            gradingCases: [
+              {
+                caseId: 'zero-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              },
+              {
+                caseId: 'one-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              }
+            ],
+            checks: [
+              { type: 'run', status: 'passed' },
+              { type: 'run', status: 'passed' }
+            ]
+          },
+          {
+            taskId: 'basic-gates/phase-flip',
+            title: 'PhaseFlip',
+            task: 'benchmarks/quantum-katas/basic-gates/phase-flip.md',
+            submission: 'benchmarks/solutions/quantum-katas/basic-gates/phase-flip.qni',
+            status: 'passed',
+            exitCode: 0,
+            gradingCases: [
+              {
+                caseId: 'zero-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              },
+              {
+                caseId: 'one-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              }
+            ],
+            checks: [
+              { type: 'run', status: 'passed' },
+              { type: 'run', status: 'passed' }
+            ]
+          },
+          {
+            taskId: 'basic-gates/sign-flip',
+            title: 'SignFlip',
+            task: 'benchmarks/quantum-katas/basic-gates/sign-flip.md',
+            submission: 'benchmarks/solutions/quantum-katas/basic-gates/sign-flip.qni',
+            status: 'passed',
+            exitCode: 0,
+            gradingCases: [
+              {
+                caseId: 'plus-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              },
+              {
+                caseId: 'minus-input',
                 status: 'passed',
                 checks: [{ type: 'run', status: 'passed' }]
               }

--- a/test/typescript/evaluation_runner.test.ts
+++ b/test/typescript/evaluation_runner.test.ts
@@ -402,8 +402,8 @@ describe('evaluation runner public entrypoints', () => {
       assert.equal(captured.value.status, 'passed');
       assert.equal(captured.value.exitCode, 0);
       assert.deepStrictEqual(captured.value.summary, {
-        total: 9,
-        passed: 9,
+        total: 12,
+        passed: 12,
         failed: 0,
         disallowed: 0,
         error: 0
@@ -428,9 +428,12 @@ describe('evaluation runner public entrypoints', () => {
       assert.equal(output.exitCode, 0);
       assert.equal(output.humanOutput, [
         'PASS benchmark suite',
-        'tasks: 9',
-        'passed: 9, failed: 0, disallowed: 0, error: 0',
+        'tasks: 12',
+        'passed: 12, failed: 0, disallowed: 0, error: 0',
         '- passed basic-gates/basis-change BasisChange',
+        '- passed basic-gates/phase-change-pi-over-3 PhaseChangePiOver3',
+        '- passed basic-gates/phase-flip PhaseFlip',
+        '- passed basic-gates/sign-flip SignFlip',
         '- passed basic-gates/state-flip StateFlip',
         '- passed superposition/all-basis-vector-with-phase-flip-two-qubits AllBasisVectorWithPhaseFlip_TwoQubits',
         '- passed superposition/all-basis-vectors-two-qubits AllBasisVectors_TwoQubits',
@@ -443,8 +446,8 @@ describe('evaluation runner public entrypoints', () => {
       ].join('\n'));
       assert.equal(output.jsonOutput.status, 'passed');
       assert.deepStrictEqual(output.jsonOutput.summary, {
-        total: 9,
-        passed: 9,
+        total: 12,
+        passed: 12,
         failed: 0,
         disallowed: 0,
         error: 0

--- a/test/typescript/research_command.test.ts
+++ b/test/typescript/research_command.test.ts
@@ -121,6 +121,9 @@ async function prepareQuantumKatasSubmissions(
 ): Promise<void> {
   const relativePaths = [
     'basic-gates/basis-change.qni',
+    'basic-gates/phase-change-pi-over-3.qni',
+    'basic-gates/phase-flip.qni',
+    'basic-gates/sign-flip.qni',
     'basic-gates/state-flip.qni',
     'superposition/all-basis-vector-with-phase-flip-two-qubits.qni',
     'superposition/all-basis-vectors-two-qubits.qni',
@@ -142,6 +145,9 @@ async function prepareQuantumKatasSubmissions(
 function quantumKatasSubmissionContent(status: UnsuccessfulResearchStatus, relativePath: string): string {
   const passedSubmissions = new Map<string, string>([
     ['basic-gates/basis-change.qni', 'qni add H --qubit 0 --step 0\n'],
+    ['basic-gates/phase-change-pi-over-3.qni', 'qni add P --angle pi/3 --qubit 0 --step 0\n'],
+    ['basic-gates/phase-flip.qni', 'qni add S --qubit 0 --step 0\n'],
+    ['basic-gates/sign-flip.qni', 'qni add Z --qubit 0 --step 0\n'],
     ['basic-gates/state-flip.qni', 'qni add X --qubit 0 --step 0\n'],
     [
       'superposition/all-basis-vector-with-phase-flip-two-qubits.qni',
@@ -766,8 +772,8 @@ describe('research command TypeScript route', () => {
       assert.match(String(metadata.createdAt), /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.000Z$/u);
       assert.equal(gradingResult.status, 'passed');
       assert.deepStrictEqual(gradingResult.summary, {
-        total: 9,
-        passed: 9,
+        total: 12,
+        passed: 12,
         failed: 0,
         disallowed: 0,
         error: 0
@@ -776,6 +782,7 @@ describe('research command TypeScript route', () => {
       assert.equal(await readFile(path.join(trialDir, 'prompt.md'), 'utf8'), 'Solve the smoke benchmark suite.\n');
       assert.equal(await readFile(path.join(trialDir, 'response.md'), 'utf8'), 'I wrote the requested .qni submissions.\n');
       assert.equal((await stat(path.join(trialDir, 'submissions'))).isDirectory(), true);
+      assert.equal((await stat(path.join(trialDir, 'submissions', 'basic-gates', 'phase-flip.qni'))).isFile(), true);
       assert.equal((await stat(path.join(trialDir, 'submissions', 'basic-gates', 'state-flip.qni'))).isFile(), true);
     });
   });

--- a/test/typescript/research_command.test.ts
+++ b/test/typescript/research_command.test.ts
@@ -782,7 +782,9 @@ describe('research command TypeScript route', () => {
       assert.equal(await readFile(path.join(trialDir, 'prompt.md'), 'utf8'), 'Solve the smoke benchmark suite.\n');
       assert.equal(await readFile(path.join(trialDir, 'response.md'), 'utf8'), 'I wrote the requested .qni submissions.\n');
       assert.equal((await stat(path.join(trialDir, 'submissions'))).isDirectory(), true);
+      assert.equal((await stat(path.join(trialDir, 'submissions', 'basic-gates', 'phase-change-pi-over-3.qni'))).isFile(), true);
       assert.equal((await stat(path.join(trialDir, 'submissions', 'basic-gates', 'phase-flip.qni'))).isFile(), true);
+      assert.equal((await stat(path.join(trialDir, 'submissions', 'basic-gates', 'sign-flip.qni'))).isFile(), true);
       assert.equal((await stat(path.join(trialDir, 'submissions', 'basic-gates', 'state-flip.qni'))).isFile(), true);
     });
   });


### PR DESCRIPTION
## 概要

Quantum Katas BasicGates の単一量子ビット課題として、SignFlip、PhaseFlip、PhaseChangePiOver3 を複数の採点ケース付きで追加しました。
各課題は `setup_commands` で入力状態を切り替えて検証し、標準解と片方の入力だけに合う不正解サンプルも用意しています。
既存の run-all、研究試行、利用手順の期待値も 12 問構成へ追従させました。

Closes #317

## 変更内容

- `benchmarks/quantum-katas/basic-gates/` に SignFlip、PhaseFlip、PhaseChangePiOver3 の課題を追加し、複数入力の `grading_cases` と `setup_commands` を定義しました。
- `benchmarks/solutions/quantum-katas/basic-gates/` に各課題の標準解を追加し、`benchmarks/incorrect/quantum-katas/basic-gates/` に PhaseFlip の不正解サンプルを追加しました。
- `features/cli/benchmark_run.feature.md` と TypeScript テストを、新規課題の合格ケース、不正解ケース、12 問の run-all 期待値へ更新しました。
- 研究試行用の提出物生成と評価ランナーの期待値を、新規 BasicGates 課題を含む構成へ更新しました。
- `docs/benchmark.md` に新規課題の実行例と 12 問 run-all の説明を追加しました。

## 確認

- `npm run check`
