### PR TITLE
BasicGates Part II と Toffoli のベンチマーク課題を追加する

### DIFF
--- a/benchmarks/incorrect/quantum-katas/basic-gates/two-qubit-gate-1-zero-only.qni
+++ b/benchmarks/incorrect/quantum-katas/basic-gates/two-qubit-gate-1-zero-only.qni
@@ -1,0 +1,1 @@
+qni add Z --qubit 0 --step 0

--- a/benchmarks/quantum-katas/basic-gates/toffoli-gate.md
+++ b/benchmarks/quantum-katas/basic-gates/toffoli-gate.md
@@ -1,0 +1,75 @@
+---
+id: basic-gates/toffoli-gate
+title: ToffoliGate
+source: Microsoft Quantum Katas / BasicGates
+difficulty: smoke
+allowed_commands:
+  - qni add
+grading_cases:
+  - id: zero-zero-zero-input
+    checks:
+      tolerance: 1e-9
+      items:
+        - type: run
+          expected:
+            - basis: "|000>"
+              amplitude:
+                real: 1
+                imaginary: 0
+  - id: one-one-zero-input
+    setup_commands:
+      - qni state set "|110>"
+    checks:
+      tolerance: 1e-9
+      items:
+        - type: run
+          expected:
+            - basis: "|111>"
+              amplitude:
+                real: 1
+                imaginary: 0
+  - id: one-one-one-input
+    setup_commands:
+      - qni state set "|111>"
+    checks:
+      tolerance: 1e-9
+      items:
+        - type: run
+          expected:
+            - basis: "|110>"
+              amplitude:
+                real: 1
+                imaginary: 0
+  - id: one-zero-one-input
+    setup_commands:
+      - qni state set "|101>"
+    checks:
+      tolerance: 1e-9
+      items:
+        - type: run
+          expected:
+            - basis: "|101>"
+              amplitude:
+                real: 1
+                imaginary: 0
+  - id: superposition-input
+    setup_commands:
+      - qni state set "0.6|110> + 0.8|111>"
+    checks:
+      tolerance: 1e-9
+      items:
+        - type: run
+          expected:
+            - basis: "|110>"
+              amplitude:
+                real: 0.8
+                imaginary: 0
+            - basis: "|111>"
+              amplitude:
+                real: 0.6
+                imaginary: 0
+---
+
+3量子ビットの任意の状態で、1つ目と2つ目の量子ビットがどちらも `|1>` のときだけ3つ目の量子ビットを反転する量子回路を、`qni` コマンド列として作成してください。
+
+提出物は `.qni` 形式で、1行に1つずつ完全な `qni` コマンドを書いてください。

--- a/benchmarks/quantum-katas/basic-gates/two-qubit-gate-1.md
+++ b/benchmarks/quantum-katas/basic-gates/two-qubit-gate-1.md
@@ -1,0 +1,51 @@
+---
+id: basic-gates/two-qubit-gate-1
+title: TwoQubitGate1
+source: Microsoft Quantum Katas / BasicGates
+difficulty: smoke
+allowed_commands:
+  - qni add
+grading_cases:
+  - id: zero-input
+    checks:
+      tolerance: 1e-9
+      items:
+        - type: run
+          expected:
+            - basis: "|00>"
+              amplitude:
+                real: 1
+                imaginary: 0
+  - id: one-input
+    setup_commands:
+      - qni state set "|10>"
+    checks:
+      tolerance: 1e-9
+      items:
+        - type: run
+          expected:
+            - basis: "|11>"
+              amplitude:
+                real: 1
+                imaginary: 0
+  - id: superposition-input
+    setup_commands:
+      - qni state set "0.6|00> + 0.8|10>"
+    checks:
+      tolerance: 1e-9
+      items:
+        - type: run
+          expected:
+            - basis: "|00>"
+              amplitude:
+                real: 0.6
+                imaginary: 0
+            - basis: "|11>"
+              amplitude:
+                real: 0.8
+                imaginary: 0
+---
+
+2量子ビットのうち、1つ目の量子ビットが `α|0> + β|1>`、2つ目の量子ビットが `|0>` の状態から、`α|00> + β|11>` に変える量子回路を、`qni` コマンド列として作成してください。
+
+提出物は `.qni` 形式で、1行に1つずつ完全な `qni` コマンドを書いてください。

--- a/benchmarks/quantum-katas/basic-gates/two-qubit-gate-2.md
+++ b/benchmarks/quantum-katas/basic-gates/two-qubit-gate-2.md
@@ -1,0 +1,62 @@
+---
+id: basic-gates/two-qubit-gate-2
+title: TwoQubitGate2
+source: Microsoft Quantum Katas / BasicGates
+difficulty: smoke
+allowed_commands:
+  - qni add
+grading_cases:
+  - id: plus-plus-input
+    setup_commands:
+      - qni state set "0.5|00> + 0.5|01> + 0.5|10> + 0.5|11>"
+    checks:
+      tolerance: 1e-9
+      items:
+        - type: run
+          expected:
+            - basis: "|00>"
+              amplitude:
+                real: 0.5
+                imaginary: 0
+            - basis: "|01>"
+              amplitude:
+                real: 0.5
+                imaginary: 0
+            - basis: "|10>"
+              amplitude:
+                real: 0.5
+                imaginary: 0
+            - basis: "|11>"
+              amplitude:
+                real: -0.5
+                imaginary: 0
+  - id: eleven-input
+    setup_commands:
+      - qni state set "|11>"
+    checks:
+      tolerance: 1e-9
+      items:
+        - type: run
+          expected:
+            - basis: "|11>"
+              amplitude:
+                real: -1
+                imaginary: 0
+  - id: ten-input
+    setup_commands:
+      - qni state set "|10>"
+    checks:
+      tolerance: 1e-9
+      items:
+        - type: run
+          expected:
+            - basis: "|10>"
+              amplitude:
+                real: 1
+                imaginary: 0
+---
+
+2量子ビットを `|+> ⊗ |+>` から `(|00> + |01> + |10> - |11>) / 2` に変える量子回路を、`qni` コマンド列として作成してください。
+
+`|+> ⊗ |+>` は `(|00> + |01> + |10> + |11>) / 2` です。
+提出物は `.qni` 形式で、1行に1つずつ完全な `qni` コマンドを書いてください。

