### PR TITLE
FredkinGate を controlled-SWAP ベンチマークに追加する

### DIFF
--- a/benchmarks/incorrect/quantum-katas/basic-gates/fredkin-gate-unconditional-swap.qni
+++ b/benchmarks/incorrect/quantum-katas/basic-gates/fredkin-gate-unconditional-swap.qni
@@ -1,0 +1,1 @@
+qni add SWAP --qubit 1,2 --step 0

--- a/benchmarks/quantum-katas/basic-gates/fredkin-gate.md
+++ b/benchmarks/quantum-katas/basic-gates/fredkin-gate.md
@@ -1,0 +1,39 @@
+---
+id: basic-gates/fredkin-gate
+title: FredkinGate
+source: Microsoft Quantum Katas / BasicGates
+difficulty: smoke
+allowed_commands:
+  - qni add
+grading_cases:
+  - id: control-zero
+    setup_commands:
+      - qni state set "1|001>"
+    checks:
+      tolerance: 1e-9
+      items:
+        - type: run
+          expected:
+            - basis: "|001>"
+              amplitude:
+                real: 1
+                imaginary: 0
+  - id: control-one
+    setup_commands:
+      - qni state set "1|101>"
+    checks:
+      tolerance: 1e-9
+      items:
+        - type: run
+          expected:
+            - basis: "|110>"
+              amplitude:
+                real: 1
+                imaginary: 0
+---
+
+3量子ビットに対して Fredkin gate、つまり controlled-SWAP を作成してください。
+
+制御量子ビットは第1量子ビットです。制御量子ビットが `|1>` のときだけ、第2量子ビットと第3量子ビットを交換してください。制御量子ビットが `|0>` のときは状態を変えないでください。
+
+提出物は `.qni` 形式で、1行に1つずつ完全な `qni` コマンドを書いてください。

--- a/benchmarks/solutions/quantum-katas/basic-gates/fredkin-gate.qni
+++ b/benchmarks/solutions/quantum-katas/basic-gates/fredkin-gate.qni
@@ -1,0 +1,1 @@
+qni add SWAP --control 0 --qubit 1,2 --step 0

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -16,7 +16,7 @@
 
 提出物には回路を作るコマンドだけを書きます。`qni run` や `qni expect` などの検証コマンドは書きません。
 
-## 9問の標準解を実行する
+## 10問の標準解を実行する
 
 ### StateFlip
 
@@ -33,6 +33,14 @@ qni benchmark run benchmarks/quantum-katas/basic-gates/basis-change.md benchmark
 ```
 
 期待される結果は `PASS BasisChange` です。BasisChange は複数の採点ケースを持ち、既定の `|0>` 入力と `setup_commands` で準備した `|1>` 入力を別々に検証します。
+
+### FredkinGate
+
+```bash
+qni benchmark run benchmarks/quantum-katas/basic-gates/fredkin-gate.md benchmarks/solutions/quantum-katas/basic-gates/fredkin-gate.qni
+```
+
+期待される結果は `PASS FredkinGate` です。FredkinGate は複数の採点ケースを持ち、制御量子ビットが `|0>` の入力と `|1>` の入力を別々に検証します。
 
 ### PlusState
 
@@ -108,6 +116,14 @@ qni benchmark run benchmarks/quantum-katas/basic-gates/basis-change.md benchmark
 
 期待される結果は `FAIL BasisChange` です。
 
+FredkinGate には、制御量子ビットを無視して常に SWAP する不正解サンプルがあります。制御量子ビットが `|0>` の採点ケースで失敗するため、終了コードは `1` です。
+
+```bash
+qni benchmark run benchmarks/quantum-katas/basic-gates/fredkin-gate.md benchmarks/incorrect/quantum-katas/basic-gates/fredkin-gate-unconditional-swap.qni
+```
+
+期待される結果は `FAIL FredkinGate` です。
+
 ## 不許可サンプルを実行する
 
 不許可サンプルは、課題ファイルの `allowed_commands` にない `qni run` を提出物に含みます。終了コードは `2` です。
@@ -148,7 +164,7 @@ qni benchmark run benchmarks/quantum-katas/basic-gates/state-flip.md benchmarks/
 
 `grading_cases` を使うと、同じ提出物を複数の初期条件で採点できます。各ケースは独立した一時作業ディレクトリで実行されます。`setup_commands` は採点ケースごとの初期状態準備に使い、提出物の `allowed_commands` とは別に評価ランナーが実行します。
 
-BasisChange では、既定の `|0>` 入力と、`qni state set "1|1>"` で準備する `|1>` 入力を分けています。
+BasisChange では、既定の `|0>` 入力と、`qni state set "1|1>"` で準備する `|1>` 入力を分けています。FredkinGate のような3量子ビット課題では、制御量子ビットが `|0>` の入力と `|1>` の入力を別々の採点ケースにします。
 
 ```yaml
 grading_cases:
@@ -192,13 +208,14 @@ grading_cases:
 qni benchmark run-all benchmarks/quantum-katas benchmarks/solutions/quantum-katas
 ```
 
-期待される結果は、9問すべてが `passed` になり、終了コードが `0` になることです。
+期待される結果は、10問すべてが `passed` になり、終了コードが `0` になることです。
 
 ```text
 PASS benchmark suite
-tasks: 9
-passed: 9, failed: 0, disallowed: 0, error: 0
+tasks: 10
+passed: 10, failed: 0, disallowed: 0, error: 0
 - passed basic-gates/basis-change BasisChange
+- passed basic-gates/fredkin-gate FredkinGate
 - passed basic-gates/state-flip StateFlip
 - passed superposition/all-basis-vector-with-phase-flip-two-qubits AllBasisVectorWithPhaseFlip_TwoQubits
 - passed superposition/all-basis-vectors-two-qubits AllBasisVectors_TwoQubits

--- a/features/cli/benchmark_run.feature.md
+++ b/features/cli/benchmark_run.feature.md
@@ -99,6 +99,28 @@ qni benchmark run で最小の合格判定を実行したい。
   PASS BasisChange
   ```
 
+## Scenario: FredkinGate 課題ファイルがある
+
+- Then リポジトリファイル "benchmarks/quantum-katas/basic-gates/fredkin-gate.md" は存在する
+
+## Scenario: FredkinGate 標準解がある
+
+- Then リポジトリファイル "benchmarks/solutions/quantum-katas/basic-gates/fredkin-gate.qni" は存在する
+
+## Scenario: FredkinGate 標準解は合格する
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/fredkin-gate.md benchmarks/solutions/quantum-katas/basic-gates/fredkin-gate.qni" を実行
+- Then コマンドは成功
+
+## Scenario: FredkinGate 標準解の合格が表示される
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/fredkin-gate.md benchmarks/solutions/quantum-katas/basic-gates/fredkin-gate.qni" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  PASS FredkinGate
+  ```
+
 ## Scenario: MinusState 課題ファイルがある
 
 - Then リポジトリファイル "benchmarks/quantum-katas/superposition/minus-state.md" は存在する
@@ -378,6 +400,24 @@ qni benchmark run で最小の合格判定を実行したい。
   - case one-input run #1: state vector did not match expected amplitudes
   ```
 
+## Scenario: FredkinGate の常に SWAP する不正解サンプルがある
+
+- Then リポジトリファイル "benchmarks/incorrect/quantum-katas/basic-gates/fredkin-gate-unconditional-swap.qni" は存在する
+
+## Scenario: FredkinGate の常に SWAP する不正解サンプルは不合格になる
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/fredkin-gate.md benchmarks/incorrect/quantum-katas/basic-gates/fredkin-gate-unconditional-swap.qni" を実行
+- Then 終了コードは 1
+
+## Scenario: FredkinGate の常に SWAP する不正解サンプルは制御 0 の採点ケースで失敗する
+
+- When "qni benchmark run benchmarks/quantum-katas/basic-gates/fredkin-gate.md benchmarks/incorrect/quantum-katas/basic-gates/fredkin-gate-unconditional-swap.qni" を実行
+- Then 標準出力に次を含む:
+
+  ```text
+  - case control-zero run #1: state vector did not match expected amplitudes
+  ```
+
 ## Scenario: frontmatter 不備の課題ファイルは終了コード 3 になる
 
 - When "qni benchmark run benchmarks/invalid/quantum-katas/basic-gates/state-flip-missing-allowed-commands.md benchmarks/solutions/quantum-katas/basic-gates/state-flip.qni" を実行
@@ -460,6 +500,10 @@ qni benchmark run で最小の合格判定を実行したい。
 
 - Then リポジトリファイル "docs/benchmark.md" は "qni benchmark run benchmarks/quantum-katas/basic-gates/basis-change.md benchmarks/solutions/quantum-katas/basic-gates/basis-change.qni" を含む
 
+## Scenario: MVP手順は FredkinGate 標準解の実行例を示す
+
+- Then リポジトリファイル "docs/benchmark.md" は "qni benchmark run benchmarks/quantum-katas/basic-gates/fredkin-gate.md benchmarks/solutions/quantum-katas/basic-gates/fredkin-gate.qni" を含む
+
 ## Scenario: MVP手順は複数採点ケースの説明を示す
 
 - Then リポジトリファイル "docs/benchmark.md" は "複数採点ケース" を含む
@@ -504,9 +548,10 @@ qni benchmark run で最小の合格判定を実行したい。
 
   ```text
   PASS benchmark suite