--- a/benchmarks/quantum-katas/basic-gates/two-qubit-gate-3.md
+++ b/benchmarks/quantum-katas/basic-gates/two-qubit-gate-3.md
@@ -1,0 +1,63 @@
+---
+id: basic-gates/two-qubit-gate-3
+title: TwoQubitGate3
+source: Microsoft Quantum Katas / BasicGates
+difficulty: smoke
+allowed_commands:
+  - qni add
+grading_cases:
+  - id: zero-zero-input
+    checks:
+      tolerance: 1e-9
+      items:
+        - type: run
+          expected:
+            - basis: "|00>"
+              amplitude:
+                real: 1
+                imaginary: 0
+  - id: zero-one-input
+    setup_commands:
+      - qni state set "|01>"
+    checks:
+      tolerance: 1e-9
+      items:
+        - type: run
+          expected:
+            - basis: "|10>"
+              amplitude:
+                real: 1
+                imaginary: 0
+  - id: one-zero-input
+    setup_commands:
+      - qni state set "|10>"
+    checks:
+      tolerance: 1e-9
+      items:
+        - type: run
+          expected:
+            - basis: "|01>"
+              amplitude:
+                real: 1
+                imaginary: 0
+  - id: superposition-input
+    setup_commands:
+      - qni state set "0.6|01> + 0.8|10>"
+    checks:
+      tolerance: 1e-9
+      items:
+        - type: run
+          expected:
+            - basis: "|01>"
+              amplitude:
+                real: 0.8
+                imaginary: 0
+            - basis: "|10>"
+              amplitude:
+                real: 0.6
+                imaginary: 0
+---
+
+2量子ビットの任意の状態 `α|00> + β|01> + γ|10> + δ|11>` を、`α|00> + γ|01> + β|10> + δ|11>` に変える量子回路を、`qni` コマンド列として作成してください。
+
+提出物は `.qni` 形式で、1行に1つずつ完全な `qni` コマンドを書いてください。

--- a/benchmarks/quantum-katas/basic-gates/two-qubit-gate-4.md
+++ b/benchmarks/quantum-katas/basic-gates/two-qubit-gate-4.md
@@ -1,0 +1,63 @@
+---
+id: basic-gates/two-qubit-gate-4
+title: TwoQubitGate4
+source: Microsoft Quantum Katas / BasicGates
+difficulty: smoke
+allowed_commands:
+  - qni add
+grading_cases:
+  - id: zero-zero-input
+    checks:
+      tolerance: 1e-9
+      items:
+        - type: run
+          expected:
+            - basis: "|01>"
+              amplitude:
+                real: 1
+                imaginary: 0
+  - id: zero-one-input
+    setup_commands:
+      - qni state set "|01>"
+    checks:
+      tolerance: 1e-9
+      items:
+        - type: run
+          expected:
+            - basis: "|00>"
+              amplitude:
+                real: 1
+                imaginary: 0
+  - id: one-zero-input
+    setup_commands:
+      - qni state set "|10>"
+    checks:
+      tolerance: 1e-9
+      items:
+        - type: run
+          expected:
+            - basis: "|10>"
+              amplitude:
+                real: 1
+                imaginary: 0
+  - id: superposition-input
+    setup_commands:
+      - qni state set "0.6|00> + 0.8|10>"
+    checks:
+      tolerance: 1e-9
+      items:
+        - type: run
+          expected:
+            - basis: "|01>"
+              amplitude:
+                real: 0.6
+                imaginary: 0
+            - basis: "|10>"
+              amplitude:
+                real: 0.8
+                imaginary: 0
+---
+
+2量子ビットの任意の状態 `α|00> + β|01> + γ|10> + δ|11>` を、`β|00> + α|01> + γ|10> + δ|11>` に変える量子回路を、`qni` コマンド列として作成してください。
+
+提出物は `.qni` 形式で、1行に1つずつ完全な `qni` コマンドを書いてください。

--- a/benchmarks/solutions/quantum-katas/basic-gates/toffoli-gate.qni
+++ b/benchmarks/solutions/quantum-katas/basic-gates/toffoli-gate.qni
@@ -1,0 +1,1 @@
+qni add X --control 0,1 --qubit 2 --step 0

--- a/benchmarks/solutions/quantum-katas/basic-gates/two-qubit-gate-1.qni
+++ b/benchmarks/solutions/quantum-katas/basic-gates/two-qubit-gate-1.qni
@@ -1,0 +1,1 @@
+qni add X --control 0 --qubit 1 --step 0

--- a/benchmarks/solutions/quantum-katas/basic-gates/two-qubit-gate-2.qni
+++ b/benchmarks/solutions/quantum-katas/basic-gates/two-qubit-gate-2.qni
@@ -1,0 +1,1 @@
+qni add Z --control 0 --qubit 1 --step 0

--- a/benchmarks/solutions/quantum-katas/basic-gates/two-qubit-gate-3.qni
+++ b/benchmarks/solutions/quantum-katas/basic-gates/two-qubit-gate-3.qni
@@ -1,0 +1,1 @@
+qni add SWAP --qubit 0,1 --step 0

--- a/benchmarks/solutions/quantum-katas/basic-gates/two-qubit-gate-4.qni
+++ b/benchmarks/solutions/quantum-katas/basic-gates/two-qubit-gate-4.qni
@@ -1,0 +1,2 @@
+qni add X --control 0 --qubit 1 --step 0
+qni add X --qubit 1 --step 1

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -14,7 +14,7 @@
 
 提出物には回路を作るコマンドだけを書きます。`qni run` や `qni expect` などの検証コマンドは書きません。
 
-## 9問の標準解を実行する
+## 14問の標準解を実行する
 
 ### StateFlip
 
@@ -31,6 +31,46 @@ qni benchmark run benchmarks/quantum-katas/basic-gates/basis-change.md benchmark
 ```
 
 期待される結果は `PASS BasisChange` です。BasisChange は複数の採点ケースを持ち、既定の `|0>` 入力と `setup_commands` で準備した `|1>` 入力を別々に検証します。
+
+### TwoQubitGate1
+
+```bash
+qni benchmark run benchmarks/quantum-katas/basic-gates/two-qubit-gate-1.md benchmarks/solutions/quantum-katas/basic-gates/two-qubit-gate-1.qni
+```
+
+期待される結果は `PASS TwoQubitGate1` です。TwoQubitGate1 は CNOT により、1つ目の量子ビットの振幅を2つ目の量子ビットへ写します。
+
+### TwoQubitGate2
+
+```bash
+qni benchmark run benchmarks/quantum-katas/basic-gates/two-qubit-gate-2.md benchmarks/solutions/quantum-katas/basic-gates/two-qubit-gate-2.qni
+```
+
+期待される結果は `PASS TwoQubitGate2` です。TwoQubitGate2 は controlled-Z により、`|11>` 成分だけの符号を反転します。
+
+### TwoQubitGate3
+
+```bash
+qni benchmark run benchmarks/quantum-katas/basic-gates/two-qubit-gate-3.md benchmarks/solutions/quantum-katas/basic-gates/two-qubit-gate-3.qni
+```
+
+期待される結果は `PASS TwoQubitGate3` です。TwoQubitGate3 は SWAP により、2つの量子ビットを入れ替えます。
+
+### TwoQubitGate4
+
+```bash
+qni benchmark run benchmarks/quantum-katas/basic-gates/two-qubit-gate-4.md benchmarks/solutions/quantum-katas/basic-gates/two-qubit-gate-4.qni
+```
+
+期待される結果は `PASS TwoQubitGate4` です。TwoQubitGate4 は CNOT と X の組み合わせにより、1つ目の量子ビットが `|0>` のときだけ2つ目の量子ビットを反転する変換を作ります。
+
+### ToffoliGate
+
+```bash
+qni benchmark run benchmarks/quantum-katas/basic-gates/toffoli-gate.md benchmarks/solutions/quantum-katas/basic-gates/toffoli-gate.qni
+```
+
+期待される結果は `PASS ToffoliGate` です。ToffoliGate は二重制御 X により、1つ目と2つ目の量子ビットがどちらも `|1>` のときだけ3つ目の量子ビットを反転します。
 
 ### PlusState
 
@@ -105,6 +145,14 @@ qni benchmark run benchmarks/quantum-katas/basic-gates/basis-change.md benchmark
 ```
 
 期待される結果は `FAIL BasisChange` です。
+
+TwoQubitGate1 には、`|00>` 入力だけに合う不正解サンプルがあります。重ね合わせ入力と `|10>` 入力の採点ケースで失敗するため、終了コードは `1` です。
+
+```bash
+qni benchmark run benchmarks/quantum-katas/basic-gates/two-qubit-gate-1.md benchmarks/incorrect/quantum-katas/basic-gates/two-qubit-gate-1-zero-only.qni
+```
+
+期待される結果は `FAIL TwoQubitGate1` です。
 
 ## 不許可サンプルを実行する
 
@@ -190,14 +238,19 @@ grading_cases:
 qni benchmark run-all benchmarks/quantum-katas benchmarks/solutions/quantum-katas
 ```
 
-期待される結果は、9問すべてが `passed` になり、終了コードが `0` になることです。
+期待される結果は、14問すべてが `passed` になり、終了コードが `0` になることです。
 
 ```text
 PASS benchmark suite
-tasks: 9
-passed: 9, failed: 0, disallowed: 0, error: 0
+tasks: 14
+passed: 14, failed: 0, disallowed: 0, error: 0
 - passed basic-gates/basis-change BasisChange
 - passed basic-gates/state-flip StateFlip