-  tasks: 9
-  passed: 9, failed: 0, disallowed: 0, error: 0
+  tasks: 10
+  passed: 10, failed: 0, disallowed: 0, error: 0
   - passed basic-gates/basis-change BasisChange
+  - passed basic-gates/fredkin-gate FredkinGate
   - passed basic-gates/state-flip StateFlip
   - passed superposition/all-basis-vector-with-phase-flip-two-qubits AllBasisVectorWithPhaseFlip_TwoQubits
   - passed superposition/all-basis-vectors-two-qubits AllBasisVectors_TwoQubits
@@ -527,8 +572,8 @@ qni benchmark run で最小の合格判定を実行したい。
     "status": "passed",
     "exitCode": 0,
     "summary": {
-      "total": 9,
-      "passed": 9,
+      "total": 10,
+      "passed": 10,
       "failed": 0,
       "disallowed": 0,
       "error": 0
@@ -554,6 +599,46 @@ qni benchmark run で最小の合格判定を実行したい。
           },
           {
             "caseId": "one-input",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          }
+        ],
+        "checks": [
+          {
+            "type": "run",
+            "status": "passed"
+          },
+          {
+            "type": "run",
+            "status": "passed"
+          }
+        ]
+      },
+      {
+        "taskId": "basic-gates/fredkin-gate",
+        "title": "FredkinGate",
+        "task": "benchmarks/quantum-katas/basic-gates/fredkin-gate.md",
+        "submission": "benchmarks/solutions/quantum-katas/basic-gates/fredkin-gate.qni",
+        "status": "passed",
+        "exitCode": 0,
+        "gradingCases": [
+          {
+            "caseId": "control-zero",
+            "status": "passed",
+            "checks": [
+              {
+                "type": "run",
+                "status": "passed"
+              }
+            ]
+          },
+          {
+            "caseId": "control-one",
             "status": "passed",
             "checks": [
               {

--- a/features/step_definitions/cli_steps.js
+++ b/features/step_definitions/cli_steps.js
@@ -216,6 +216,7 @@ function writeCircuitJson(scenarioDir, data) {
 function quantumKatasSubmissionContent(status, relativePath) {
   const passedSubmissions = new Map([
     ['basic-gates/basis-change.qni', 'qni add H --qubit 0 --step 0\n'],
+    ['basic-gates/fredkin-gate.qni', 'qni add SWAP --control 0 --qubit 1,2 --step 0\n'],
     ['basic-gates/state-flip.qni', 'qni add X --qubit 0 --step 0\n'],
     [
       'superposition/all-basis-vector-with-phase-flip-two-qubits.qni',
@@ -257,6 +258,7 @@ function quantumKatasSubmissionContent(status, relativePath) {
 function writeQuantumKatasSubmissions(scenarioDir, status, submissionsDir) {
   const relativePaths = [
     'basic-gates/basis-change.qni',
+    'basic-gates/fredkin-gate.qni',
     'basic-gates/state-flip.qni',
     'superposition/all-basis-vector-with-phase-flip-two-qubits.qni',
     'superposition/all-basis-vectors-two-qubits.qni',

--- a/test/typescript/benchmark_command.test.ts
+++ b/test/typescript/benchmark_command.test.ts
@@ -434,6 +434,21 @@ describe('benchmark command TypeScript route', () => {
     });
   });
 
+  it('passes the FredkinGate solution using explicit grading cases', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, [
+        'benchmark',
+        'run',
+        'benchmarks/quantum-katas/basic-gates/fredkin-gate.md',
+        'benchmarks/solutions/quantum-katas/basic-gates/fredkin-gate.qni'
+      ]);
+
+      assert.equal(result.exitStatus, 0, result.stderr);
+      assert.equal(result.stdout, 'PASS FredkinGate\nchecks: 2\n');
+      assert.equal(result.stderr, '');
+    });
+  });
+
   it('passes the MinusState solution using a run check', async () => {
     await withTempDir(async (dir) => {
       const result = captureDispatcherRun(dir, [
@@ -620,6 +635,30 @@ describe('benchmark command TypeScript route', () => {
     });
   });
 
+  it('fails the FredkinGate unconditional SWAP incorrect sample in the control-zero grading case', async () => {
+    await withTempDir(async (dir) => {
+      const result = captureDispatcherRun(dir, [
+        'benchmark',
+        'run',
+        'benchmarks/quantum-katas/basic-gates/fredkin-gate.md',
+        'benchmarks/incorrect/quantum-katas/basic-gates/fredkin-gate-unconditional-swap.qni'
+      ]);
+
+      assert.equal(result.exitStatus, 1, result.stderr);
+      assert.equal(result.stdout, [
+        'FAIL FredkinGate',
+        'checks: 2',
+        'failed checks:',
+        '- case control-zero run #1: state vector did not match expected amplitudes',
+        '  expected / actual mismatches:',
+        '  - |001>: expected 1, actual 0',
+        '  - |010>: expected 0, actual 1',
+        ''
+      ].join('\n'));
+      assert.equal(result.stderr, '');
+    });
+  });
+
   it('prints failed grading case ids in human-readable check details', async () => {
     await withTempDir(async (dir) => {
       await writeFile(path.join(dir, 'task.md'), xOnZeroAndOneGradingCasesTask());
@@ -800,8 +839,8 @@ describe('benchmark command TypeScript route', () => {
       assert.equal(captured.value.status, 'passed');
       assert.equal(captured.value.exitCode, 0);
       assert.deepStrictEqual(captured.value.summary, {
-        total: 9,
-        passed: 9,
+        total: 10,
+        passed: 10,
         failed: 0,
         disallowed: 0,
         error: 0
@@ -814,6 +853,15 @@ describe('benchmark command TypeScript route', () => {
       })), [
         {
           taskId: 'basic-gates/basis-change',
+          status: 'passed',
+          exitCode: 0,
+          checks: [
+            { type: 'run', status: 'passed' },
+            { type: 'run', status: 'passed' }
+          ]
+        },
+        {
+          taskId: 'basic-gates/fredkin-gate',
           status: 'passed',
           exitCode: 0,
           checks: [
@@ -885,9 +933,10 @@ describe('benchmark command TypeScript route', () => {
       assert.equal(result.exitStatus, 0, result.stderr);
       assert.equal(result.stdout, [
         'PASS benchmark suite',
-        'tasks: 9',
-        'passed: 9, failed: 0, disallowed: 0, error: 0',
+        'tasks: 10',
+        'passed: 10, failed: 0, disallowed: 0, error: 0',
         '- passed basic-gates/basis-change BasisChange',
+        '- passed basic-gates/fredkin-gate FredkinGate',
         '- passed basic-gates/state-flip StateFlip',
         '- passed superposition/all-basis-vector-with-phase-flip-two-qubits AllBasisVectorWithPhaseFlip_TwoQubits',
         '- passed superposition/all-basis-vectors-two-qubits AllBasisVectors_TwoQubits',
@@ -918,8 +967,8 @@ describe('benchmark command TypeScript route', () => {
         status: 'passed',
         exitCode: 0,
         summary: {
-          total: 9,
-          passed: 9,
+          total: 10,
+          passed: 10,
           failed: 0,
           disallowed: 0,
           error: 0
@@ -940,6 +989,30 @@ describe('benchmark command TypeScript route', () => {
               },
               {
                 caseId: 'one-input',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              }
+            ],
+            checks: [
+              { type: 'run', status: 'passed' },
+              { type: 'run', status: 'passed' }
+            ]
+          },
+          {
+            taskId: 'basic-gates/fredkin-gate',
+            title: 'FredkinGate',
+            task: 'benchmarks/quantum-katas/basic-gates/fredkin-gate.md',
+            submission: 'benchmarks/solutions/quantum-katas/basic-gates/fredkin-gate.qni',
+            status: 'passed',
+            exitCode: 0,
+            gradingCases: [
+              {
+                caseId: 'control-zero',
+                status: 'passed',
+                checks: [{ type: 'run', status: 'passed' }]
+              },
+              {
+                caseId: 'control-one',
                 status: 'passed',
                 checks: [{ type: 'run', status: 'passed' }]
               }

--- a/test/typescript/evaluation_runner.test.ts
+++ b/test/typescript/evaluation_runner.test.ts
@@ -402,8 +402,8 @@ describe('evaluation runner public entrypoints', () => {
       assert.equal(captured.value.status, 'passed');
       assert.equal(captured.value.exitCode, 0);
       assert.deepStrictEqual(captured.value.summary, {
-        total: 9,
-        passed: 9,
+        total: 10,
+        passed: 10,
         failed: 0,
         disallowed: 0,
         error: 0
@@ -428,9 +428,10 @@ describe('evaluation runner public entrypoints', () => {
       assert.equal(output.exitCode, 0);
       assert.equal(output.humanOutput, [
         'PASS benchmark suite',
-        'tasks: 9',
-        'passed: 9, failed: 0, disallowed: 0, error: 0',
+        'tasks: 10',
+        'passed: 10, failed: 0, disallowed: 0, error: 0',
         '- passed basic-gates/basis-change BasisChange',
+        '- passed basic-gates/fredkin-gate FredkinGate',
         '- passed basic-gates/state-flip StateFlip',
         '- passed superposition/all-basis-vector-with-phase-flip-two-qubits AllBasisVectorWithPhaseFlip_TwoQubits',
         '- passed superposition/all-basis-vectors-two-qubits AllBasisVectors_TwoQubits',
@@ -443,8 +444,8 @@ describe('evaluation runner public entrypoints', () => {
       ].join('\n'));
       assert.equal(output.jsonOutput.status, 'passed');
       assert.deepStrictEqual(output.jsonOutput.summary, {
-        total: 9,
-        passed: 9,
+        total: 10,
+        passed: 10,
         failed: 0,
         disallowed: 0,
         error: 0

--- a/test/typescript/research_command.test.ts
+++ b/test/typescript/research_command.test.ts
@@ -121,6 +121,7 @@ async function prepareQuantumKatasSubmissions(
 ): Promise<void> {
   const relativePaths = [
     'basic-gates/basis-change.qni',
+    'basic-gates/fredkin-gate.qni',
     'basic-gates/state-flip.qni',
     'superposition/all-basis-vector-with-phase-flip-two-qubits.qni',
     'superposition/all-basis-vectors-two-qubits.qni',
@@ -142,6 +143,7 @@ async function prepareQuantumKatasSubmissions(
 function quantumKatasSubmissionContent(status: UnsuccessfulResearchStatus, relativePath: string): string {
   const passedSubmissions = new Map<string, string>([
     ['basic-gates/basis-change.qni', 'qni add H --qubit 0 --step 0\n'],
+    ['basic-gates/fredkin-gate.qni', 'qni add SWAP --control 0 --qubit 1,2 --step 0\n'],
     ['basic-gates/state-flip.qni', 'qni add X --qubit 0 --step 0\n'],
     [
       'superposition/all-basis-vector-with-phase-flip-two-qubits.qni',
@@ -766,8 +768,8 @@ describe('research command TypeScript route', () => {
       assert.match(String(metadata.createdAt), /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.000Z$/u);
       assert.equal(gradingResult.status, 'passed');
       assert.deepStrictEqual(gradingResult.summary, {
-        total: 9,
-        passed: 9,
+        total: 10,
+        passed: 10,
         failed: 0,
         disallowed: 0,
         error: 0


### PR DESCRIPTION
## 概要

FredkinGate を Quantum Katas BasicGates の controlled-SWAP ベンチマークとして追加しました。
制御量子ビットが `|0>` の場合と `|1>` の場合を `grading_cases` / `setup_commands` で分けて検証し、常に SWAP してしまう不正解も検出できるようにしています。

Closes #321

## 変更内容

- `benchmarks/quantum-katas/basic-gates/fredkin-gate.md` と標準解 `.qni` を追加し、controlled-SWAP の複数採点ケースを定義
- 常に SWAP する不正解サンプルを追加し、制御が `|0>` のケースで failed になることを確認
- `benchmark run` / `run-all` の Cucumber 仕様、TypeScript テスト、研究試行用の提出物生成を 10 問構成に更新
- `docs/benchmark.md` に FredkinGate の実行例と 10 問スモークセットの出力例を反映

## 確認

- `npm run check`