+- passed basic-gates/toffoli-gate ToffoliGate
+- passed basic-gates/two-qubit-gate-1 TwoQubitGate1
+- passed basic-gates/two-qubit-gate-2 TwoQubitGate2
+- passed basic-gates/two-qubit-gate-3 TwoQubitGate3
+- passed basic-gates/two-qubit-gate-4 TwoQubitGate4
 - passed superposition/all-basis-vector-with-phase-flip-two-qubits AllBasisVectorWithPhaseFlip_TwoQubits
 - passed superposition/all-basis-vectors-two-qubits AllBasisVectors_TwoQubits
 - passed superposition/all-basis-vectors-with-phases-two-qubits AllBasisVectorsWithPhases_TwoQubits

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -38,7 +38,7 @@ qni benchmark run benchmarks/quantum-katas/basic-gates/basis-change.md benchmark
 qni benchmark run benchmarks/quantum-katas/basic-gates/two-qubit-gate-1.md benchmarks/solutions/quantum-katas/basic-gates/two-qubit-gate-1.qni
 ```
 
-期待される結果は `PASS TwoQubitGate1` です。TwoQubitGate1 は CNOT により、1つ目の量子ビットの振幅を2つ目の量子ビットへ写します。
+期待される結果は `PASS TwoQubitGate1` です。TwoQubitGate1 は CNOT により、1つ目の量子ビットが `|1>` のときに2つ目の量子ビットを反転します。
 
 ### TwoQubitGate2
 

--- a/features/cli/benchmark_run.feature.md
+++ b/features/cli/benchmark_run.feature.md
@@ -504,10 +504,15 @@ qni benchmark run で最小の合格判定を実行したい。
 
   ```text
   PASS benchmark suite
-  tasks: 9
-  passed: 9, failed: 0, disallowed: 0, error: 0
+  tasks: 14
+  passed: 14, failed: 0, disallowed: 0, error: 0
   - passed basic-gates/basis-change BasisChange
   - passed basic-gates/state-flip StateFlip
+  - passed basic-gates/toffoli-gate ToffoliGate
+  - passed basic-gates/two-qubit-gate-1 TwoQubitGate1
+  - passed basic-gates/two-qubit-gate-2 TwoQubitGate2
+  - passed basic-gates/two-qubit-gate-3 TwoQubitGate3
+  - passed basic-gates/two-qubit-gate-4 TwoQubitGate4
   - passed superposition/all-basis-vector-with-phase-flip-two-qubits AllBasisVectorWithPhaseFlip_TwoQubits
   - passed superposition/all-basis-vectors-two-qubits AllBasisVectors_TwoQubits
   - passed superposition/all-basis-vectors-with-phases-two-qubits AllBasisVectorsWithPhases_TwoQubits
@@ -527,8 +532,8 @@ qni benchmark run で最小の合格判定を実行したい。
     "status": "passed",
     "exitCode": 0,
     "summary": {
-      "total": 9,
-      "passed": 9,
+      "total": 14,
+      "passed": 14,
       "failed": 0,
       "disallowed": 0,
       "error": 0
@@ -582,6 +587,332 @@ qni benchmark run で最小の合格判定を実行したい。
         "status": "passed",
         "exitCode": 0,
         "checks": [
+          {
+            "type": "run",
+            "status": "passed"
+          }
+        ]
+      },
+      {
+        "taskId": "basic-gates/toffoli-gate",
+        "title": "ToffoliGate",
+        "task": "benchmarks/quantum-katas/basic-gates/toffoli-gate.md",
+        "submission": "benchmarks/solutions/quantum-katas/basic-gates/toffoli-gate.qni",
+        "status": "passed",
+        "exitCode": 0,
+        "gradingCases": [
+          {
+            "caseId": "zero-zero-zero-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          },
+          {
+            "caseId": "one-one-zero-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          },
+          {
+            "caseId": "one-one-one-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          },
+          {
+            "caseId": "one-zero-one-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          },
+          {
+            "caseId": "superposition-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          }
+        ],
+        "checks": [
+          {
+            "type": "run",
+            "status": "passed"
+          },
+          {
+            "type": "run",
+            "status": "passed"
+          },
+          {
+            "type": "run",
+            "status": "passed"
+          },
+          {
+            "type": "run",
+            "status": "passed"
+          },
+          {
+            "type": "run",
+            "status": "passed"
+          }
+        ]
+      },
+      {
+        "taskId": "basic-gates/two-qubit-gate-1",
+        "title": "TwoQubitGate1",
+        "task": "benchmarks/quantum-katas/basic-gates/two-qubit-gate-1.md",
+        "submission": "benchmarks/solutions/quantum-katas/basic-gates/two-qubit-gate-1.qni",
+        "status": "passed",
+        "exitCode": 0,
+        "gradingCases": [
+          {
+            "caseId": "zero-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          },
+          {
+            "caseId": "one-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          },
+          {
+            "caseId": "superposition-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          }
+        ],
+        "checks": [
+          {
+            "type": "run",
+            "status": "passed"
+          },
+          {
+            "type": "run",
+            "status": "passed"
+          },
+          {
+            "type": "run",
+            "status": "passed"
+          }
+        ]
+      },
+      {
+        "taskId": "basic-gates/two-qubit-gate-2",
+        "title": "TwoQubitGate2",
+        "task": "benchmarks/quantum-katas/basic-gates/two-qubit-gate-2.md",
+        "submission": "benchmarks/solutions/quantum-katas/basic-gates/two-qubit-gate-2.qni",
+        "status": "passed",
+        "exitCode": 0,
+        "gradingCases": [
+          {
+            "caseId": "plus-plus-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          },
+          {
+            "caseId": "eleven-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          },
+          {
+            "caseId": "ten-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          }
+        ],
+        "checks": [
+          {
+            "type": "run",
+            "status": "passed"
+          },
+          {
+            "type": "run",
+            "status": "passed"
+          },
+          {
+            "type": "run",
+            "status": "passed"
+          }
+        ]
+      },
+      {
+        "taskId": "basic-gates/two-qubit-gate-3",
+        "title": "TwoQubitGate3",
+        "task": "benchmarks/quantum-katas/basic-gates/two-qubit-gate-3.md",
+        "submission": "benchmarks/solutions/quantum-katas/basic-gates/two-qubit-gate-3.qni",
+        "status": "passed",
+        "exitCode": 0,
+        "gradingCases": [
+          {
+            "caseId": "zero-zero-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          },
+          {
+            "caseId": "zero-one-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          },
+          {
+            "caseId": "one-zero-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          },
+          {
+            "caseId": "superposition-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          }
+        ],
+        "checks": [
+          {
+            "type": "run",
+            "status": "passed"
+          },
+          {
+            "type": "run",
+            "status": "passed"
+          },
+          {
+            "type": "run",
+            "status": "passed"
+          },
+          {
+            "type": "run",
+            "status": "passed"
+          }
+        ]
+      },
+      {
+        "taskId": "basic-gates/two-qubit-gate-4",
+        "title": "TwoQubitGate4",
+        "task": "benchmarks/quantum-katas/basic-gates/two-qubit-gate-4.md",
+        "submission": "benchmarks/solutions/quantum-katas/basic-gates/two-qubit-gate-4.qni",
+        "status": "passed",
+        "exitCode": 0,
+        "gradingCases": [
+          {
+            "caseId": "zero-zero-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          },
+          {
+            "caseId": "zero-one-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          },
+          {
+            "caseId": "one-zero-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          },
+          {
+            "caseId": "superposition-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          }
+        ],
+        "checks": [
+          {
+            "type": "run",
+            "status": "passed"
+          },
+          {
+            "type": "run",
+            "status": "passed"
+          },
+          {
+            "type": "run",
+            "status": "passed"
+          },
           {
             "type": "run",
             "status": "passed"

--- a/features/katas/basic_gates/multi_qubit_benchmarks.feature.md
+++ b/features/katas/basic_gates/multi_qubit_benchmarks.feature.md
@@ -1,0 +1,39 @@
+# Feature: Quantum Katas BasicGates Part II ベンチマーク
+
+qni-cli のベンチマーク利用者として、Quantum Katas BasicGates Part II の多量子ビット課題を
+既存の `qni add` と複数採点ケースで評価したい。
+
+## Scenario: TwoQubitGate1 標準解は複数入力で合格する
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/two-qubit-gate-1.md benchmarks/solutions/quantum-katas/basic-gates/two-qubit-gate-1.qni" を実行
+- Then コマンドは成功
+
+## Scenario: TwoQubitGate2 標準解は複数入力で合格する
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/two-qubit-gate-2.md benchmarks/solutions/quantum-katas/basic-gates/two-qubit-gate-2.qni" を実行
+- Then コマンドは成功
+
+## Scenario: TwoQubitGate3 標準解は複数入力で合格する
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/two-qubit-gate-3.md benchmarks/solutions/quantum-katas/basic-gates/two-qubit-gate-3.qni" を実行
+- Then コマンドは成功
+
+## Scenario: TwoQubitGate4 標準解は複数入力で合格する
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/two-qubit-gate-4.md benchmarks/solutions/quantum-katas/basic-gates/two-qubit-gate-4.qni" を実行
+- Then コマンドは成功
+
+## Scenario: ToffoliGate 標準解は複数入力で合格する
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/toffoli-gate.md benchmarks/solutions/quantum-katas/basic-gates/toffoli-gate.qni" を実行
+- Then コマンドは成功
+
+## Scenario: TwoQubitGate1 の片方の入力だけに合う不正解サンプルは不合格になる
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/two-qubit-gate-1.md benchmarks/incorrect/quantum-katas/basic-gates/two-qubit-gate-1-zero-only.qni" を実行
+- Then 終了コードは 1
+
+## Scenario: Quantum Katas スモークセットは BasicGates Part II を含めて一括実行できる
+
+- When "qni benchmark run-all benchmarks/quantum-katas benchmarks/solutions/quantum-katas" を実行
+- Then コマンドは成功

--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -217,6 +217,14 @@ function quantumKatasSubmissionContent(status, relativePath) {
   const passedSubmissions = new Map([
     ['basic-gates/basis-change.qni', 'qni add H --qubit 0 --step 0\n'],
     ['basic-gates/state-flip.qni', 'qni add X --qubit 0 --step 0\n'],
+    ['basic-gates/toffoli-gate.qni', 'qni add X --control 0,1 --qubit 2 --step 0\n'],
+    ['basic-gates/two-qubit-gate-1.qni', 'qni add X --control 0 --qubit 1 --step 0\n'],
+    ['basic-gates/two-qubit-gate-2.qni', 'qni add Z --control 0 --qubit 1 --step 0\n'],
+    ['basic-gates/two-qubit-gate-3.qni', 'qni add SWAP --qubit 0,1 --step 0\n'],
+    [
+      'basic-gates/two-qubit-gate-4.qni',
+      'qni add X --control 0 --qubit 1 --step 0\nqni add X --qubit 1 --step 1\n'
+    ],
     [
       'superposition/all-basis-vector-with-phase-flip-two-qubits.qni',
       'qni add H --qubit 0 --step 0\nqni add H --qubit 1 --step 0\nqni add Z --control 0 --qubit 1 --step 1\n'
@@ -258,6 +266,11 @@ function writeQuantumKatasSubmissions(scenarioDir, status, submissionsDir) {
   const relativePaths = [
     'basic-gates/basis-change.qni',
     'basic-gates/state-flip.qni',
+    'basic-gates/toffoli-gate.qni',
+    'basic-gates/two-qubit-gate-1.qni',
+    'basic-gates/two-qubit-gate-2.qni',
+    'basic-gates/two-qubit-gate-3.qni',
+    'basic-gates/two-qubit-gate-4.qni',
     'superposition/all-basis-vector-with-phase-flip-two-qubits.qni',
     'superposition/all-basis-vectors-two-qubits.qni',
     'superposition/all-basis-vectors-with-phases-two-qubits.qni',

--- a/test/typescript/benchmark_command.test.ts
+++ b/test/typescript/benchmark_command.test.ts
@@ -800,8 +800,8 @@ describe('benchmark command TypeScript route', () => {
       assert.equal(captured.value.status, 'passed');
       assert.equal(captured.value.exitCode, 0);
       assert.deepStrictEqual(captured.value.summary, {
-        total: 9,
-        passed: 9,
+        total: 14,
+        passed: 14,
         failed: 0,
         disallowed: 0,
         error: 0
@@ -826,6 +826,60 @@ describe('benchmark command TypeScript route', () => {
           status: 'passed',
           exitCode: 0,
           checks: [{ type: 'run', status: 'passed' }]
+        },
+        {
+          taskId: 'basic-gates/toffoli-gate',
+          status: 'passed',
+          exitCode: 0,
+          checks: [
+            { type: 'run', status: 'passed' },
+            { type: 'run', status: 'passed' },
+            { type: 'run', status: 'passed' },
+            { type: 'run', status: 'passed' },
+            { type: 'run', status: 'passed' }
+          ]
+        },
+        {
+          taskId: 'basic-gates/two-qubit-gate-1',
+          status: 'passed',
+          exitCode: 0,
+          checks: [
+            { type: 'run', status: 'passed' },
+            { type: 'run', status: 'passed' },
+            { type: 'run', status: 'passed' }
+          ]
+        },
+        {
+          taskId: 'basic-gates/two-qubit-gate-2',
+          status: 'passed',
+          exitCode: 0,
+          checks: [
+            { type: 'run', status: 'passed' },
+            { type: 'run', status: 'passed' },
+            { type: 'run', status: 'passed' }
+          ]
+        },
+        {
+          taskId: 'basic-gates/two-qubit-gate-3',
+          status: 'passed',
+          exitCode: 0,
+          checks: [
+            { type: 'run', status: 'passed' },
+            { type: 'run', status: 'passed' },
+            { type: 'run', status: 'passed' },
+            { type: 'run', status: 'passed' }
+          ]
+        },
+        {
+          taskId: 'basic-gates/two-qubit-gate-4',
+          status: 'passed',
+          exitCode: 0,
+          checks: [
+            { type: 'run', status: 'passed' },
+            { type: 'run', status: 'passed' },
+            { type: 'run', status: 'passed' },
+            { type: 'run', status: 'passed' }
+          ]
         },
         {
           taskId: 'superposition/all-basis-vector-with-phase-flip-two-qubits',
@@ -885,10 +939,15 @@ describe('benchmark command TypeScript route', () => {
       assert.equal(result.exitStatus, 0, result.stderr);
       assert.equal(result.stdout, [
         'PASS benchmark suite',
-        'tasks: 9',
-        'passed: 9, failed: 0, disallowed: 0, error: 0',
+        'tasks: 14',
+        'passed: 14, failed: 0, disallowed: 0, error: 0',
         '- passed basic-gates/basis-change BasisChange',
         '- passed basic-gates/state-flip StateFlip',
+        '- passed basic-gates/toffoli-gate ToffoliGate',
+        '- passed basic-gates/two-qubit-gate-1 TwoQubitGate1',
+        '- passed basic-gates/two-qubit-gate-2 TwoQubitGate2',
+        '- passed basic-gates/two-qubit-gate-3 TwoQubitGate3',
+        '- passed basic-gates/two-qubit-gate-4 TwoQubitGate4',
         '- passed superposition/all-basis-vector-with-phase-flip-two-qubits AllBasisVectorWithPhaseFlip_TwoQubits',
         '- passed superposition/all-basis-vectors-two-qubits AllBasisVectors_TwoQubits',
         '- passed superposition/all-basis-vectors-with-phases-two-qubits AllBasisVectorsWithPhases_TwoQubits',
@@ -918,8 +977,8 @@ describe('benchmark command TypeScript route', () => {
         status: 'passed',
         exitCode: 0,
         summary: {
-          total: 9,
-          passed: 9,
+          total: 14,
+          passed: 14,
           failed: 0,
           disallowed: 0,
           error: 0
@@ -957,6 +1016,180 @@ describe('benchmark command TypeScript route', () => {
             status: 'passed',
             exitCode: 0,
             checks: [{ type: 'run', status: 'passed' }]
+          },
+          {
+            taskId: 'basic-gates/toffoli-gate',
+            title: 'ToffoliGate',
+            task: 'benchmarks/quantum-katas/basic-gates/toffoli-gate.md',
+            submission: 'benchmarks/solutions/quantum-katas/basic-gates/toffoli-gate.qni',
+            status: 'passed',
+            exitCode: 0,
+            gradingCases: [
+              {
+                caseId: 'zero-zero-zero-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              },
+              {
+                caseId: 'one-one-zero-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              },
+              {
+                caseId: 'one-one-one-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              },
+              {
+                caseId: 'one-zero-one-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              },
+              {
+                caseId: 'superposition-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              }
+            ],
+            checks: [
+              { type: 'run', status: 'passed' },
+              { type: 'run', status: 'passed' },
+              { type: 'run', status: 'passed' },
+              { type: 'run', status: 'passed' },
+              { type: 'run', status: 'passed' }
+            ]
+          },
+          {
+            taskId: 'basic-gates/two-qubit-gate-1',
+            title: 'TwoQubitGate1',
+            task: 'benchmarks/quantum-katas/basic-gates/two-qubit-gate-1.md',
+            submission: 'benchmarks/solutions/quantum-katas/basic-gates/two-qubit-gate-1.qni',
+            status: 'passed',
+            exitCode: 0,
+            gradingCases: [
+              {
+                caseId: 'zero-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              },
+              {
+                caseId: 'one-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              },
+              {
+                caseId: 'superposition-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              }
+            ],
+            checks: [
+              { type: 'run', status: 'passed' },
+              { type: 'run', status: 'passed' },
+              { type: 'run', status: 'passed' }
+            ]
+          },
+          {
+            taskId: 'basic-gates/two-qubit-gate-2',
+            title: 'TwoQubitGate2',
+            task: 'benchmarks/quantum-katas/basic-gates/two-qubit-gate-2.md',
+            submission: 'benchmarks/solutions/quantum-katas/basic-gates/two-qubit-gate-2.qni',
+            status: 'passed',
+            exitCode: 0,
+            gradingCases: [
+              {
+                caseId: 'plus-plus-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              },
+              {
+                caseId: 'eleven-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              },
+              {
+                caseId: 'ten-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              }
+            ],
+            checks: [
+              { type: 'run', status: 'passed' },
+              { type: 'run', status: 'passed' },
+              { type: 'run', status: 'passed' }
+            ]
+          },
+          {
+            taskId: 'basic-gates/two-qubit-gate-3',
+            title: 'TwoQubitGate3',
+            task: 'benchmarks/quantum-katas/basic-gates/two-qubit-gate-3.md',
+            submission: 'benchmarks/solutions/quantum-katas/basic-gates/two-qubit-gate-3.qni',
+            status: 'passed',
+            exitCode: 0,
+            gradingCases: [
+              {
+                caseId: 'zero-zero-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              },
+              {
+                caseId: 'zero-one-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              },
+              {
+                caseId: 'one-zero-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              },
+              {
+                caseId: 'superposition-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              }
+            ],
+            checks: [
+              { type: 'run', status: 'passed' },
+              { type: 'run', status: 'passed' },
+              { type: 'run', status: 'passed' },
+              { type: 'run', status: 'passed' }
+            ]
+          },
+          {
+            taskId: 'basic-gates/two-qubit-gate-4',
+            title: 'TwoQubitGate4',
+            task: 'benchmarks/quantum-katas/basic-gates/two-qubit-gate-4.md',
+            submission: 'benchmarks/solutions/quantum-katas/basic-gates/two-qubit-gate-4.qni',
+            status: 'passed',
+            exitCode: 0,
+            gradingCases: [
+              {
+                caseId: 'zero-zero-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              },
+              {
+                caseId: 'zero-one-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              },
+              {
+                caseId: 'one-zero-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              },
+              {
+                caseId: 'superposition-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              }
+            ],
+            checks: [
+              { type: 'run', status: 'passed' },
+              { type: 'run', status: 'passed' },
+              { type: 'run', status: 'passed' },
+              { type: 'run', status: 'passed' }
+            ]
           },
           {
             taskId: 'superposition/all-basis-vector-with-phase-flip-two-qubits',

--- a/test/typescript/evaluation_runner.test.ts
+++ b/test/typescript/evaluation_runner.test.ts
@@ -402,8 +402,8 @@ describe('evaluation runner public entrypoints', () => {
       assert.equal(captured.value.status, 'passed');
       assert.equal(captured.value.exitCode, 0);
       assert.deepStrictEqual(captured.value.summary, {
-        total: 9,
-        passed: 9,
+        total: 14,
+        passed: 14,
         failed: 0,
         disallowed: 0,
         error: 0
@@ -428,10 +428,15 @@ describe('evaluation runner public entrypoints', () => {
       assert.equal(output.exitCode, 0);
       assert.equal(output.humanOutput, [
         'PASS benchmark suite',
-        'tasks: 9',
-        'passed: 9, failed: 0, disallowed: 0, error: 0',
+        'tasks: 14',
+        'passed: 14, failed: 0, disallowed: 0, error: 0',
         '- passed basic-gates/basis-change BasisChange',
         '- passed basic-gates/state-flip StateFlip',
+        '- passed basic-gates/toffoli-gate ToffoliGate',
+        '- passed basic-gates/two-qubit-gate-1 TwoQubitGate1',
+        '- passed basic-gates/two-qubit-gate-2 TwoQubitGate2',
+        '- passed basic-gates/two-qubit-gate-3 TwoQubitGate3',
+        '- passed basic-gates/two-qubit-gate-4 TwoQubitGate4',
         '- passed superposition/all-basis-vector-with-phase-flip-two-qubits AllBasisVectorWithPhaseFlip_TwoQubits',
         '- passed superposition/all-basis-vectors-two-qubits AllBasisVectors_TwoQubits',
         '- passed superposition/all-basis-vectors-with-phases-two-qubits AllBasisVectorsWithPhases_TwoQubits',
@@ -443,8 +448,8 @@ describe('evaluation runner public entrypoints', () => {
       ].join('\n'));
       assert.equal(output.jsonOutput.status, 'passed');
       assert.deepStrictEqual(output.jsonOutput.summary, {
-        total: 9,
-        passed: 9,
+        total: 14,
+        passed: 14,
         failed: 0,
         disallowed: 0,
         error: 0

--- a/test/typescript/research_command.test.ts
+++ b/test/typescript/research_command.test.ts
@@ -122,6 +122,11 @@ async function prepareQuantumKatasSubmissions(
   const relativePaths = [
     'basic-gates/basis-change.qni',
     'basic-gates/state-flip.qni',
+    'basic-gates/toffoli-gate.qni',
+    'basic-gates/two-qubit-gate-1.qni',
+    'basic-gates/two-qubit-gate-2.qni',
+    'basic-gates/two-qubit-gate-3.qni',
+    'basic-gates/two-qubit-gate-4.qni',
     'superposition/all-basis-vector-with-phase-flip-two-qubits.qni',
     'superposition/all-basis-vectors-two-qubits.qni',
     'superposition/all-basis-vectors-with-phases-two-qubits.qni',
@@ -143,6 +148,14 @@ function quantumKatasSubmissionContent(status: UnsuccessfulResearchStatus, relat
   const passedSubmissions = new Map<string, string>([
     ['basic-gates/basis-change.qni', 'qni add H --qubit 0 --step 0\n'],
     ['basic-gates/state-flip.qni', 'qni add X --qubit 0 --step 0\n'],
+    ['basic-gates/toffoli-gate.qni', 'qni add X --control 0,1 --qubit 2 --step 0\n'],
+    ['basic-gates/two-qubit-gate-1.qni', 'qni add X --control 0 --qubit 1 --step 0\n'],
+    ['basic-gates/two-qubit-gate-2.qni', 'qni add Z --control 0 --qubit 1 --step 0\n'],
+    ['basic-gates/two-qubit-gate-3.qni', 'qni add SWAP --qubit 0,1 --step 0\n'],
+    [
+      'basic-gates/two-qubit-gate-4.qni',
+      'qni add X --control 0 --qubit 1 --step 0\nqni add X --qubit 1 --step 1\n'
+    ],
     [
       'superposition/all-basis-vector-with-phase-flip-two-qubits.qni',
       'qni add H --qubit 0 --step 0\nqni add H --qubit 1 --step 0\nqni add Z --control 0 --qubit 1 --step 1\n'
@@ -766,8 +779,8 @@ describe('research command TypeScript route', () => {
       assert.match(String(metadata.createdAt), /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.000Z$/u);
       assert.equal(gradingResult.status, 'passed');
       assert.deepStrictEqual(gradingResult.summary, {
-        total: 9,
-        passed: 9,
+        total: 14,
+        passed: 14,
         failed: 0,
         disallowed: 0,
         error: 0


### PR DESCRIPTION
## 概要

BasicGates の二量子ビット課題と ToffoliGate を Quantum Katas のスモークベンチマークに追加しました。各課題に複数の採点ケースを持たせ、標準解と不正解サンプルで成功と失敗の両方を確認できるようにしています。

Closes #319

## 変更内容

- `benchmarks/quantum-katas/basic-gates/` に TwoQubitGate1 から TwoQubitGate4 と ToffoliGate の課題を追加し、対応する標準解 `.qni` を追加しました。
- TwoQubitGate1 のゼロ入力だけに合う不正解サンプルを追加し、Cucumber feature で失敗ケースを確認するようにしました。
- run-all のスモークセットを 9 問から 14 問へ更新し、Cucumber 補助データ、TypeScript 期待値、`docs/benchmark.md` を整合させました。

## 確認

- `npm run check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 基本ゲート領域に Toffoli および 2量子ビット回路（TwoQubitGate1〜4）の新しい課題を追加しました。  
  * 量子回路の入力パターンと採点ケースが拡充されました（合格・不合格例を含む）。
* **ドキュメント**
  * ベンチマークの実行例、期待結果、案内を更新しました（スモークセット一括実行の対象数も反映）。
* **テスト**
  * ベンチマーク集計（人間向け出力／JSON）および成功・失敗判定の期待値を更新しました（対象：14件）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->